### PR TITLE
ci: publish via pnpm and pin Node 24 from .node-version

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,8 +6,12 @@ runs:
   steps:
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
       with:
-        cache: true
+        node-version-file: .node-version
+        cache: pnpm
 
     - name: Setup Turbo Cache
       uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   format:
     name: Format

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -17,6 +17,9 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release:
     name: Release

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "knip": "knip",
     "lint": "oxlint .",
     "prepare": "lefthook install",
-    "release": "pnpm build && changeset publish",
+    "release": "pnpm build && pnpm publish -r --access public --no-git-checks",
     "test": "turbo run test",
     "test:integration": "turbo run test:integration",
     "typecheck": "turbo run typecheck",


### PR DESCRIPTION
## Summary

- Switch the release script from `changeset publish` to `pnpm publish -r --access public --no-git-checks`. The previous release run failed with `ENEEDAUTH` because `changeset publish` shells out to `npm`, and the runner's preinstalled npm is older than 11.5.1 — too old to exchange GHA OIDC env vars for a publish token. pnpm 10.16+ implements npm Trusted Publishing against the same npmjs Trusted Publisher config.
- Have the setup composite install Node via `actions/setup-node@v4` reading `.node-version`, so the pinned runtime is the single source of truth across every job.
- Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` at workflow level so the JS actions still pinned to Node 20 (`actions/cache@v4`, `pnpm/action-setup@v4`) execute under Node 24 today, silencing the deprecation warning.

## Notes

- The npmjs Trusted Publisher config (repo + `release.yml` workflow path) is unchanged — pnpm hits the same registry endpoint as npm.
- `engines.node: ">=20"` in root `package.json` is intentionally left alone — it's the public minimum-supported runtime for consumers, not the dev/CI runtime.
- `changesets/action`'s GitHub Releases auto-creation parses changesets-formatted publish output. `pnpm publish` emits a different format, so per-package GitHub Releases will likely stop being created. npm publishes still happen normally; we can wire releases back via `changeset tag` or a small adapter in a follow-up if desired.

## Test plan

- [ ] Confirm CI workflow run uses Node 24.14.1 (matches `.node-version`)
- [ ] Confirm Node 20 deprecation warning is gone from CI logs
- [ ] On next merge to `main`, confirm the Release workflow publishes all six packages successfully via OIDC (no `ENEEDAUTH`)
- [ ] Confirm published versions appear on npm and reference the GitHub repo as Trusted Publisher

🤖 Generated with [Claude Code](https://claude.com/claude-code)