### PR TITLE
feat: add connectTimeoutMs and release connection on create() failure

### DIFF
--- a/.changeset/release-connection-on-create-failure.md
+++ b/.changeset/release-connection-on-create-failure.md
@@ -1,0 +1,10 @@
+---
+"@amqp-contract/client": patch
+"@amqp-contract/worker": patch
+---
+
+Fix connection leak when `TypedAmqpClient.create()` or `TypedAmqpWorker.create()` fails.
+
+Previously, if `waitForConnect` rejected (client/worker) or `consumeAll` errored after some consumers had registered (worker), the underlying connection's reference count remained incremented and any registered consumers stayed running. The caller received a `Result.Error` with no handle to clean up.
+
+Both factories now invoke `close()` before propagating the error, releasing the connection ref-count via the singleton and cancelling any partially-registered consumers.

--- a/.changeset/release-connection-on-create-failure.md
+++ b/.changeset/release-connection-on-create-failure.md
@@ -1,10 +1,11 @@
 ---
-"@amqp-contract/client": patch
-"@amqp-contract/worker": patch
+"@amqp-contract/core": minor
+"@amqp-contract/client": minor
+"@amqp-contract/worker": minor
 ---
 
-Fix connection leak when `TypedAmqpClient.create()` or `TypedAmqpWorker.create()` fails.
+Add `connectTimeoutMs` option to `TypedAmqpClient.create()`, `TypedAmqpWorker.create()`, and `AmqpClient`, and fix a connection leak on the failure path.
 
-Previously, if `waitForConnect` rejected (client/worker) or `consumeAll` errored after some consumers had registered (worker), the underlying connection's reference count remained incremented and any registered consumers stayed running. The caller received a `Result.Error` with no handle to clean up.
+`amqp-connection-manager` retries connections indefinitely and never rejects `waitForConnect` on its own. Without a timeout, a misconfigured URL or unreachable broker pinned the call forever. The new `connectTimeoutMs` option races `waitForConnect` against a timer so `create()` can fail fast.
 
-Both factories now invoke `close()` before propagating the error, releasing the connection ref-count via the singleton and cancelling any partially-registered consumers.
+The same code path also fixes a connection leak: when `create()` failed (timeout, or `consumeAll` erroring after some consumers had registered), the connection's reference count in `ConnectionManagerSingleton` stayed incremented and any registered consumers stayed running. Both factories now invoke `close()` before propagating the error.

--- a/packages/client/src/client-cleanup.spec.ts
+++ b/packages/client/src/client-cleanup.spec.ts
@@ -1,0 +1,25 @@
+import type { ContractDefinition } from "@amqp-contract/contract";
+import { ConnectionManagerSingleton } from "@amqp-contract/core";
+import { beforeEach, describe, expect, it } from "vitest";
+import { TypedAmqpClient } from "./client.js";
+
+describe("TypedAmqpClient.create cleanup", () => {
+  beforeEach(async () => {
+    await ConnectionManagerSingleton.getInstance()._resetForTesting();
+  });
+
+  it("releases the pooled connection when waitForConnect times out", async () => {
+    const contract: ContractDefinition = {};
+
+    // Port 1 is closed on every reasonable host; amqp-connection-manager will
+    // retry forever, so the timeout is what forces create() to fail.
+    const result = await TypedAmqpClient.create({
+      contract,
+      urls: ["amqp://localhost:1"],
+      connectTimeoutMs: 200,
+    }).toPromise();
+
+    expect(result.isError()).toBe(true);
+    expect(ConnectionManagerSingleton.getInstance()._getConnectionCountForTesting()).toBe(0);
+  });
+});

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -94,7 +94,21 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
       telemetry ?? defaultTelemetryProvider,
     );
 
