### PR TITLE
fix(ci): pass RELEASE_PAT to checkout so release pushes trigger CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # Use the PAT here too so the git remote is configured with PAT
+          # credentials. The bare GITHUB_TOKEN-authenticated push that
+          # checkout normally sets up is treated by GitHub as a bot event
+          # and would not fire `pull_request` workflows on the resulting
+          # branch — defeating the whole point of using a PAT for releases.
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Setup
         uses: ./.github/actions/setup


### PR DESCRIPTION
## Why this is still needed after #448

#448 made the changesets action's REST API calls use `RELEASE_PAT` (so PR creation is attributed to a PAT user). But the workflow's `git push` is authenticated by the credentials that `actions/checkout` configures on the local repo, and **`actions/checkout` defaulted to `secrets.GITHUB_TOKEN`** because we didn't override `with.token`.

Result: the changesets action's `git push origin HEAD:changeset-release/main --force` ran under the bot token. GitHub's anti-recursion rule still applied to that push event, so PR #447's main `pull_request` CI workflows continued to be suppressed (only CodeQL ran, as it has its own scheduling).

## Change

Pass `RELEASE_PAT` to `actions/checkout` as well:

```diff
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.RELEASE_PAT }}
```

Now both the API calls and the git push run under the PAT, and the release branch's push event will trigger `pull_request` CI normally.

## After this lands

For PR #447 specifically, push an empty commit to its branch (or close + reopen it) to retrigger CI under the new credential. Future Version Packages PRs will hit CI without intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)