### PR TITLE
fix(ci): release workflow uses RELEASE_PAT to trigger CI on Version Packages PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,5 +44,13 @@ jobs:
           commit: "chore: release packages"
           title: "chore: release packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use a Personal Access Token rather than the default GITHUB_TOKEN.
+          # Events triggered by GITHUB_TOKEN do not start new workflow runs
+          # (GitHub's anti-recursion safeguard), so the "Version Packages"
+          # PR opened by this action would otherwise skip CI entirely. A PAT
+          # attributes the PR to a real user and CI fires normally.
+          # Required repo secret: RELEASE_PAT (classic PAT with `repo` scope,
+          # or a fine-grained token with Contents: read/write + Pull requests:
+          # read/write on this repo).
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Why

PR #447 (auto-generated "Version Packages" PR) only ran CodeQL — none of the regular CI checks (Tests, Build, Integration Tests, Type Check, Lint, Knip, Format, Bundle Size, Security Audit) fired.

That's GitHub's anti-recursion safeguard: events authored by `secrets.GITHUB_TOKEN` do not trigger new workflow runs. So the PR the changesets action opens with that token never hits the `on: pull_request` workflow, and it can't satisfy required status checks for merge.

## Change

Switch `release.yml` to use a Personal Access Token (`secrets.RELEASE_PAT`) for the changesets step's `GITHUB_TOKEN`:

```diff
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
```

PRs and commits the action creates are then attributed to a real user, and CI runs normally.

## Required repo setting

Add a repo secret named **`RELEASE_PAT`**:

- **Classic PAT**: scope `repo` (full).
- **Fine-grained PAT** (preferred): scoped to this repo only, with permissions:
  - Contents: Read and write
  - Pull requests: Read and write
  - Metadata: Read-only (added automatically)

Then add it under **Settings → Secrets and variables → Actions → New repository secret**, name `RELEASE_PAT`.

## After this lands

- Future "Version Packages" PRs will trigger the full CI suite.
- For PR #447 (already open), the easiest unstick is to push an empty commit to its branch once `RELEASE_PAT` exists — that re-runs CI under the bot but the next release cycle will use the PAT cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)