-    return client.waitForConnectionReady().mapOk(() => client);
+    return client.waitForConnectionReady().flatMap((result) =>
+      result.match({
+        Ok: () => Future.value(Result.Ok<TypedAmqpClient<TContract>, TechnicalError>(client)),
+        // Release the AmqpClient's connection ref-count so a failed create() does not leak.
+        Error: (error) =>
+          client
+            .close()
+            .tapError((closeError) => {
+              logger?.warn("Failed to close client after connection failure", {
+                error: closeError,
+              });
+            })
+            .map(() => Result.Error<TypedAmqpClient<TContract>, TechnicalError>(error)),
+      }),
+    );
   }
 
   /**

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -56,8 +56,9 @@ export type CreateClientOptions<TContract extends ContractDefinition> = {
   defaultPublishOptions?: PublishOptions | undefined;
   /**
    * Maximum time in ms to wait for the AMQP connection to become ready before
-   * `create()` rejects. Without this option, `create()` waits forever — the
-   * underlying amqp-connection-manager retries indefinitely.
+   * `create()` resolves to `Result.Error<TechnicalError>`. Without this option,
+   * `create()` waits forever — the underlying amqp-connection-manager retries
+   * indefinitely.
    */
   connectTimeoutMs?: number | undefined;
 };

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -54,6 +54,12 @@ export type CreateClientOptions<TContract extends ContractDefinition> = {
    * By default, persistent is set to true for message durability.
    */
   defaultPublishOptions?: PublishOptions | undefined;
+  /**
+   * Maximum time in ms to wait for the AMQP connection to become ready before
+   * `create()` rejects. Without this option, `create()` waits forever — the
+   * underlying amqp-connection-manager retries indefinitely.
+   */
+  connectTimeoutMs?: number | undefined;
 };
 
 /**
@@ -85,10 +91,11 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
     defaultPublishOptions,
     logger,
     telemetry,
+    connectTimeoutMs,
   }: CreateClientOptions<TContract>): Future<Result<TypedAmqpClient<TContract>, TechnicalError>> {
     const client = new TypedAmqpClient(
       contract,
-      new AmqpClient(contract, { urls, connectionOptions }),
+      new AmqpClient(contract, { urls, connectionOptions, connectTimeoutMs }),
       { persistent: true, ...defaultPublishOptions },
       logger,
       telemetry ?? defaultTelemetryProvider,

--- a/packages/core/src/amqp-client.ts
+++ b/packages/core/src/amqp-client.ts
@@ -41,11 +41,14 @@ function callSetupFunc(
  * @property urls - AMQP broker URL(s). Multiple URLs provide failover support.
  * @property connectionOptions - Optional connection configuration (heartbeat, reconnect settings, etc.).
  * @property channelOptions - Optional channel configuration options.
+ * @property connectTimeoutMs - Maximum time in ms to wait for the channel to become ready
+ *   in `waitForConnect`. If unset, waits forever (amqp-connection-manager retries indefinitely).
  */
 export type AmqpClientOptions = {
   urls: ConnectionUrl[];
   connectionOptions?: AmqpConnectionManagerOptions | undefined;
   channelOptions?: Partial<CreateChannelOpts> | undefined;
+  connectTimeoutMs?: number | undefined;
 };
 
 /**
@@ -102,6 +105,7 @@ export class AmqpClient {
   private readonly channelWrapper: ChannelWrapper;
   private readonly urls: ConnectionUrl[];
   private readonly connectionOptions?: AmqpConnectionManagerOptions;
+  private readonly connectTimeoutMs?: number;
 
   /**
    * Create a new AMQP client instance.
@@ -122,6 +126,9 @@ export class AmqpClient {
     this.urls = options.urls;
     if (options.connectionOptions !== undefined) {
       this.connectionOptions = options.connectionOptions;
+    }
+    if (options.connectTimeoutMs !== undefined) {
+      this.connectTimeoutMs = options.connectTimeoutMs;
     }
 
     // Always use singleton to get/create connection
@@ -169,10 +176,37 @@ export class AmqpClient {
   /**
    * Wait for the channel to be connected and ready.
    *
+   * If `connectTimeoutMs` was provided in the constructor options, the returned
+   * Future rejects with a TechnicalError once the timeout elapses. Without a
+   * timeout, this waits forever — amqp-connection-manager retries connections
+   * indefinitely and never rejects on its own.
+   *
    * @returns A Future that resolves when the channel is connected
    */
   waitForConnect(): Future<Result<void, TechnicalError>> {
-    return Future.fromPromise(this.channelWrapper.waitForConnect()).mapError(
+    const connectPromise = this.channelWrapper.waitForConnect();
+
+    const racedPromise =
+      this.connectTimeoutMs === undefined
+        ? connectPromise
+        : new Promise<void>((resolve, reject) => {
+            const timeoutMs = this.connectTimeoutMs!;
+            const handle = setTimeout(() => {
+              reject(new Error(`Timed out waiting for AMQP connection after ${timeoutMs}ms`));
+            }, timeoutMs);
+            connectPromise.then(
+              () => {
+                clearTimeout(handle);
+                resolve();
+              },
+              (error: unknown) => {
+                clearTimeout(handle);
+                reject(error);
+              },
+            );
+          });
+
+    return Future.fromPromise(racedPromise).mapError(
       (error: unknown) => new TechnicalError("Failed to connect to AMQP broker", error),
     );
   }

--- a/packages/core/src/amqp-client.ts
+++ b/packages/core/src/amqp-client.ts
@@ -177,11 +177,18 @@ export class AmqpClient {
    * Wait for the channel to be connected and ready.
    *
    * If `connectTimeoutMs` was provided in the constructor options, the returned
-   * Future rejects with a TechnicalError once the timeout elapses. Without a
-   * timeout, this waits forever — amqp-connection-manager retries connections
-   * indefinitely and never rejects on its own.
+   * Future resolves to `Result.Error<TechnicalError>` once the timeout elapses.
+   * Without a timeout, this waits forever — amqp-connection-manager retries
+   * connections indefinitely and never errors on its own.
    *
-   * @returns A Future that resolves when the channel is connected
+   * NOTE: When using `AmqpClient` directly (not via `TypedAmqpClient` /
+   * `TypedAmqpWorker`), the constructor has already incremented the pooled
+   * connection's reference count. Callers must invoke `close()` on the error
+   * path to release the connection — `waitForConnect` does not do this
+   * automatically. The typed factories handle this cleanup for you.
+   *
+   * @returns A Future resolving to `Result.Ok(void)` on connect, or
+   *   `Result.Error(TechnicalError)` on timeout / connection failure.
    */
   waitForConnect(): Future<Result<void, TechnicalError>> {
     const connectPromise = this.channelWrapper.waitForConnect();

--- a/packages/core/src/connection-manager.ts
+++ b/packages/core/src/connection-manager.ts
@@ -160,6 +160,15 @@ export class ConnectionManagerSingleton {
   }
 
   /**
+   * Get the number of active pooled connections.
+   *
+   * @internal
+   */
+  _getConnectionCountForTesting(): number {
+    return this.connections.size;
+  }
+
+  /**
    * Reset all cached connections (for testing purposes)
    * @internal
    */

--- a/packages/worker/src/worker-cleanup.spec.ts
+++ b/packages/worker/src/worker-cleanup.spec.ts
@@ -1,0 +1,26 @@
+import type { ContractDefinition } from "@amqp-contract/contract";
+import { ConnectionManagerSingleton } from "@amqp-contract/core";
+import { beforeEach, describe, expect, it } from "vitest";
+import { TypedAmqpWorker } from "./worker.js";
+
+describe("TypedAmqpWorker.create cleanup", () => {
+  beforeEach(async () => {
+    await ConnectionManagerSingleton.getInstance()._resetForTesting();
+  });
+
+  it("releases the pooled connection when waitForConnect times out", async () => {
+    const contract: ContractDefinition = {};
+
+    // Port 1 is closed on every reasonable host; amqp-connection-manager will
+    // retry forever, so the timeout is what forces create() to fail.
+    const result = await TypedAmqpWorker.create({
+      contract,
+      handlers: {},
+      urls: ["amqp://localhost:1"],
+      connectTimeoutMs: 200,
+    }).toPromise();
+
+    expect(result.isError()).toBe(true);
+    expect(ConnectionManagerSingleton.getInstance()._getConnectionCountForTesting()).toBe(0);
+  });
+});

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -255,7 +255,22 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
     return worker
       .waitForConnectionReady()
       .flatMapOk(() => worker.consumeAll())
-      .mapOk(() => worker);
+      .flatMap((result) =>
+        result.match({
+          Ok: () => Future.value(Result.Ok<TypedAmqpWorker<TContract>, TechnicalError>(worker)),
+          // Release the AmqpClient's connection ref-count and cancel any consumers
+          // that registered before the failure, so a failed create() does not leak.
+          Error: (error) =>
+            worker
+              .close()
+              .tapError((closeError) => {
+                logger?.warn("Failed to close worker after setup failure", {
+                  error: closeError,
+                });
+              })
+              .map(() => Result.Error<TypedAmqpWorker<TContract>, TechnicalError>(error)),
+        }),
+      );
   }
 
   /**

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -104,6 +104,12 @@ export type CreateWorkerOptions<TContract extends ContractDefinition> = {
    * Handler-specific options provided in tuple form override these defaults.
    */
   defaultConsumerOptions?: ConsumerOptions | undefined;
+  /**
+   * Maximum time in ms to wait for the AMQP connection to become ready before
+   * `create()` rejects. Without this option, `create()` waits forever — the
+   * underlying amqp-connection-manager retries indefinitely.
+   */
+  connectTimeoutMs?: number | undefined;
 };
 
 /**
@@ -237,12 +243,14 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
     defaultConsumerOptions,
     logger,
     telemetry,
+    connectTimeoutMs,
   }: CreateWorkerOptions<TContract>): Future<Result<TypedAmqpWorker<TContract>, TechnicalError>> {
     const worker = new TypedAmqpWorker(
       contract,
       new AmqpClient(contract, {
         urls,
         connectionOptions,
+        connectTimeoutMs,
       }),
       handlers,
       defaultConsumerOptions ?? {},

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -106,8 +106,9 @@ export type CreateWorkerOptions<TContract extends ContractDefinition> = {
   defaultConsumerOptions?: ConsumerOptions | undefined;
   /**
    * Maximum time in ms to wait for the AMQP connection to become ready before
-   * `create()` rejects. Without this option, `create()` waits forever — the
-   * underlying amqp-connection-manager retries indefinitely.
+   * `create()` resolves to `Result.Error<TechnicalError>`. Without this option,
+   * `create()` waits forever — the underlying amqp-connection-manager retries
+   * indefinitely.
    */
   connectTimeoutMs?: number | undefined;
 };


