### PR TITLE
ci: wire up npm Trusted Publishing in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,14 +34,6 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-      # Trusted Publishing exchanges the workflow's OIDC token for a
-      # short-lived npm credential, removing the need for a long-lived
-      # NPM_TOKEN. It requires npm >= 11.5.1, which is newer than the npm
-      # bundled with the Node version pinned by ./.github/actions/setup, so
-      # upgrade the CLI explicitly before publishing.
-      - name: Install npm with Trusted Publishing support
-        run: npm install -g npm@latest
-
       - name: Build
         run: pnpm build
 
@@ -68,7 +60,7 @@ jobs:
           # or a fine-grained token with Contents: read/write + Pull requests:
           # read/write on this repo).
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
-          # No NPM_TOKEN — auth is handled by Trusted Publishing via the
-          # OIDC token granted by `id-token: write` above. Each published
-          # package must have a trusted publisher configured on npmjs.com
-          # pointing at this repo + workflow file (.github/workflows/release.yml).
+          # NPM_TOKEN is intentionally absent — npm Trusted Publishing uses
+          # the OIDC token minted via `id-token: write` above. Each package
+          # must have a Trusted Publisher configured on npmjs.com pointing
+          # at this repo + workflow file (.github/workflows/release.yml).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,14 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      # Trusted Publishing exchanges the workflow's OIDC token for a
+      # short-lived npm credential, removing the need for a long-lived
+      # NPM_TOKEN. It requires npm >= 11.5.1, which is newer than the npm
+      # bundled with the Node version pinned by ./.github/actions/setup, so
+      # upgrade the CLI explicitly before publishing.
+      - name: Install npm with Trusted Publishing support
+        run: npm install -g npm@latest
+
       - name: Build
         run: pnpm build
 
@@ -60,4 +68,7 @@ jobs:
           # or a fine-grained token with Contents: read/write + Pull requests:
           # read/write on this repo).
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # No NPM_TOKEN — auth is handled by Trusted Publishing via the
+          # OIDC token granted by `id-token: write` above. Each published
+          # package must have a trusted publisher configured on npmjs.com
+          # pointing at this repo + workflow file (.github/workflows/release.yml).


### PR DESCRIPTION
## Summary

- Drop the long-lived `NPM_TOKEN` from `release.yml`; auth now flows through OIDC Trusted Publishing using the `id-token: write` permission the job already requests.
- Update inline comment to capture the rationale and the npmjs.com configuration prerequisite.

Matches the equivalent change in [`btravers/temporal-contract`](https://github.com/btravers/temporal-contract/commit/01ed94d048065f09667fec4ee71bc6f611a54cf4) — release logs there confirm the runner's bundled npm already supports Trusted Publishing (no explicit npm CLI upgrade needed).

## Prerequisites before merging

Each published package needs a trusted publisher configured on npmjs.com first. For every package under `packages/*`:

1. Open the package settings on npmjs.com.
2. Add a GitHub Actions trusted publisher: repo `btravers/amqp-contract`, workflow `.github/workflows/release.yml`, environment empty.

After this PR merges and the next release runs successfully, the `NPM_TOKEN` repo secret can be deleted.

## Test plan

- [ ] Trusted publisher configured on npmjs.com for each `@amqp-contract/*` package.
- [ ] Merge and verify the next changeset release publishes via OIDC (look for `OIDC is available - using npm trusted publishing` in the log).
- [ ] Once green, remove the `NPM_TOKEN` secret from repo settings.

## Follow-up (not in this PR)

- Enable npm provenance attestations (`NPM_CONFIG_PROVENANCE=true`) — natural pairing with Trusted Publishing but kept separate to keep this change focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)