### PR TITLE
fix(ci): use `pnpm run …` for changeset version/publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,13 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: pnpm version
-          publish: pnpm release
+          # Use `pnpm run …` so we invoke the package.json scripts. Bare
+          # `pnpm version` collides with pnpm's built-in `version` command and
+          # silently prints `process.versions` instead of running the changeset
+          # version script, leaving package.json files untouched and the
+          # release stuck.
+          version: pnpm run version
+          publish: pnpm run release
           commit: "chore: release packages"
           title: "chore: release packages"
         env:


### PR DESCRIPTION
## Summary

The Release workflow has been failing on every merge to main since at least PR #443 because `pnpm version` (without args) collides with pnpm's built-in `version` subcommand: it prints `process.versions` and exits 0, so the changeset version step is a no-op. The changesets action then sees `git status --porcelain` empty, decides to open a "Version Packages" PR — which also fails (`HttpError: GitHub Actions is not permitted to create or approve pull requests`).

This PR fixes the script invocation. The PR-creation permission is a one-time repo setting fix, see "Required follow-up" below.

## Change

`release.yml`:

```diff
-          version: pnpm version
-          publish: pnpm release
+          version: pnpm run version
+          publish: pnpm run release
```

`pnpm run version` invokes the `version` script in the root `package.json` (`changeset version`), and `pnpm run release` invokes the `release` script (`pnpm build && changeset publish`).

## Repository setting required

Once this is merged, also enable: **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"**. Without this, the changesets action cannot open the "Version Packages" PR even with the script fix in place.

## After both fixes

The next push to main (or this PR's merge) will trigger the workflow, which will open a "Version Packages" PR consuming the two pending changesets and bumping all packages to **0.22.0**. Merging that PR auto-publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)