### PR DESCRIPTION
## Summary

- Add an optional `connectTimeoutMs` to `TypedAmqpClient.create()`, `TypedAmqpWorker.create()`, and `AmqpClient`. amqp-connection-manager retries connections indefinitely and never rejects `waitForConnect` on its own, so misconfigured URLs previously pinned `create()` forever. The new option races the connect promise against a timer so `create()` can fail fast.
- Fix the connection leak that surfaces on the failure path: when `create()` failed (now reachable via timeout, or via `consumeAll` erroring after some consumers had registered), `ConnectionManagerSingleton`'s ref-count stayed incremented and partially-registered consumers stayed running. Both factories now invoke `close()` before propagating the error. Close failures during cleanup are logged via the supplied logger but do not override the original error.

## Why

Came up while reviewing the codebase. The leak was identified by code reading; the timeout was added both as a useful production feature (bounded startup time, k8s-friendly) and to make the failure path deterministically testable.

## Test plan

- [x] Added regression test `packages/client/src/client-cleanup.spec.ts`: connects to `amqp://localhost:1` with a 200 ms timeout, asserts `create()` returns `Result.Error` and `ConnectionManagerSingleton._getConnectionCountForTesting()` returns 0. Confirmed the test FAILS pre-fix (5s vitest timeout — the leaked retry loop pins the test runner) and PASSES post-fix (~205 ms).
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` all pass.
- [ ] `pnpm test:integration` against a local RabbitMQ — Docker wasn't available in this environment; the success-path integration tests should still pass since the new option is opt-in and the cleanup branch only runs on `Result.Error`.

## Verification of related concerns from the review

- Confirmed `@swan-io/boxed@3.2.1` exposes `Result.match` (`OptionResult.d.ts:226`).
- The OTel `require()` in `core/telemetry.ts` is fine in the ESM build — tsdown auto-shims it via `createRequire(import.meta.url)` (`packages/core/dist/index.mjs:6`). No fix needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)