### PR TITLE
refactor!: replace @swan-io/boxed with neverthrow

### DIFF
--- a/.agents/rules/code-style.md
+++ b/.agents/rules/code-style.md
@@ -7,7 +7,7 @@
 - **`.js` extensions required** — all imports must include `.js` extension (ESM requirement)
 - **Standard Schema v1** — for runtime validation (Zod, Valibot, ArkType supported)
 - **Catalog dependencies** — use `pnpm-workspace.yaml` catalog, not hardcoded versions
-- **Future/Result handlers** — always use `Future<Result<void, HandlerError>>`, not `async`
+- **ResultAsync/Result handlers** — always use `ResultAsync<void, HandlerError>`, not `async`
 - **Conventional commits** — required; use conventional commit types (for example: feat, fix, docs, chore, test, refactor)
 - **Strict mode** — enabled in tsconfig.json
 - Prefer `readonly` arrays and properties where appropriate
@@ -53,11 +53,11 @@ processOrder: async ({ payload }) => {
   await process(payload);
 };
 
-// Good — use Future/Result pattern
+// Good — use ResultAsync/Result pattern
 processOrder: ({ payload }) =>
-  Future.fromPromise(process(payload))
-    .mapOk(() => undefined)
-    .mapError((e) => new RetryableError("Failed", e));
+  ResultAsync.fromPromise(process(payload))
+    .map(() => undefined)
+    .mapErr((e) => new RetryableError("Failed", e));
 
 // Bad — accessing message directly
 processOrder: (message) => {

--- a/.agents/rules/dependencies.md
+++ b/.agents/rules/dependencies.md
@@ -4,7 +4,7 @@
 
 | Package                   | Version | Purpose                                |
 | ------------------------- | ------- | -------------------------------------- |
-| `neverthrow`              | 3.2.1   | ResultAsync/Result functional types    |
+| `neverthrow`              | 8.2.0   | ResultAsync/Result functional types    |
 | `amqplib`                 | 0.10.9  | AMQP 0.9.1 client                      |
 | `amqp-connection-manager` | 5.0.0   | Connection management                  |
 | `zod`                     | 4.3.6   | Schema validation (Standard Schema v1) |

--- a/.agents/rules/dependencies.md
+++ b/.agents/rules/dependencies.md
@@ -4,7 +4,7 @@
 
 | Package                   | Version | Purpose                                |
 | ------------------------- | ------- | -------------------------------------- |
-| `@swan-io/boxed`          | 3.2.1   | Future/Result functional types         |
+| `neverthrow`              | 3.2.1   | ResultAsync/Result functional types    |
 | `amqplib`                 | 0.10.9  | AMQP 0.9.1 client                      |
 | `amqp-connection-manager` | 5.0.0   | Connection management                  |
 | `zod`                     | 4.3.6   | Schema validation (Standard Schema v1) |

--- a/.agents/rules/handlers.md
+++ b/.agents/rules/handlers.md
@@ -5,7 +5,7 @@
 Handlers receive `({ payload, headers }, rawMessage)` and return `ResultAsync<void, HandlerError>`:
 
 ```typescript
-import { ResultAsync, Result } from "neverthrow";
+import { okAsync, ResultAsync } from "neverthrow";
 import { RetryableError, NonRetryableError } from "@amqp-contract/worker";
 
 // Handler signature: (message, rawMessage) => ResultAsync<void, HandlerError>
@@ -14,11 +14,12 @@ const handler = ({ payload }, rawMessage) => {
   return okAsync(undefined);
 };
 
-// For async operations, use ResultAsync.fromPromise
+// For async operations, use ResultAsync.fromPromise(promise, errorMapper)
 const asyncHandler = ({ payload }) =>
-  ResultAsync.fromPromise(processPayment(payload))
-    .map(() => undefined)
-    .mapErr((error) => new RetryableError("Payment failed", error));
+  ResultAsync.fromPromise(
+    processPayment(payload),
+    (error) => new RetryableError("Payment failed", error),
+  ).map(() => undefined);
 ```
 
 ## Handler Parameters
@@ -37,12 +38,13 @@ Use `defineHandler` for all new code to get full type inference from the contrac
 
 ```typescript
 import { defineHandler, RetryableError, NonRetryableError } from "@amqp-contract/worker";
-import { ResultAsync, Result } from "neverthrow";
+import { errAsync, okAsync, ResultAsync } from "neverthrow";
 
 const processOrderHandler = defineHandler(contract, "processOrder", ({ payload }) =>
-  ResultAsync.fromPromise(processPayment(payload.orderId))
-    .map(() => undefined)
-    .mapErr((error) => new RetryableError("Payment service unavailable", error)),
+  ResultAsync.fromPromise(
+    processPayment(payload.orderId),
+    (error) => new RetryableError("Payment service unavailable", error),
+  ).map(() => undefined),
 );
 
 // For permanent failures
@@ -65,14 +67,12 @@ const validateOrderHandler = defineHandler(contract, "validateOrder", ({ payload
 ```typescript
 // Conditional error handling
 ({ payload }) =>
-  ResultAsync.fromPromise(process(payload))
-    .map(() => undefined)
-    .mapErr((error) => {
-      if (error instanceof ValidationError) {
-        return new NonRetryableError("Invalid data");
-      }
-      return new RetryableError("Temporary failure", error);
-    });
+  ResultAsync.fromPromise(process(payload), (error) => {
+    if (error instanceof ValidationError) {
+      return new NonRetryableError("Invalid data");
+    }
+    return new RetryableError("Temporary failure", error);
+  }).map(() => undefined);
 ```
 
 ## Handler Options
@@ -92,26 +92,26 @@ This project uses [neverthrow](https://github.com/supermacro/neverthrow) for fun
 
 ### ResultAsync<A, E> Key Methods
 
-| Method                             | Description                            | Example                                 |
-| ---------------------------------- | -------------------------------------- | --------------------------------------- |
-| `ResultAsync.value(result)`        | Create resolved ResultAsync            | `okAsync(undefined)`                    |
-| `ResultAsync.fromPromise(promise)` | Convert Promise to ResultAsync<Result> | `ResultAsync.fromPromise(fetch(url))`   |
-| `.map(f)`                          | Transform Ok value                     | `.map(() => undefined)`                 |
-| `.mapErr(f)`                       | Transform Error value                  | `.mapErr((e) => new RetryableError(e))` |
-| `.andThen(f)`                      | Chain with another ResultAsync         | `.andThen((v) => okAsync(v))`           |
-| ``                                 | Convert to Promise (rejects on Error)  | `await future`                          |
+| Method                                 | Description                                                    | Example                                                      |
+| -------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------ |
+| `okAsync(value)` / `errAsync(error)`   | Create a resolved ResultAsync                                  | `okAsync(undefined)` / `errAsync(new Error("x"))`            |
+| `ResultAsync.fromPromise(promise, fn)` | Convert Promise to ResultAsync; `fn` maps the rejection reason | `ResultAsync.fromPromise(fetch(url), (e) => new TechErr(e))` |
+| `.map(f)`                              | Transform Ok value                                             | `.map(() => undefined)`                                      |
+| `.mapErr(f)`                           | Transform Error value                                          | `.mapErr((e) => new RetryableError(e))`                      |
+| `.andThen(f)`                          | Chain with another Result/ResultAsync                          | `.andThen((v) => okAsync(v))`                                |
+| `await resultAsync`                    | Resolves to a `Result<T, E>` (does not throw on `Err`)         | `const r = await future; if (r.isErr()) { ... }`             |
 
 ### Result<Ok, Error> Key Methods
 
-| Method                  | Description           | Example                                        |
-| ----------------------- | --------------------- | ---------------------------------------------- |
-| `ok(value)`             | Create success        | `ok(undefined)`                                |
-| `err(error)`            | Create failure        | `err(new RetryableError("failed"))`            |
-| `.isOk()` / `.isErr()`  | Type guards           | `if (result.isOk()) { ... }`                   |
-| `.map(f)`               | Transform Ok          | `result.map(x => x * 2)`                       |
-| `.mapErr(f)`            | Transform Error       | `result.mapErr(e => new Error(e))`             |
-| `.getOr(default)`       | Extract with fallback | `result.getOr(0)`                              |
-| `.match({ Ok, Error })` | Pattern match         | `result.match({ Ok: v => v, Error: () => 0 })` |
+| Method                 | Description                          | Example                             |
+| ---------------------- | ------------------------------------ | ----------------------------------- |
+| `ok(value)`            | Create success                       | `ok(undefined)`                     |
+| `err(error)`           | Create failure                       | `err(new RetryableError("failed"))` |
+| `.isOk()` / `.isErr()` | Type guards                          | `if (result.isOk()) { ... }`        |
+| `.map(f)`              | Transform Ok                         | `result.map(x => x * 2)`            |
+| `.mapErr(f)`           | Transform Error                      | `result.mapErr(e => new Error(e))`  |
+| `.getOr(default)`      | Extract with fallback                | `result.getOr(0)`                   |
+| `.match(okFn, errFn)`  | Pattern match (positional callbacks) | `result.match(v => v, () => 0)`     |
 
 ### Common Patterns
 
@@ -121,9 +121,10 @@ This project uses [neverthrow](https://github.com/supermacro/neverthrow) for fun
 
 // Async with error mapping
 ({ payload }) =>
-  ResultAsync.fromPromise(asyncOperation(payload))
-    .map(() => undefined)
-    .mapErr((error) => new RetryableError("Failed", error));
+  ResultAsync.fromPromise(
+    asyncOperation(payload),
+    (error) => new RetryableError("Failed", error),
+  ).map(() => undefined);
 ```
 
 ## Worker Package Exports

--- a/.agents/rules/handlers.md
+++ b/.agents/rules/handlers.md
@@ -2,23 +2,23 @@
 
 ## Handler Signature
 
-Handlers receive `({ payload, headers }, rawMessage)` and return `Future<Result<void, HandlerError>>`:
+Handlers receive `({ payload, headers }, rawMessage)` and return `ResultAsync<void, HandlerError>`:
 
 ```typescript
-import { Future, Result } from "@swan-io/boxed";
+import { ResultAsync, Result } from "neverthrow";
 import { RetryableError, NonRetryableError } from "@amqp-contract/worker";
 
-// Handler signature: (message, rawMessage) => Future<Result<void, HandlerError>>
+// Handler signature: (message, rawMessage) => ResultAsync<void, HandlerError>
 const handler = ({ payload }, rawMessage) => {
   console.log(payload.orderId);
-  return Future.value(Result.Ok(undefined));
+  return okAsync(undefined);
 };
 
-// For async operations, use Future.fromPromise
+// For async operations, use ResultAsync.fromPromise
 const asyncHandler = ({ payload }) =>
-  Future.fromPromise(processPayment(payload))
-    .mapOk(() => undefined)
-    .mapError((error) => new RetryableError("Payment failed", error));
+  ResultAsync.fromPromise(processPayment(payload))
+    .map(() => undefined)
+    .mapErr((error) => new RetryableError("Payment failed", error));
 ```
 
 ## Handler Parameters
@@ -37,20 +37,20 @@ Use `defineHandler` for all new code to get full type inference from the contrac
 
 ```typescript
 import { defineHandler, RetryableError, NonRetryableError } from "@amqp-contract/worker";
-import { Future, Result } from "@swan-io/boxed";
+import { ResultAsync, Result } from "neverthrow";
 
 const processOrderHandler = defineHandler(contract, "processOrder", ({ payload }) =>
-  Future.fromPromise(processPayment(payload.orderId))
-    .mapOk(() => undefined)
-    .mapError((error) => new RetryableError("Payment service unavailable", error)),
+  ResultAsync.fromPromise(processPayment(payload.orderId))
+    .map(() => undefined)
+    .mapErr((error) => new RetryableError("Payment service unavailable", error)),
 );
 
 // For permanent failures
 const validateOrderHandler = defineHandler(contract, "validateOrder", ({ payload }) => {
   if (payload.amount < 1) {
-    return Future.value(Result.Error(new NonRetryableError("Invalid amount")));
+    return errAsync(new NonRetryableError("Invalid amount"));
   }
-  return Future.value(Result.Ok(undefined));
+  return okAsync(undefined);
 });
 ```
 
@@ -65,9 +65,9 @@ const validateOrderHandler = defineHandler(contract, "validateOrder", ({ payload
 ```typescript
 // Conditional error handling
 ({ payload }) =>
-  Future.fromPromise(process(payload))
-    .mapOk(() => undefined)
-    .mapError((error) => {
+  ResultAsync.fromPromise(process(payload))
+    .map(() => undefined)
+    .mapErr((error) => {
       if (error instanceof ValidationError) {
         return new NonRetryableError("Invalid data");
       }
@@ -86,44 +86,44 @@ const handlers = {
 };
 ```
 
-## @swan-io/boxed API Reference
+## neverthrow API Reference
 
-This project uses [@swan-io/boxed](https://boxed.cool) for functional error handling.
+This project uses [neverthrow](https://github.com/supermacro/neverthrow) for functional error handling.
 
-### Future<Result<A, E>> Key Methods
+### ResultAsync<A, E> Key Methods
 
-| Method                        | Description                           | Example                                         |
-| ----------------------------- | ------------------------------------- | ----------------------------------------------- |
-| `Future.value(result)`        | Create resolved Future                | `Future.value(Result.Ok(undefined))`            |
-| `Future.fromPromise(promise)` | Convert Promise to Future<Result>     | `Future.fromPromise(fetch(url))`                |
-| `.mapOk(f)`                   | Transform Ok value                    | `.mapOk(() => undefined)`                       |
-| `.mapError(f)`                | Transform Error value                 | `.mapError((e) => new RetryableError(e))`       |
-| `.flatMapOk(f)`               | Chain with another Future             | `.flatMapOk((v) => Future.value(Result.Ok(v)))` |
-| `.resultToPromise()`          | Convert to Promise (rejects on Error) | `await future.resultToPromise()`                |
+| Method                             | Description                            | Example                                 |
+| ---------------------------------- | -------------------------------------- | --------------------------------------- |
+| `ResultAsync.value(result)`        | Create resolved ResultAsync            | `okAsync(undefined)`                    |
+| `ResultAsync.fromPromise(promise)` | Convert Promise to ResultAsync<Result> | `ResultAsync.fromPromise(fetch(url))`   |
+| `.map(f)`                          | Transform Ok value                     | `.map(() => undefined)`                 |
+| `.mapErr(f)`                       | Transform Error value                  | `.mapErr((e) => new RetryableError(e))` |
+| `.andThen(f)`                      | Chain with another ResultAsync         | `.andThen((v) => okAsync(v))`           |
+| ``                                 | Convert to Promise (rejects on Error)  | `await future`                          |
 
 ### Result<Ok, Error> Key Methods
 
-| Method                   | Description           | Example                                        |
-| ------------------------ | --------------------- | ---------------------------------------------- |
-| `Result.Ok(value)`       | Create success        | `Result.Ok(undefined)`                         |
-| `Result.Error(error)`    | Create failure        | `Result.Error(new RetryableError("failed"))`   |
-| `.isOk()` / `.isError()` | Type guards           | `if (result.isOk()) { ... }`                   |
-| `.map(f)`                | Transform Ok          | `result.map(x => x * 2)`                       |
-| `.mapError(f)`           | Transform Error       | `result.mapError(e => new Error(e))`           |
-| `.getOr(default)`        | Extract with fallback | `result.getOr(0)`                              |
-| `.match({ Ok, Error })`  | Pattern match         | `result.match({ Ok: v => v, Error: () => 0 })` |
+| Method                  | Description           | Example                                        |
+| ----------------------- | --------------------- | ---------------------------------------------- |
+| `ok(value)`             | Create success        | `ok(undefined)`                                |
+| `err(error)`            | Create failure        | `err(new RetryableError("failed"))`            |
+| `.isOk()` / `.isErr()`  | Type guards           | `if (result.isOk()) { ... }`                   |
+| `.map(f)`               | Transform Ok          | `result.map(x => x * 2)`                       |
+| `.mapErr(f)`            | Transform Error       | `result.mapErr(e => new Error(e))`             |
+| `.getOr(default)`       | Extract with fallback | `result.getOr(0)`                              |
+| `.match({ Ok, Error })` | Pattern match         | `result.match({ Ok: v => v, Error: () => 0 })` |
 
 ### Common Patterns
 
 ```typescript
 // Simple sync handler
-({ payload }) => Future.value(Result.Ok(undefined));
+({ payload }) => okAsync(undefined);
 
 // Async with error mapping
 ({ payload }) =>
-  Future.fromPromise(asyncOperation(payload))
-    .mapOk(() => undefined)
-    .mapError((error) => new RetryableError("Failed", error));
+  ResultAsync.fromPromise(asyncOperation(payload))
+    .map(() => undefined)
+    .mapErr((error) => new RetryableError("Failed", error));
 ```
 
 ## Worker Package Exports

--- a/.agents/rules/project-overview.md
+++ b/.agents/rules/project-overview.md
@@ -7,7 +7,7 @@
 - **TypeScript 5.9+** — strict type safety
 - **Standard Schema v1** — universal schema validation interface (Zod, Valibot, ArkType)
 - **amqplib** — AMQP 0.9.1 client for Node.js
-- **@swan-io/boxed** — Future/Result functional error handling
+- **neverthrow** — ResultAsync/Result functional error handling
 - **Vitest** — test framework
 - **Turbo** — monorepo build system
 - **pnpm** — package manager

--- a/.agents/rules/testing.md
+++ b/.agents/rules/testing.md
@@ -51,11 +51,11 @@ describe("Order Processing", () => {
 
 ## Handler Testing
 
-Handlers return `Future.value(Result.Ok(undefined))` in mocks:
+Handlers return `okAsync(undefined)` in mocks:
 
 ```typescript
 // Test handler mock
-const mockHandler = vi.fn().mockReturnValue(Future.value(Result.Ok(undefined)));
+const mockHandler = vi.fn().mockReturnValue(okAsync(undefined));
 
 // Assertion pattern
 expect(mockHandler).toHaveBeenCalledWith(

--- a/.changeset/replace-boxed-with-neverthrow.md
+++ b/.changeset/replace-boxed-with-neverthrow.md
@@ -1,0 +1,31 @@
+---
+"@amqp-contract/asyncapi": minor
+"@amqp-contract/client": minor
+"@amqp-contract/contract": minor
+"@amqp-contract/core": minor
+"@amqp-contract/testing": minor
+"@amqp-contract/worker": minor
+---
+
+Replace `@swan-io/boxed` with `neverthrow` for the public Result/async API.
+
+**Breaking.** Public method signatures change from `Future<Result<T, E>>` to `ResultAsync<T, E>`. Handlers must now return `ResultAsync<void, HandlerError>` (regular consumers) or `ResultAsync<TResponse, HandlerError>` (RPCs).
+
+Migration cheat-sheet:
+
+| Before (`@swan-io/boxed`)             | After (`neverthrow`)                  |
+| ------------------------------------- | ------------------------------------- |
+| `Future.value(Result.Ok(x))`          | `okAsync(x)`                          |
+| `Future.value(Result.Error(e))`       | `errAsync(e)`                         |
+| `Result.Ok(x)` / `Result.Error(e)`    | `ok(x)` / `err(e)`                    |
+| `Future.fromPromise(p).mapError(fn)`  | `ResultAsync.fromPromise(p, fn)`      |
+| `f.mapOk(fn)` / `f.mapError(fn)`      | `f.map(fn)` / `f.mapErr(fn)`          |
+| `f.flatMapOk(fn)` / `f.flatMapError`  | `f.andThen(fn)` / `f.orElse(fn)`      |
+| `f.tapOk(fn)` / `f.tapError(fn)`      | `f.andTee(fn)` / `f.orTee(fn)`        |
+| `r.match({ Ok, Error })`              | `r.match(okFn, errFn)` (positional)   |
+| `Future.all([...])` of Result-Futures | `ResultAsync.combine([...])`          |
+| `await x.resultToPromise()` (unwrap)  | `(await x)._unsafeUnwrap()`           |
+| `await x.toPromise()` (Result wrap)   | `await x` (`ResultAsync` is thenable) |
+| `result.isError()`                    | `result.isErr()`                      |
+
+`Future` semantics that are not preserved: laziness and cancellation. `ResultAsync` is eager and Promise-backed. None of the library internals depended on Future-side cancel.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,22 +4,22 @@ Type-safe contracts for AMQP/RabbitMQ messaging with automatic runtime validatio
 
 ## Rules
 
-| Rule                                                    | Description                                                               |
-| ------------------------------------------------------- | ------------------------------------------------------------------------- |
-| [Project Overview](.agents/rules/project-overview.md)   | Architecture, packages, monorepo structure                                |
-| [Commands](.agents/rules/commands.md)                   | Dev, quality, test, versioning commands                                   |
-| [Contract Patterns](.agents/rules/contract-patterns.md) | Contract composition, event/command, retry, type inference                |
-| [Handlers](.agents/rules/handlers.md)                   | Handler signatures, Future/Result, boxed API, error types, worker exports |
-| [Code Style](.agents/rules/code-style.md)               | TypeScript rules, imports, anti-patterns, best practices                  |
-| [Testing](.agents/rules/testing.md)                     | Testing strategy, integration tests, fixtures, assertions                 |
-| [Dependencies](.agents/rules/dependencies.md)           | Key deps, catalog management, monorepo tooling                            |
+| Rule                                                    | Description                                                                  |
+| ------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| [Project Overview](.agents/rules/project-overview.md)   | Architecture, packages, monorepo structure                                   |
+| [Commands](.agents/rules/commands.md)                   | Dev, quality, test, versioning commands                                      |
+| [Contract Patterns](.agents/rules/contract-patterns.md) | Contract composition, event/command, retry, type inference                   |
+| [Handlers](.agents/rules/handlers.md)                   | Handler signatures, ResultAsync, neverthrow API, error types, worker exports |
+| [Code Style](.agents/rules/code-style.md)               | TypeScript rules, imports, anti-patterns, best practices                     |
+| [Testing](.agents/rules/testing.md)                     | Testing strategy, integration tests, fixtures, assertions                    |
+| [Dependencies](.agents/rules/dependencies.md)           | Key deps, catalog management, monorepo tooling                               |
 
 ## Key Constraints
 
 - No `any` types — use `unknown` and narrow
 - Type aliases over interfaces — `type Foo = {}` not `interface Foo {}`
 - `.js` extensions required in all imports (ESM)
-- Handlers return `Future<Result<void, HandlerError>>` — not async/await
+- Handlers return `ResultAsync<void, HandlerError>` (neverthrow) — not async/await
 - Standard Schema v1 for validation (Zod, Valibot, ArkType)
 - Catalog dependencies via `pnpm-workspace.yaml` — not hardcoded versions
 - Conventional commits required (e.g. feat, fix, docs, chore, test, refactor — full set per Conventional Commits spec)

--- a/docs/TERMINOLOGY.md
+++ b/docs/TERMINOLOGY.md
@@ -80,21 +80,23 @@ When implementing the contract, we use our terms:
 
 ```typescript
 // Client = runtime publisher
-const client = await TypedAmqpClient.create({ contract, urls });
+const client = (await TypedAmqpClient.create({ contract, urls }))._unsafeUnwrap();
 
 await client.publish("orderCreated", message);
 
 // Worker = runtime consumer
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: ({ payload }) => {
-      // Handle message
-      return okAsync(undefined);
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: ({ payload }) => {
+        // Handle message
+        return okAsync(undefined);
+      },
     },
-  },
-  urls,
-});
+    urls,
+  })
+)._unsafeUnwrap();
 ```
 
 These terms (`TypedAmqpClient`, `TypedAmqpWorker`) describe the **runtime components** that implement the contract.
@@ -150,15 +152,17 @@ await publisher.publish(exchange, routingKey, message);
 const consumer = await createConsumer(queue, handler);
 
 // amqp-contract uses:
-const client = await TypedAmqpClient.create({ contract, urls });
+const client = (await TypedAmqpClient.create({ contract, urls }))._unsafeUnwrap();
 
 await client.publish("orderCreated", message);
 
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: { processOrder: handler },
-  urls,
-});
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: { processOrder: handler },
+    urls,
+  })
+)._unsafeUnwrap();
 ```
 
 The functionality is identical; only the naming differs.

--- a/docs/TERMINOLOGY.md
+++ b/docs/TERMINOLOGY.md
@@ -80,9 +80,9 @@ When implementing the contract, we use our terms:
 
 ```typescript
 // Client = runtime publisher
-const client = await TypedAmqpClient.create({ contract, urls }).resultToPromise();
+const client = await TypedAmqpClient.create({ contract, urls });
 
-await client.publish("orderCreated", message).resultToPromise();
+await client.publish("orderCreated", message);
 
 // Worker = runtime consumer
 const worker = await TypedAmqpWorker.create({
@@ -90,11 +90,11 @@ const worker = await TypedAmqpWorker.create({
   handlers: {
     processOrder: ({ payload }) => {
       // Handle message
-      return Future.value(Result.Ok(undefined));
+      return okAsync(undefined);
     },
   },
   urls,
-}).resultToPromise();
+});
 ```
 
 These terms (`TypedAmqpClient`, `TypedAmqpWorker`) describe the **runtime components** that implement the contract.
@@ -150,20 +150,20 @@ await publisher.publish(exchange, routingKey, message);
 const consumer = await createConsumer(queue, handler);
 
 // amqp-contract uses:
-const client = await TypedAmqpClient.create({ contract, urls }).resultToPromise();
+const client = await TypedAmqpClient.create({ contract, urls });
 
-await client.publish("orderCreated", message).resultToPromise();
+await client.publish("orderCreated", message);
 
 const worker = await TypedAmqpWorker.create({
   contract,
   handlers: { processOrder: handler },
   urls,
-}).resultToPromise();
+});
 ```
 
 The functionality is identical; only the naming differs.
 
-## Future Considerations
+## ResultAsync Considerations
 
 We're committed to listening to the community. If there's strong feedback that the standard AMQP terms would be clearer, we may consider:
 

--- a/docs/TERMINOLOGY.md
+++ b/docs/TERMINOLOGY.md
@@ -79,6 +79,8 @@ These terms (`publishers`, `consumers`) describe the **messaging patterns** in y
 When implementing the contract, we use our terms:
 
 ```typescript
+import { okAsync } from "neverthrow";
+
 // Client = runtime publisher
 const client = (await TypedAmqpClient.create({ contract, urls }))._unsafeUnwrap();
 

--- a/docs/blog/introducing-amqp-contract.md
+++ b/docs/blog/introducing-amqp-contract.md
@@ -125,10 +125,12 @@ Now use the contract to create a type-safe client:
 import { TypedAmqpClient } from "@amqp-contract/client";
 import { contract } from "./contract";
 
-const client = await TypedAmqpClient.create({
-  contract,
-  urls: ["amqp://localhost"],
-});
+const client = (
+  await TypedAmqpClient.create({
+    contract,
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 
 // ✅ Fully typed! TypeScript knows exactly what fields are required
 const result = await client.publish("orderCreated", {
@@ -149,13 +151,13 @@ const result = await client.publish("orderCreated", {
 });
 
 // Explicit error handling with Result type
-result.match({
-  Ok: () => console.log("✅ Order published successfully"),
-  Error: (error) => {
+result.match(
+  () => console.log("✅ Order published successfully"),
+  (error) => {
     console.error("❌ Failed to publish order:", error);
     // error is either TechnicalError or MessageValidationError
   },
-});
+);
 ```
 
 ### 3. Type-Safe Consuming
@@ -166,27 +168,29 @@ And create a type-safe worker for consuming messages:
 import { TypedAmqpWorker } from "@amqp-contract/worker";
 import { contract } from "./contract";
 
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    // ✅ payload is fully typed based on your schema
-    processOrder: ({ payload }) => {
-      console.log(`Processing order: ${payload.orderId}`);
-      console.log(`Customer: ${payload.customerId}`);
-      console.log(`Total: $${payload.totalAmount}`);
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      // ✅ payload is fully typed based on your schema
+      processOrder: ({ payload }) => {
+        console.log(`Processing order: ${payload.orderId}`);
+        console.log(`Customer: ${payload.customerId}`);
+        console.log(`Total: $${payload.totalAmount}`);
 
-      // ✅ Full autocomplete for all fields
-      payload.items.forEach((item) => {
-        console.log(`- ${item.quantity}x Product ${item.productId}`);
-      });
+        // ✅ Full autocomplete for all fields
+        payload.items.forEach((item) => {
+          console.log(`- ${item.quantity}x Product ${item.productId}`);
+        });
 
-      // ✅ TypeScript catches typos and wrong field names
-      // console.log(payload.ordreId); // ❌ TypeScript error!
-      return okAsync(undefined);
+        // ✅ TypeScript catches typos and wrong field names
+        // console.log(payload.ordreId); // ❌ TypeScript error!
+        return okAsync(undefined);
+      },
     },
-  },
-  urls: ["amqp://localhost"],
-});
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 
 console.log("✅ Worker ready");
 ```
@@ -211,14 +215,14 @@ const result = await client.publish("orderCreated", {
   status: "invalid", // ❌ Validation error - must be pending/processing/completed
 });
 
-result.match({
-  Ok: () => {},
-  Error: (error) => {
+result.match(
+  () => {},
+  (error) => {
     if (error instanceof MessageValidationError) {
       console.log("Validation issues:", error.issues);
     }
   },
-});
+);
 ```
 
 ### 🛠️ Compile-Time Checks

--- a/docs/blog/introducing-amqp-contract.md
+++ b/docs/blog/introducing-amqp-contract.md
@@ -166,6 +166,7 @@ And create a type-safe worker for consuming messages:
 
 ```typescript
 import { TypedAmqpWorker } from "@amqp-contract/worker";
+import { okAsync } from "neverthrow";
 import { contract } from "./contract";
 
 const worker = (

--- a/docs/blog/introducing-amqp-contract.md
+++ b/docs/blog/introducing-amqp-contract.md
@@ -128,7 +128,7 @@ import { contract } from "./contract";
 const client = await TypedAmqpClient.create({
   contract,
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 
 // ✅ Fully typed! TypeScript knows exactly what fields are required
 const result = await client.publish("orderCreated", {
@@ -182,11 +182,11 @@ const worker = await TypedAmqpWorker.create({
 
       // ✅ TypeScript catches typos and wrong field names
       // console.log(payload.ordreId); // ❌ TypeScript error!
-      return Future.value(Result.Ok(undefined));
+      return okAsync(undefined);
     },
   },
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 
 console.log("✅ Worker ready");
 ```
@@ -227,7 +227,7 @@ TypeScript catches errors before runtime:
 
 ```typescript
 // ❌ TypeScript error - "orderDeleted" doesn't exist in contract
-await client.publish("orderDeleted", { orderId: "123" }).resultToPromise();
+await client.publish("orderDeleted", { orderId: "123" });
 
 // ❌ TypeScript error - missing handler for "processOrder"
 await TypedAmqpWorker.create({

--- a/docs/blog/resilient-message-handling-with-retry-strategy.md
+++ b/docs/blog/resilient-message-handling-with-retry-strategy.md
@@ -25,19 +25,22 @@ In any distributed system using message queues, you'll encounter various types o
 
 ```typescript
 // ❌ Without proper retry handling (using deprecated unsafe handler pattern)
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: ({ payload }) => {
-      // What happens when the payment service is temporarily down?
-      return ResultAsync.fromPromise(paymentService.charge(payload))
-        .map(() => undefined)
-        .mapErr((error) => new RetryableError("Payment failed", error));
-      // Without retry configuration, message may be lost or stuck
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: ({ payload }) => {
+        // What happens when the payment service is temporarily down?
+        return ResultAsync.fromPromise(
+          paymentService.charge(payload),
+          (error) => new RetryableError("Payment failed", error),
+        ).map(() => undefined);
+        // Without retry configuration, message may be lost or stuck
+      },
     },
-  },
-  urls: ["amqp://localhost"],
-});
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 ```
 
 Common problems with naive retry approaches:
@@ -65,7 +68,7 @@ import {
   defineMessage,
 } from "@amqp-contract/contract";
 import { TypedAmqpWorker, RetryableError } from "@amqp-contract/worker";
-import { ResultAsync } from "neverthrow";
+import { okAsync, ResultAsync } from "neverthrow";
 import { z } from "zod";
 
 const dlx = defineExchange("orders-dlx");
@@ -92,17 +95,20 @@ const contract = defineContract({
 });
 
 // Worker automatically uses queue's retry configuration
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: ({ payload }) =>
-      // If this fails, message is automatically retried with exponential backoff
-      ResultAsync.fromPromise(paymentService.charge(payload))
-        .map(() => undefined)
-        .mapErr((error) => new RetryableError("Payment failed", error)),
-  },
-  urls: ["amqp://localhost"],
-});
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: ({ payload }) =>
+        // If this fails, message is automatically retried with exponential backoff
+        ResultAsync.fromPromise(
+          paymentService.charge(payload),
+          (error) => new RetryableError("Payment failed", error),
+        ).map(() => undefined),
+    },
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 ```
 
 ## Choosing a Retry Strategy
@@ -116,7 +122,7 @@ A simpler mode that requeues failed messages immediately (no wait queues):
 ```typescript
 import { defineQueue, defineExchange, defineContract } from "@amqp-contract/contract";
 import { TypedAmqpWorker, RetryableError } from "@amqp-contract/worker";
-import { ResultAsync } from "neverthrow";
+import { okAsync, ResultAsync } from "neverthrow";
 
 // Define queue with immediate-requeue retry
 const ordersQueue = defineQueue("orders", {
@@ -129,16 +135,19 @@ const ordersQueue = defineQueue("orders", {
 });
 
 // Worker automatically uses queue's retry configuration
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: ({ payload }) =>
-      ResultAsync.fromPromise(paymentService.charge(payload))
-        .map(() => undefined)
-        .mapErr((error) => new RetryableError("Payment failed", error)),
-  },
-  urls: ["amqp://localhost"],
-});
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: ({ payload }) =>
+        ResultAsync.fromPromise(
+          paymentService.charge(payload),
+          (error) => new RetryableError("Payment failed", error),
+        ).map(() => undefined),
+    },
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 ```
 
 **How it works:**
@@ -295,23 +304,24 @@ Use `RetryableError` when the operation might succeed if retried:
 
 ```typescript
 import { TypedAmqpWorker, RetryableError } from "@amqp-contract/worker";
-import { ResultAsync } from "neverthrow";
+import { okAsync, ResultAsync } from "neverthrow";
 
 // Retry is configured at the queue level in the contract
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: ({ payload }) =>
-      ResultAsync.fromPromise(externalApiCall(payload))
-        .map(() => undefined)
-        .mapErr(
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: ({ payload }) =>
+        ResultAsync.fromPromise(
+          externalApiCall(payload),
           (error) =>
             // Explicitly signal this should be retried
             new RetryableError("External API temporarily unavailable", error),
-        ),
-  },
-  urls: ["amqp://localhost"],
-});
+        ).map(() => undefined),
+    },
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 ```
 
 ### NonRetryableError - For Permanent Failures
@@ -320,35 +330,38 @@ Use `NonRetryableError` when retrying would be pointless:
 
 ```typescript
 import { TypedAmqpWorker, NonRetryableError, RetryableError } from "@amqp-contract/worker";
-import { ResultAsync, Result } from "neverthrow";
+import { okAsync, ResultAsync, Result } from "neverthrow";
 
 // Retry is configured at the queue level in the contract
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: ({ payload }) => {
-      // Validation errors should not be retried
-      if (payload.amount <= 0) {
-        return ResultAsync.value(
-          err(new NonRetryableError("Invalid order amount - cannot be negative")),
-        );
-      }
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: ({ payload }) => {
+        // Validation errors should not be retried
+        if (payload.amount <= 0) {
+          return ResultAsync.value(
+            err(new NonRetryableError("Invalid order amount - cannot be negative")),
+          );
+        }
 
-      // Business rule violations - check and fail fast
-      return ResultAsync.fromPromise(isBlacklistedCustomer(payload.customerId))
-        .andThen((isBlacklisted) => {
-          if (isBlacklisted) {
-            return errAsync(new NonRetryableError("Customer is blacklisted"));
-          }
-          return ResultAsync.fromPromise(processPayment(payload))
-            .map(() => undefined)
-            .mapErr((error) => new RetryableError("Payment failed", error));
-        })
-        .mapErr((error) => new RetryableError("Check failed", error));
+        // Business rule violations - check and fail fast
+        return ResultAsync.fromPromise(isBlacklistedCustomer(payload.customerId))
+          .andThen((isBlacklisted) => {
+            if (isBlacklisted) {
+              return errAsync(new NonRetryableError("Customer is blacklisted"));
+            }
+            return ResultAsync.fromPromise(
+              processPayment(payload),
+              (error) => new RetryableError("Payment failed", error),
+            ).map(() => undefined);
+          })
+          .mapErr((error) => new RetryableError("Check failed", error));
+      },
     },
-  },
-  urls: ["amqp://localhost"],
-});
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 ```
 
 **NonRetryableError behavior:**
@@ -371,7 +384,7 @@ For the most explicit error handling, use safe handlers that return `ResultAsync
 
 ```typescript
 import { defineHandler, RetryableError, NonRetryableError } from "@amqp-contract/worker";
-import { ResultAsync, Result } from "neverthrow";
+import { okAsync, ResultAsync, Result } from "neverthrow";
 import { match } from "ts-pattern";
 
 const processOrderHandler = defineHandler(contract, "processOrder", ({ payload }) => {
@@ -397,13 +410,15 @@ const processOrderHandler = defineHandler(contract, "processOrder", ({ payload }
 });
 
 // Retry is configured at the queue level in the contract
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: processOrderHandler,
-  },
-  urls: ["amqp://localhost"],
-});
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: processOrderHandler,
+    },
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 ```
 
 ## Retry Header Tracking
@@ -471,7 +486,7 @@ const ordersQueue = defineQueue("orders", {
 Since messages may be processed multiple times, design your handlers to be idempotent:
 
 ```typescript
-import { ResultAsync, Result } from "neverthrow";
+import { okAsync, ResultAsync, Result } from "neverthrow";
 import { RetryableError } from "@amqp-contract/worker";
 
 const processOrderHandler = ({ payload }) => {
@@ -493,10 +508,10 @@ const processOrderHandler = ({ payload }) => {
 Set up alerts for messages reaching your dead letter queue:
 
 ```typescript
-import { ResultAsync, Result } from "neverthrow";
+import { okAsync, ResultAsync, Result } from "neverthrow";
 
 // Example: DLQ monitoring consumer
-const dlqMonitor = await TypedAmqpWorker.create({
+const dlqMonitor = (await TypedAmqpWorker.create({
   contract: dlqContract,
   handlers: {
     monitorFailedOrders: ({ payload }) => {
@@ -507,13 +522,12 @@ const dlqMonitor = await TypedAmqpWorker.create({
           message: `Order ${payload.orderId} failed after max retries`,
           headers: payload.headers,
         }),
-      )
-        .map(() => undefined)
-        .mapErr(() => new Error("Alert failed"));
+      , () => new Error("Alert failed"))
+        .map(() => undefined);
     },
   },
   urls: ["amqp://localhost"],
-});
+}))._unsafeUnwrap();
 ```
 
 ## Per-Queue Configuration

--- a/docs/blog/resilient-message-handling-with-retry-strategy.md
+++ b/docs/blog/resilient-message-handling-with-retry-strategy.md
@@ -330,7 +330,7 @@ Use `NonRetryableError` when retrying would be pointless:
 
 ```typescript
 import { TypedAmqpWorker, NonRetryableError, RetryableError } from "@amqp-contract/worker";
-import { okAsync, ResultAsync, Result } from "neverthrow";
+import { errAsync, okAsync, ResultAsync } from "neverthrow";
 
 // Retry is configured at the queue level in the contract
 const worker = (
@@ -340,9 +340,7 @@ const worker = (
       processOrder: ({ payload }) => {
         // Validation errors should not be retried
         if (payload.amount <= 0) {
-          return ResultAsync.value(
-            err(new NonRetryableError("Invalid order amount - cannot be negative")),
-          );
+          return errAsync(new NonRetryableError("Invalid order amount - cannot be negative"));
         }
 
         // Business rule violations - check and fail fast
@@ -384,7 +382,7 @@ For the most explicit error handling, use safe handlers that return `ResultAsync
 
 ```typescript
 import { defineHandler, RetryableError, NonRetryableError } from "@amqp-contract/worker";
-import { okAsync, ResultAsync, Result } from "neverthrow";
+import { errAsync, okAsync, ResultAsync } from "neverthrow";
 import { match } from "ts-pattern";
 
 const processOrderHandler = defineHandler(contract, "processOrder", ({ payload }) => {

--- a/docs/blog/resilient-message-handling-with-retry-strategy.md
+++ b/docs/blog/resilient-message-handling-with-retry-strategy.md
@@ -30,9 +30,9 @@ const worker = await TypedAmqpWorker.create({
   handlers: {
     processOrder: ({ payload }) => {
       // What happens when the payment service is temporarily down?
-      return Future.fromPromise(paymentService.charge(payload))
-        .mapOk(() => undefined)
-        .mapError((error) => new RetryableError("Payment failed", error));
+      return ResultAsync.fromPromise(paymentService.charge(payload))
+        .map(() => undefined)
+        .mapErr((error) => new RetryableError("Payment failed", error));
       // Without retry configuration, message may be lost or stuck
     },
   },
@@ -65,7 +65,7 @@ import {
   defineMessage,
 } from "@amqp-contract/contract";
 import { TypedAmqpWorker, RetryableError } from "@amqp-contract/worker";
-import { Future } from "@swan-io/boxed";
+import { ResultAsync } from "neverthrow";
 import { z } from "zod";
 
 const dlx = defineExchange("orders-dlx");
@@ -97,12 +97,12 @@ const worker = await TypedAmqpWorker.create({
   handlers: {
     processOrder: ({ payload }) =>
       // If this fails, message is automatically retried with exponential backoff
-      Future.fromPromise(paymentService.charge(payload))
-        .mapOk(() => undefined)
-        .mapError((error) => new RetryableError("Payment failed", error)),
+      ResultAsync.fromPromise(paymentService.charge(payload))
+        .map(() => undefined)
+        .mapErr((error) => new RetryableError("Payment failed", error)),
   },
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 ```
 
 ## Choosing a Retry Strategy
@@ -116,7 +116,7 @@ A simpler mode that requeues failed messages immediately (no wait queues):
 ```typescript
 import { defineQueue, defineExchange, defineContract } from "@amqp-contract/contract";
 import { TypedAmqpWorker, RetryableError } from "@amqp-contract/worker";
-import { Future } from "@swan-io/boxed";
+import { ResultAsync } from "neverthrow";
 
 // Define queue with immediate-requeue retry
 const ordersQueue = defineQueue("orders", {
@@ -133,12 +133,12 @@ const worker = await TypedAmqpWorker.create({
   contract,
   handlers: {
     processOrder: ({ payload }) =>
-      Future.fromPromise(paymentService.charge(payload))
-        .mapOk(() => undefined)
-        .mapError((error) => new RetryableError("Payment failed", error)),
+      ResultAsync.fromPromise(paymentService.charge(payload))
+        .map(() => undefined)
+        .mapErr((error) => new RetryableError("Payment failed", error)),
   },
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 ```
 
 **How it works:**
@@ -295,23 +295,23 @@ Use `RetryableError` when the operation might succeed if retried:
 
 ```typescript
 import { TypedAmqpWorker, RetryableError } from "@amqp-contract/worker";
-import { Future } from "@swan-io/boxed";
+import { ResultAsync } from "neverthrow";
 
 // Retry is configured at the queue level in the contract
 const worker = await TypedAmqpWorker.create({
   contract,
   handlers: {
     processOrder: ({ payload }) =>
-      Future.fromPromise(externalApiCall(payload))
-        .mapOk(() => undefined)
-        .mapError(
+      ResultAsync.fromPromise(externalApiCall(payload))
+        .map(() => undefined)
+        .mapErr(
           (error) =>
             // Explicitly signal this should be retried
             new RetryableError("External API temporarily unavailable", error),
         ),
   },
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 ```
 
 ### NonRetryableError - For Permanent Failures
@@ -320,7 +320,7 @@ Use `NonRetryableError` when retrying would be pointless:
 
 ```typescript
 import { TypedAmqpWorker, NonRetryableError, RetryableError } from "@amqp-contract/worker";
-import { Future, Result } from "@swan-io/boxed";
+import { ResultAsync, Result } from "neverthrow";
 
 // Retry is configured at the queue level in the contract
 const worker = await TypedAmqpWorker.create({
@@ -329,26 +329,26 @@ const worker = await TypedAmqpWorker.create({
     processOrder: ({ payload }) => {
       // Validation errors should not be retried
       if (payload.amount <= 0) {
-        return Future.value(
-          Result.Error(new NonRetryableError("Invalid order amount - cannot be negative")),
+        return ResultAsync.value(
+          err(new NonRetryableError("Invalid order amount - cannot be negative")),
         );
       }
 
       // Business rule violations - check and fail fast
-      return Future.fromPromise(isBlacklistedCustomer(payload.customerId))
-        .flatMapOk((isBlacklisted) => {
+      return ResultAsync.fromPromise(isBlacklistedCustomer(payload.customerId))
+        .andThen((isBlacklisted) => {
           if (isBlacklisted) {
-            return Future.value(Result.Error(new NonRetryableError("Customer is blacklisted")));
+            return errAsync(new NonRetryableError("Customer is blacklisted"));
           }
-          return Future.fromPromise(processPayment(payload))
-            .mapOk(() => undefined)
-            .mapError((error) => new RetryableError("Payment failed", error));
+          return ResultAsync.fromPromise(processPayment(payload))
+            .map(() => undefined)
+            .mapErr((error) => new RetryableError("Payment failed", error));
         })
-        .mapError((error) => new RetryableError("Check failed", error));
+        .mapErr((error) => new RetryableError("Check failed", error));
     },
   },
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 ```
 
 **NonRetryableError behavior:**
@@ -367,22 +367,22 @@ const worker = await TypedAmqpWorker.create({
 
 ## Safe Handlers for Maximum Control
 
-For the most explicit error handling, use safe handlers that return `Future<Result>`:
+For the most explicit error handling, use safe handlers that return `ResultAsync<Result>`:
 
 ```typescript
 import { defineHandler, RetryableError, NonRetryableError } from "@amqp-contract/worker";
-import { Future, Result } from "@swan-io/boxed";
+import { ResultAsync, Result } from "neverthrow";
 import { match } from "ts-pattern";
 
 const processOrderHandler = defineHandler(contract, "processOrder", ({ payload }) => {
   // Validation - non-retryable
   if (payload.amount <= 0) {
-    return Future.value(Result.Error(new NonRetryableError("Invalid amount")));
+    return errAsync(new NonRetryableError("Invalid amount"));
   }
 
-  return Future.fromPromise(processPayment(payload))
-    .mapOk(() => undefined)
-    .mapError((error) =>
+  return ResultAsync.fromPromise(processPayment(payload))
+    .map(() => undefined)
+    .mapErr((error) =>
       match(error)
         .when(
           (e) => e instanceof PaymentDeclinedError,
@@ -403,7 +403,7 @@ const worker = await TypedAmqpWorker.create({
     processOrder: processOrderHandler,
   },
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 ```
 
 ## Retry Header Tracking
@@ -471,20 +471,20 @@ const ordersQueue = defineQueue("orders", {
 Since messages may be processed multiple times, design your handlers to be idempotent:
 
 ```typescript
-import { Future, Result } from "@swan-io/boxed";
+import { ResultAsync, Result } from "neverthrow";
 import { RetryableError } from "@amqp-contract/worker";
 
 const processOrderHandler = ({ payload }) => {
   // Use the orderId as an idempotency key
-  return Future.fromPromise(db.orders.findById(payload.orderId))
-    .flatMapOk((existing) => {
+  return ResultAsync.fromPromise(db.orders.findById(payload.orderId))
+    .andThen((existing) => {
       if (existing) {
         console.log(`Order ${payload.orderId} already processed, skipping`);
-        return Future.value(Result.Ok(undefined));
+        return okAsync(undefined);
       }
-      return Future.fromPromise(db.orders.create(payload)).mapOk(() => undefined);
+      return ResultAsync.fromPromise(db.orders.create(payload)).map(() => undefined);
     })
-    .mapError((error) => new RetryableError("Database error", error));
+    .mapErr((error) => new RetryableError("Database error", error));
 };
 ```
 
@@ -493,7 +493,7 @@ const processOrderHandler = ({ payload }) => {
 Set up alerts for messages reaching your dead letter queue:
 
 ```typescript
-import { Future, Result } from "@swan-io/boxed";
+import { ResultAsync, Result } from "neverthrow";
 
 // Example: DLQ monitoring consumer
 const dlqMonitor = await TypedAmqpWorker.create({
@@ -501,15 +501,15 @@ const dlqMonitor = await TypedAmqpWorker.create({
   handlers: {
     monitorFailedOrders: ({ payload }) => {
       // Alert your monitoring system
-      return Future.fromPromise(
+      return ResultAsync.fromPromise(
         alerting.send({
           severity: "warning",
           message: `Order ${payload.orderId} failed after max retries`,
           headers: payload.headers,
         }),
       )
-        .mapOk(() => undefined)
-        .mapError(() => new Error("Alert failed"));
+        .map(() => undefined)
+        .mapErr(() => new Error("Alert failed"));
     },
   },
   urls: ["amqp://localhost"],

--- a/docs/examples/basic-order-processing.md
+++ b/docs/examples/basic-order-processing.md
@@ -306,10 +306,12 @@ The client is in a separate package (`@amqp-contract-examples/basic-order-proces
 import { TypedAmqpClient } from "@amqp-contract/client";
 import { orderContract } from "@amqp-contract-examples/basic-order-processing-contract";
 
-const client = await TypedAmqpClient.create({
-  contract: orderContract,
-  urls: ["amqp://localhost"],
-});
+const client = (
+  await TypedAmqpClient.create({
+    contract: orderContract,
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 
 // Publish new order with explicit error handling
 const result = await client.publish("orderCreated", {
@@ -320,13 +322,13 @@ const result = await client.publish("orderCreated", {
   createdAt: new Date().toISOString(),
 });
 
-result.match({
-  Ok: () => console.log("Order published successfully"),
-  Error: (error) => {
+result.match(
+  () => console.log("Order published successfully"),
+  (error) => {
     console.error("Failed to publish:", error.message);
     // Handle error appropriately
   },
-});
+);
 
 // Publish status update
 const updateResult = await client.publish("orderUpdated", {
@@ -335,10 +337,10 @@ const updateResult = await client.publish("orderUpdated", {
   updatedAt: new Date().toISOString(),
 });
 
-updateResult.match({
-  Ok: () => console.log("Status update published"),
-  Error: (error) => console.error("Failed:", error),
-});
+updateResult.match(
+  () => console.log("Status update published"),
+  (error) => console.error("Failed:", error),
+);
 ```
 
 ## Worker Implementation
@@ -352,33 +354,35 @@ import { orderContract } from "@amqp-contract-examples/basic-order-processing-co
 
 const connection = await connect("amqp://localhost");
 
-const worker = await TypedAmqpWorker.create({
-  contract: orderContract,
-  handlers: {
-    processOrder: ({ payload }) => {
-      console.log(`[PROCESSING] Order ${payload.orderId}`);
-      console.log(`  Customer: ${payload.customerId}`);
-      console.log(`  Total: $${payload.totalAmount}`);
-      return okAsync(undefined);
-    },
+const worker = (
+  await TypedAmqpWorker.create({
+    contract: orderContract,
+    handlers: {
+      processOrder: ({ payload }) => {
+        console.log(`[PROCESSING] Order ${payload.orderId}`);
+        console.log(`  Customer: ${payload.customerId}`);
+        console.log(`  Total: $${payload.totalAmount}`);
+        return okAsync(undefined);
+      },
 
-    notifyOrder: ({ payload }) => {
-      console.log(`[NOTIFICATION] Order ${payload.orderId} event`);
-      return okAsync(undefined);
-    },
+      notifyOrder: ({ payload }) => {
+        console.log(`[NOTIFICATION] Order ${payload.orderId} event`);
+        return okAsync(undefined);
+      },
 
-    shipOrder: ({ payload }) => {
-      console.log(`[SHIPPING] Order ${payload.orderId} - ${payload.status}`);
-      return okAsync(undefined);
-    },
+      shipOrder: ({ payload }) => {
+        console.log(`[SHIPPING] Order ${payload.orderId} - ${payload.status}`);
+        return okAsync(undefined);
+      },
 
-    handleUrgentOrder: ({ payload }) => {
-      console.log(`[URGENT] Order ${payload.orderId} - ${payload.status}`);
-      return okAsync(undefined);
+      handleUrgentOrder: ({ payload }) => {
+        console.log(`[URGENT] Order ${payload.orderId} - ${payload.status}`);
+        return okAsync(undefined);
+      },
     },
-  },
-  connection,
-});
+    connection,
+  })
+)._unsafeUnwrap();
 ```
 
 ## Message Routing Table

--- a/docs/examples/basic-order-processing.md
+++ b/docs/examples/basic-order-processing.md
@@ -309,7 +309,7 @@ import { orderContract } from "@amqp-contract-examples/basic-order-processing-co
 const client = await TypedAmqpClient.create({
   contract: orderContract,
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 
 // Publish new order with explicit error handling
 const result = await client.publish("orderCreated", {
@@ -359,22 +359,22 @@ const worker = await TypedAmqpWorker.create({
       console.log(`[PROCESSING] Order ${payload.orderId}`);
       console.log(`  Customer: ${payload.customerId}`);
       console.log(`  Total: $${payload.totalAmount}`);
-      return Future.value(Result.Ok(undefined));
+      return okAsync(undefined);
     },
 
     notifyOrder: ({ payload }) => {
       console.log(`[NOTIFICATION] Order ${payload.orderId} event`);
-      return Future.value(Result.Ok(undefined));
+      return okAsync(undefined);
     },
 
     shipOrder: ({ payload }) => {
       console.log(`[SHIPPING] Order ${payload.orderId} - ${payload.status}`);
-      return Future.value(Result.Ok(undefined));
+      return okAsync(undefined);
     },
 
     handleUrgentOrder: ({ payload }) => {
       console.log(`[URGENT] Order ${payload.orderId} - ${payload.status}`);
-      return Future.value(Result.Ok(undefined));
+      return okAsync(undefined);
     },
   },
   connection,

--- a/docs/examples/command-pattern.md
+++ b/docs/examples/command-pattern.md
@@ -68,10 +68,12 @@ import { TypedAmqpClient } from "@amqp-contract/client";
 import { contract } from "@org/payment-contract";
 import { randomUUID } from "node:crypto";
 
-const client = await TypedAmqpClient.create({
-  contract,
-  urls: ["amqp://localhost"],
-});
+const client = (
+  await TypedAmqpClient.create({
+    contract,
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 
 await client.publish("chargeCustomer", {
   customerId: "cust_123",
@@ -106,25 +108,24 @@ const chargeHandler = defineHandler(contract, "chargeCustomer", ({ payload }) =>
       currency: payload.currency,
       idempotencyKey: payload.idempotencyKey,
     }),
-  )
-    .map(() => undefined)
-    .mapErr((error) => {
+  , (error) => {
       // Card declined / fraud / closed account — won't change with retry.
       if (error instanceof PermanentDeclineError) {
         return new NonRetryableError(`Charge declined: ${error.code}`, error);
       }
       // 5xx, network, timeout — let the queue retry with backoff.
       return new RetryableError("Payment provider unavailable", error);
-    }),
+    })
+    .map(() => undefined),
 );
 
-const worker = await TypedAmqpWorker.create({
+const worker = (await TypedAmqpWorker.create({
   contract,
   handlers: {
     chargeCustomer: [chargeHandler, { prefetch: 5 }],
   },
   urls: ["amqp://localhost"],
-});
+}))._unsafeUnwrap();
 
 process.on("SIGINT", async () => {
   await worker.close();

--- a/docs/examples/command-pattern.md
+++ b/docs/examples/command-pattern.md
@@ -71,16 +71,14 @@ import { randomUUID } from "node:crypto";
 const client = await TypedAmqpClient.create({
   contract,
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 
-await client
-  .publish("chargeCustomer", {
-    customerId: "cust_123",
-    amountCents: 4_999,
-    currency: "USD",
-    idempotencyKey: randomUUID(),
-  })
-  .resultToPromise();
+await client.publish("chargeCustomer", {
+  customerId: "cust_123",
+  amountCents: 4_999,
+  currency: "USD",
+  idempotencyKey: randomUUID(),
+});
 ```
 
 A `subscriptions-service`, `refunds-service`, or any other publisher does the same — they all use `chargeCustomer`. Routing-key dispatch is handled by the contract; callers never name `payments.charge` themselves.
@@ -97,11 +95,11 @@ import {
   RetryableError,
   NonRetryableError,
 } from "@amqp-contract/worker";
-import { Future, Result } from "@swan-io/boxed";
+import { ResultAsync, Result } from "neverthrow";
 import { contract } from "@org/payment-contract";
 
 const chargeHandler = defineHandler(contract, "chargeCustomer", ({ payload }) =>
-  Future.fromPromise(
+  ResultAsync.fromPromise(
     chargeProvider({
       customerId: payload.customerId,
       amount: payload.amountCents,
@@ -109,8 +107,8 @@ const chargeHandler = defineHandler(contract, "chargeCustomer", ({ payload }) =>
       idempotencyKey: payload.idempotencyKey,
     }),
   )
-    .mapOk(() => undefined)
-    .mapError((error) => {
+    .map(() => undefined)
+    .mapErr((error) => {
       // Card declined / fraud / closed account — won't change with retry.
       if (error instanceof PermanentDeclineError) {
         return new NonRetryableError(`Charge declined: ${error.code}`, error);
@@ -126,10 +124,10 @@ const worker = await TypedAmqpWorker.create({
     chargeCustomer: [chargeHandler, { prefetch: 5 }],
   },
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 
 process.on("SIGINT", async () => {
-  await worker.close().resultToPromise();
+  await worker.close();
   process.exit(0);
 });
 ```

--- a/docs/examples/command-pattern.md
+++ b/docs/examples/command-pattern.md
@@ -108,24 +108,26 @@ const chargeHandler = defineHandler(contract, "chargeCustomer", ({ payload }) =>
       currency: payload.currency,
       idempotencyKey: payload.idempotencyKey,
     }),
-  , (error) => {
+    (error) => {
       // Card declined / fraud / closed account — won't change with retry.
       if (error instanceof PermanentDeclineError) {
         return new NonRetryableError(`Charge declined: ${error.code}`, error);
       }
       // 5xx, network, timeout — let the queue retry with backoff.
       return new RetryableError("Payment provider unavailable", error);
-    })
-    .map(() => undefined),
+    },
+  ).map(() => undefined),
 );
 
-const worker = (await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    chargeCustomer: [chargeHandler, { prefetch: 5 }],
-  },
-  urls: ["amqp://localhost"],
-}))._unsafeUnwrap();
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      chargeCustomer: [chargeHandler, { prefetch: 5 }],
+    },
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 
 process.on("SIGINT", async () => {
   await worker.close();

--- a/docs/guide/client-usage.md
+++ b/docs/guide/client-usage.md
@@ -4,16 +4,18 @@ Learn how to use the type-safe AMQP client to publish messages.
 
 ## Creating a Client
 
-Create a type-safe client from your contract. The `create` method returns a `ResultAsync<Result<...>>` that must be awaited:
+Create a type-safe client from your contract. `TypedAmqpClient.create(...)` returns `ResultAsync<TypedAmqpClient, TechnicalError>` — `await` yields a `Result`, which you unwrap (`_unsafeUnwrap()`) or pattern-match before using:
 
 ```typescript
 import { TypedAmqpClient } from "@amqp-contract/client";
 import { contract } from "./contract";
 
-const client = await TypedAmqpClient.create({
-  contract,
-  urls: ["amqp://localhost"],
-});
+const client = (
+  await TypedAmqpClient.create({
+    contract,
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 ```
 
 ### Default Publish Options
@@ -21,14 +23,16 @@ const client = await TypedAmqpClient.create({
 Configure default publish options that apply to all messages published by the client:
 
 ```typescript
-const client = await TypedAmqpClient.create({
-  contract,
-  urls: ["amqp://localhost"],
-  defaultPublishOptions: {
-    priority: 5,
-    headers: { "x-app-version": "1.0.0" },
-  },
-});
+const client = (
+  await TypedAmqpClient.create({
+    contract,
+    urls: ["amqp://localhost"],
+    defaultPublishOptions: {
+      priority: 5,
+      headers: { "x-app-version": "1.0.0" },
+    },
+  })
+)._unsafeUnwrap();
 ```
 
 Default publish options can be overridden by options passed to individual `publish` calls.
@@ -47,10 +51,10 @@ const result = await client.publish("orderCreated", {
   items: [{ productId: "PROD-A", quantity: 2 }],
 });
 
-result.match({
-  Ok: () => console.log("✅ Published"),
-  Error: (error) => console.error("❌ Failed:", error.message),
-});
+result.match(
+  () => console.log("✅ Published"),
+  (error) => console.error("❌ Failed:", error.message),
+);
 ```
 
 ### Type Safety
@@ -78,10 +82,10 @@ const result = await client.publish('orderCreated', {
   amount: 99.99,
 });
 
-result.match({
-  Ok: () => console.log('Published'),
-  Error: (error) => console.error('Validation failed:', error),
-});
+result.match(
+  () => console.log('Published'),
+  (error) => console.error('Validation failed:', error),
+  );
 ```
 
 ## Publishing Options
@@ -157,16 +161,16 @@ const result = await client.publish("orderCreated", {
   amount: 99.99,
 });
 
-result.match({
-  Ok: () => console.log("✅ Published"),
-  Error: (error) =>
+result.match(
+  () => console.log("✅ Published"),
+  (error) =>
     match(error)
       .with(P.instanceOf(MessageValidationError), (err) =>
         console.error("Validation failed:", err.issues),
       )
       .with(P.instanceOf(TechnicalError), (err) => console.error("Technical error:", err.message))
       .exhaustive(),
-});
+);
 ```
 
 **Error Types:**
@@ -188,10 +192,12 @@ async function main() {
   let client;
 
   try {
-    client = await TypedAmqpClient.create({
-      contract,
-      urls: ["amqp://localhost"],
-    });
+    client = (
+      await TypedAmqpClient.create({
+        contract,
+        urls: ["amqp://localhost"],
+      })
+    )._unsafeUnwrap();
 
     const result = await client.publish("orderCreated", {
       orderId: "ORD-123",
@@ -199,9 +205,9 @@ async function main() {
       amount: 99.99,
       items: [{ productId: "PROD-A", quantity: 2 }],
     });
-    result.match({
-      Ok: () => console.log("✅ Message published"),
-      Error: (error) =>
+    result.match(
+      () => console.log("✅ Message published"),
+      (error) =>
         match(error)
           .with(P.instanceOf(MessageValidationError), (err) =>
             console.error("❌ Validation failed:", err.issues),
@@ -210,7 +216,7 @@ async function main() {
             console.error("❌ Technical error:", err.message),
           )
           .exhaustive(),
-    });
+    );
   } catch (error) {
     console.error("Unexpected error:", error);
   } finally {

--- a/docs/guide/client-usage.md
+++ b/docs/guide/client-usage.md
@@ -4,7 +4,7 @@ Learn how to use the type-safe AMQP client to publish messages.
 
 ## Creating a Client
 
-Create a type-safe client from your contract. The `create` method returns a `Future<Result<...>>` that must be awaited:
+Create a type-safe client from your contract. The `create` method returns a `ResultAsync<Result<...>>` that must be awaited:
 
 ```typescript
 import { TypedAmqpClient } from "@amqp-contract/client";
@@ -13,7 +13,7 @@ import { contract } from "./contract";
 const client = await TypedAmqpClient.create({
   contract,
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 ```
 
 ### Default Publish Options
@@ -28,7 +28,7 @@ const client = await TypedAmqpClient.create({
     priority: 5,
     headers: { "x-app-version": "1.0.0" },
   },
-}).resultToPromise();
+});
 ```
 
 Default publish options can be overridden by options passed to individual `publish` calls.
@@ -91,13 +91,11 @@ result.match({
 Override the routing key for specific messages:
 
 ```typescript
-const result = await client
-  .publish(
-    "orderCreated",
-    { orderId: "ORD-123", amount: 99.99 },
-    { routingKey: "order.created.urgent" },
-  )
-  .resultToPromise();
+const result = await client.publish(
+  "orderCreated",
+  { orderId: "ORD-123", amount: 99.99 },
+  { routingKey: "order.created.urgent" },
+);
 ```
 
 ### Message Properties
@@ -105,19 +103,17 @@ const result = await client
 Set AMQP message properties:
 
 ```typescript
-const result = await client
-  .publish(
-    "orderCreated",
-    { orderId: "ORD-123", amount: 99.99 },
-    {
-      options: {
-        persistent: false,
-        priority: 10,
-        headers: { "x-request-id": "req-123" },
-      },
+const result = await client.publish(
+  "orderCreated",
+  { orderId: "ORD-123", amount: 99.99 },
+  {
+    options: {
+      persistent: false,
+      priority: 10,
+      headers: { "x-request-id": "req-123" },
     },
-  )
-  .resultToPromise();
+  },
+);
 ```
 
 ### Publishing with Headers
@@ -125,19 +121,17 @@ const result = await client
 When your message schema defines a [headers schema](/guide/defining-contracts#message-headers), pass headers via the `options.headers` property:
 
 ```typescript
-const result = await client
-  .publish(
-    "orderCreated",
-    { orderId: "ORD-123", amount: 99.99 },
-    {
-      headers: {
-        correlationId: "550e8400-e29b-41d4-a716-446655440000",
-        priority: "high",
-        tenantId: "tenant-42",
-      },
+const result = await client.publish(
+  "orderCreated",
+  { orderId: "ORD-123", amount: 99.99 },
+  {
+    headers: {
+      correlationId: "550e8400-e29b-41d4-a716-446655440000",
+      priority: "high",
+      tenantId: "tenant-42",
     },
-  )
-  .resultToPromise();
+  },
+);
 ```
 
 Headers are validated by the consumer at runtime using the headers schema defined in `defineMessage`. On the publish side, headers are passed as raw AMQP message properties — make sure to match the expected schema to avoid consumer-side validation errors.
@@ -197,17 +191,14 @@ async function main() {
     client = await TypedAmqpClient.create({
       contract,
       urls: ["amqp://localhost"],
-    }).resultToPromise();
+    });
 
-    const result = await client
-      .publish("orderCreated", {
-        orderId: "ORD-123",
-        customerId: "CUST-456",
-        amount: 99.99,
-        items: [{ productId: "PROD-A", quantity: 2 }],
-      })
-      .resultToPromise();
-
+    const result = await client.publish("orderCreated", {
+      orderId: "ORD-123",
+      customerId: "CUST-456",
+      amount: 99.99,
+      items: [{ productId: "PROD-A", quantity: 2 }],
+    });
     result.match({
       Ok: () => console.log("✅ Message published"),
       Error: (error) =>

--- a/docs/guide/comparison.md
+++ b/docs/guide/comparison.md
@@ -66,10 +66,12 @@ import { TypedAmqpClient } from "@amqp-contract/client";
 import { contract } from "./contract.js";
 
 // Create client once
-const client = await TypedAmqpClient.create({
-  contract, // Resources declared automatically!
-  urls: ["amqp://localhost"],
-});
+const client = (
+  await TypedAmqpClient.create({
+    contract, // Resources declared automatically!
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 
 // Publish - fully typed and validated!
 const result = await client.publish("orderCreated", {
@@ -78,10 +80,10 @@ const result = await client.publish("orderCreated", {
   customerId: "CUST-456", // ✅ Required fields enforced!
 });
 
-result.match({
-  Ok: () => console.log("✅ Published"),
-  Error: (error) => console.error("❌ Failed:", error),
-}); // ✅ Automatic validation!
+result.match(
+  () => console.log("✅ Published"),
+  (error) => console.error("❌ Failed:", error),
+); // ✅ Automatic validation!
 
 // Cleanup managed for you
 await client.close();
@@ -116,22 +118,24 @@ channel.consume("order-processing", (msg) => {
 
 ```typescript [✅ amqp-contract - Fully typed]
 import { TypedAmqpWorker } from "@amqp-contract/worker";
-import { ResultAsync, Result } from "neverthrow";
+import { okAsync, ResultAsync, Result } from "neverthrow";
 import { contract } from "./contract.js";
 
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: ({ payload }) => {
-      // ✅ Payload is fully typed!
-      console.log(payload.orderId); // ✅ Full autocomplete!
-      console.log(payload.amount); // ✅ Type-safe!
-      // ✅ Automatic validation - invalid messages rejected!
-      return okAsync(undefined);
-    }, // ✅ Auto-acknowledgment on success!
-  },
-  urls: ["amqp://localhost"],
-});
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: ({ payload }) => {
+        // ✅ Payload is fully typed!
+        console.log(payload.orderId); // ✅ Full autocomplete!
+        console.log(payload.amount); // ✅ Type-safe!
+        // ✅ Automatic validation - invalid messages rejected!
+        return okAsync(undefined);
+      }, // ✅ Auto-acknowledgment on success!
+    },
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 ```
 
 :::

--- a/docs/guide/comparison.md
+++ b/docs/guide/comparison.md
@@ -69,7 +69,7 @@ import { contract } from "./contract.js";
 const client = await TypedAmqpClient.create({
   contract, // Resources declared automatically!
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 
 // Publish - fully typed and validated!
 const result = await client.publish("orderCreated", {
@@ -116,7 +116,7 @@ channel.consume("order-processing", (msg) => {
 
 ```typescript [✅ amqp-contract - Fully typed]
 import { TypedAmqpWorker } from "@amqp-contract/worker";
-import { Future, Result } from "@swan-io/boxed";
+import { ResultAsync, Result } from "neverthrow";
 import { contract } from "./contract.js";
 
 const worker = await TypedAmqpWorker.create({
@@ -127,11 +127,11 @@ const worker = await TypedAmqpWorker.create({
       console.log(payload.orderId); // ✅ Full autocomplete!
       console.log(payload.amount); // ✅ Type-safe!
       // ✅ Automatic validation - invalid messages rejected!
-      return Future.value(Result.Ok(undefined));
+      return okAsync(undefined);
     }, // ✅ Auto-acknowledgment on success!
   },
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 ```
 
 :::

--- a/docs/guide/connection-sharing.md
+++ b/docs/guide/connection-sharing.md
@@ -31,40 +31,43 @@ import { TypedAmqpWorker } from "@amqp-contract/worker";
 import { contract } from "./contract";
 
 // 1. Create client - automatically creates connection
-const client = await TypedAmqpClient.create({
-  contract,
-  urls: ["amqp://localhost"], // ← Just provide URLs
-  connectionOptions: {
-    heartbeatIntervalInSeconds: 30,
-  },
-});
+const client = (
+  await TypedAmqpClient.create({
+    contract,
+    urls: ["amqp://localhost"], // ← Just provide URLs
+    connectionOptions: {
+      heartbeatIntervalInSeconds: 30,
+    },
+  })
+)._unsafeUnwrap();
 
 // 2. Create worker - automatically reuses the same connection!
-const worker = await TypedAmqpWorker.create({
-  contract,
-  urls: ["amqp://localhost"], // ← Same URLs = automatic sharing
-  handlers: {
-    processOrder: ({ payload }) => {
-      console.log("Processing order:", payload.orderId);
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    urls: ["amqp://localhost"], // ← Same URLs = automatic sharing
+    handlers: {
+      processOrder: ({ payload }) => {
+        console.log("Processing order:", payload.orderId);
 
-      // Can publish from within consumer
-      return ResultAsync.fromPromise(
-        client.publish("orderProcessed", {
-          orderId: payload.orderId,
-          status: "completed",
-        }),
-      )
-        .map(() => {
-          console.log("Order processed event published");
-          return undefined;
-        })
-        .mapErr((error) => {
-          console.error("Failed to publish:", error);
-          return new RetryableError("Failed to publish", error);
-        });
+        // Can publish from within consumer — `publish` already returns a
+        // ResultAsync, so we chain its combinators directly.
+        return client
+          .publish("orderProcessed", {
+            orderId: payload.orderId,
+            status: "completed",
+          })
+          .map(() => {
+            console.log("Order processed event published");
+          })
+          .mapErr((error) => {
+            console.error("Failed to publish:", error);
+            return new RetryableError("Failed to publish", error);
+          });
+      },
     },
-  },
-});
+  })
+)._unsafeUnwrap();
 
 // Both client and worker automatically share a single connection! ✅
 // Result: 1 connection, 2 channels
@@ -112,18 +115,22 @@ When you create multiple clients or workers with the same URLs and connection op
 
 ```typescript
 // ✅ Automatically shares a single connection
-const client = await TypedAmqpClient.create({
-  contract,
-  urls: ["amqp://localhost"], // ← URLs match
-});
+const client = (
+  await TypedAmqpClient.create({
+    contract,
+    urls: ["amqp://localhost"], // ← URLs match
+  })
+)._unsafeUnwrap();
 
-const worker = await TypedAmqpWorker.create({
-  contract,
-  urls: ["amqp://localhost"], // ← URLs match = shared connection
-  handlers: {
-    /* ... */
-  },
-});
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    urls: ["amqp://localhost"], // ← URLs match = shared connection
+    handlers: {
+      /* ... */
+    },
+  })
+)._unsafeUnwrap();
 
 // Result: 1 connection, 2 channels ✅
 // - Less resource usage
@@ -142,31 +149,39 @@ You can create multiple clients and workers - they automatically share connectio
 
 ```typescript
 // All automatically share the same connection
-const orderClient = await TypedAmqpClient.create({
-  contract: orderContract,
-  urls: ["amqp://localhost"], // ← Same URLs
-});
+const orderClient = (
+  await TypedAmqpClient.create({
+    contract: orderContract,
+    urls: ["amqp://localhost"], // ← Same URLs
+  })
+)._unsafeUnwrap();
 
-const notificationClient = await TypedAmqpClient.create({
-  contract: notificationContract,
-  urls: ["amqp://localhost"], // ← Same URLs
-});
+const notificationClient = (
+  await TypedAmqpClient.create({
+    contract: notificationContract,
+    urls: ["amqp://localhost"], // ← Same URLs
+  })
+)._unsafeUnwrap();
 
-const orderWorker = await TypedAmqpWorker.create({
-  contract: orderContract,
-  urls: ["amqp://localhost"], // ← Same URLs
-  handlers: {
-    /* ... */
-  },
-});
+const orderWorker = (
+  await TypedAmqpWorker.create({
+    contract: orderContract,
+    urls: ["amqp://localhost"], // ← Same URLs
+    handlers: {
+      /* ... */
+    },
+  })
+)._unsafeUnwrap();
 
-const notificationWorker = await TypedAmqpWorker.create({
-  contract: notificationContract,
-  urls: ["amqp://localhost"], // ← Same URLs
-  handlers: {
-    /* ... */
-  },
-});
+const notificationWorker = (
+  await TypedAmqpWorker.create({
+    contract: notificationContract,
+    urls: ["amqp://localhost"], // ← Same URLs
+    handlers: {
+      /* ... */
+    },
+  })
+)._unsafeUnwrap();
 
 // All automatically share one connection with 4 separate channels
 ```
@@ -177,15 +192,19 @@ If you need separate connections (e.g., for different RabbitMQ clusters), just u
 
 ```typescript
 // These will have separate connections
-const mainClient = await TypedAmqpClient.create({
-  contract,
-  urls: ["amqp://main-cluster"], // ← Different URLs
-});
+const mainClient = (
+  await TypedAmqpClient.create({
+    contract,
+    urls: ["amqp://main-cluster"], // ← Different URLs
+  })
+)._unsafeUnwrap();
 
-const analyticsClient = await TypedAmqpClient.create({
-  contract,
-  urls: ["amqp://analytics-cluster"], // ← Different URLs
-});
+const analyticsClient = (
+  await TypedAmqpClient.create({
+    contract,
+    urls: ["amqp://analytics-cluster"], // ← Different URLs
+  })
+)._unsafeUnwrap();
 
 // Result: 2 separate connections (one per cluster)
 ```
@@ -204,34 +223,42 @@ For maximum sharing benefits, use the same `connectionOptions` across all client
 // ✅ Best: Use consistent options (or omit for defaults)
 const connectionOptions = { heartbeatIntervalInSeconds: 30 };
 
-const client = await TypedAmqpClient.create({
-  contract,
-  urls: ["amqp://localhost"],
-  connectionOptions, // ← Same options
-});
+const client = (
+  await TypedAmqpClient.create({
+    contract,
+    urls: ["amqp://localhost"],
+    connectionOptions, // ← Same options
+  })
+)._unsafeUnwrap();
 
-const worker = await TypedAmqpWorker.create({
-  contract,
-  urls: ["amqp://localhost"],
-  connectionOptions, // ← Same options = connection shared
-  handlers: {
-    /* ... */
-  },
-});
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    urls: ["amqp://localhost"],
+    connectionOptions, // ← Same options = connection shared
+    handlers: {
+      /* ... */
+    },
+  })
+)._unsafeUnwrap();
 
 // ✅ Also good: Omit options to use defaults
-const client = await TypedAmqpClient.create({
-  contract,
-  urls: ["amqp://localhost"], // ← No options
-});
+const client = (
+  await TypedAmqpClient.create({
+    contract,
+    urls: ["amqp://localhost"], // ← No options
+  })
+)._unsafeUnwrap();
 
-const worker = await TypedAmqpWorker.create({
-  contract,
-  urls: ["amqp://localhost"], // ← No options = connection shared
-  handlers: {
-    /* ... */
-  },
-});
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    urls: ["amqp://localhost"], // ← No options = connection shared
+    handlers: {
+      /* ... */
+    },
+  })
+)._unsafeUnwrap();
 ```
 
 #### 2. **Extract Shared Configuration**
@@ -249,18 +276,22 @@ const AMQP_CONFIG = {
 } as const;
 
 // All components use the same configuration
-const client = await TypedAmqpClient.create({
-  contract: orderContract,
-  ...AMQP_CONFIG,
-});
+const client = (
+  await TypedAmqpClient.create({
+    contract: orderContract,
+    ...AMQP_CONFIG,
+  })
+)._unsafeUnwrap();
 
-const worker = await TypedAmqpWorker.create({
-  contract: orderContract,
-  ...AMQP_CONFIG,
-  handlers: {
-    /* ... */
-  },
-});
+const worker = (
+  await TypedAmqpWorker.create({
+    contract: orderContract,
+    ...AMQP_CONFIG,
+    handlers: {
+      /* ... */
+    },
+  })
+)._unsafeUnwrap();
 ```
 
 #### 3. **Understand Configuration Conflicts**
@@ -269,20 +300,24 @@ Different `connectionOptions` create separate connections:
 
 ```typescript
 // ⚠️ Warning: Different options = separate connections (may be intentional)
-const client = await TypedAmqpClient.create({
-  contract,
-  urls: ["amqp://localhost"],
-  connectionOptions: { heartbeatIntervalInSeconds: 30 }, // ← Options A
-});
+const client = (
+  await TypedAmqpClient.create({
+    contract,
+    urls: ["amqp://localhost"],
+    connectionOptions: { heartbeatIntervalInSeconds: 30 }, // ← Options A
+  })
+)._unsafeUnwrap();
 
-const worker = await TypedAmqpWorker.create({
-  contract,
-  urls: ["amqp://localhost"],
-  connectionOptions: { heartbeatIntervalInSeconds: 60 }, // ← Options B (different)
-  handlers: {
-    /* ... */
-  },
-});
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    urls: ["amqp://localhost"],
+    connectionOptions: { heartbeatIntervalInSeconds: 60 }, // ← Options B (different)
+    handlers: {
+      /* ... */
+    },
+  })
+)._unsafeUnwrap();
 
 // Result: 2 separate connections (different configurations)
 // This may be intentional if you need different heartbeat settings
@@ -354,18 +389,22 @@ Connection sharing is **completely backward compatible** and happens automatical
 
 ```typescript
 // Existing code automatically benefits from connection sharing
-const client = await TypedAmqpClient.create({
-  contract,
-  urls: ["amqp://localhost"], // ← Connection automatically created
-});
+const client = (
+  await TypedAmqpClient.create({
+    contract,
+    urls: ["amqp://localhost"], // ← Connection automatically created
+  })
+)._unsafeUnwrap();
 
-const worker = await TypedAmqpWorker.create({
-  contract,
-  urls: ["amqp://localhost"], // ← Same URLs = connection automatically shared
-  handlers: {
-    /* ... */
-  },
-});
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    urls: ["amqp://localhost"], // ← Same URLs = connection automatically shared
+    handlers: {
+      /* ... */
+    },
+  })
+)._unsafeUnwrap();
 
 // No code changes needed - connection sharing just works!
 // Result: 1 connection, 2 channels (automatically managed)
@@ -381,66 +420,82 @@ Connection sharing is automatic when URLs and connection options match. If you s
 
    ```typescript
    // ❌ Different URLs = different connections
-   const client = await TypedAmqpClient.create({
-     contract,
-     urls: ["amqp://localhost:5672"],
-   });
-   const worker = await TypedAmqpWorker.create({
-     contract,
-     urls: ["amqp://localhost"], // Different URL!
-     handlers: {
-       /* ... */
-     },
-   });
+   const client = (
+     await TypedAmqpClient.create({
+       contract,
+       urls: ["amqp://localhost:5672"],
+     })
+   )._unsafeUnwrap();
+   const worker = (
+     await TypedAmqpWorker.create({
+       contract,
+       urls: ["amqp://localhost"], // Different URL!
+       handlers: {
+         /* ... */
+       },
+     })
+   )._unsafeUnwrap();
 
    // ✅ Same URLs = shared connection
    const urls = ["amqp://localhost"];
-   const client = await TypedAmqpClient.create({
-     contract,
-     urls,
-   });
-   const worker = await TypedAmqpWorker.create({
-     contract,
-     urls, // Same URL reference
-     handlers: {
-       /* ... */
-     },
-   });
+   const client = (
+     await TypedAmqpClient.create({
+       contract,
+       urls,
+     })
+   )._unsafeUnwrap();
+   const worker = (
+     await TypedAmqpWorker.create({
+       contract,
+       urls, // Same URL reference
+       handlers: {
+         /* ... */
+       },
+     })
+   )._unsafeUnwrap();
    ```
 
 2. **Check connection options match**:
 
    ```typescript
    // ❌ Different options = different connections
-   const client = await TypedAmqpClient.create({
-     contract,
-     urls: ["amqp://localhost"],
-     connectionOptions: { heartbeatIntervalInSeconds: 30 },
-   });
-   const worker = await TypedAmqpWorker.create({
-     contract,
-     urls: ["amqp://localhost"],
-     connectionOptions: { heartbeatIntervalInSeconds: 60 }, // Different!
-     handlers: {
-       /* ... */
-     },
-   });
+   const client = (
+     await TypedAmqpClient.create({
+       contract,
+       urls: ["amqp://localhost"],
+       connectionOptions: { heartbeatIntervalInSeconds: 30 },
+     })
+   )._unsafeUnwrap();
+   const worker = (
+     await TypedAmqpWorker.create({
+       contract,
+       urls: ["amqp://localhost"],
+       connectionOptions: { heartbeatIntervalInSeconds: 60 }, // Different!
+       handlers: {
+         /* ... */
+       },
+     })
+   )._unsafeUnwrap();
 
    // ✅ Same options = shared connection
    const connectionOptions = { heartbeatIntervalInSeconds: 30 };
-   const client = await TypedAmqpClient.create({
-     contract,
-     urls: ["amqp://localhost"],
-     connectionOptions,
-   });
-   const worker = await TypedAmqpWorker.create({
-     contract,
-     urls: ["amqp://localhost"],
-     connectionOptions, // Same options reference
-     handlers: {
-       /* ... */
-     },
-   });
+   const client = (
+     await TypedAmqpClient.create({
+       contract,
+       urls: ["amqp://localhost"],
+       connectionOptions,
+     })
+   )._unsafeUnwrap();
+   const worker = (
+     await TypedAmqpWorker.create({
+       contract,
+       urls: ["amqp://localhost"],
+       connectionOptions, // Same options reference
+       handlers: {
+         /* ... */
+       },
+     })
+   )._unsafeUnwrap();
    ```
 
 ### Cleanup in tests

--- a/docs/guide/connection-sharing.md
+++ b/docs/guide/connection-sharing.md
@@ -37,7 +37,7 @@ const client = await TypedAmqpClient.create({
   connectionOptions: {
     heartbeatIntervalInSeconds: 30,
   },
-}).resultToPromise();
+});
 
 // 2. Create worker - automatically reuses the same connection!
 const worker = await TypedAmqpWorker.create({
@@ -48,23 +48,23 @@ const worker = await TypedAmqpWorker.create({
       console.log("Processing order:", payload.orderId);
 
       // Can publish from within consumer
-      return Future.fromPromise(
+      return ResultAsync.fromPromise(
         client.publish("orderProcessed", {
           orderId: payload.orderId,
           status: "completed",
         }),
       )
-        .mapOk(() => {
+        .map(() => {
           console.log("Order processed event published");
           return undefined;
         })
-        .mapError((error) => {
+        .mapErr((error) => {
           console.error("Failed to publish:", error);
           return new RetryableError("Failed to publish", error);
         });
     },
   },
-}).resultToPromise();
+});
 
 // Both client and worker automatically share a single connection! ✅
 // Result: 1 connection, 2 channels

--- a/docs/guide/core-concepts.md
+++ b/docs/guide/core-concepts.md
@@ -55,10 +55,12 @@ const contract = defineContract({
 });
 
 // 5. Client knows exact types
-const client = await TypedAmqpClient.create({
-  contract,
-  urls: ["amqp://localhost"],
-});
+const client = (
+  await TypedAmqpClient.create({
+    contract,
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 
 const result = await client.publish("orderCreated", {
   orderId: "ORD-123", // ✅ TypeScript knows!
@@ -66,10 +68,10 @@ const result = await client.publish("orderCreated", {
   // invalid: true,     // ❌ TypeScript error!
 });
 
-result.match({
-  Ok: () => console.log("Published"),
-  Error: (error) => console.error("Failed:", error),
-});
+result.match(
+  () => console.log("Published"),
+  (error) => console.error("Failed:", error),
+);
 ```
 
 ## Automatic Validation
@@ -88,13 +90,13 @@ const result = await client.publish("orderCreated", {
   amount: "not-a-number", // ❌ Validation error!
 });
 
-result.match({
-  Ok: () => console.log("Published"),
-  Error: (error) => {
+result.match(
+  () => console.log("Published"),
+  (error) => {
     // Handle MessageValidationError or TechnicalError
     console.error("Failed:", error.message);
   },
-});
+);
 ```
 
 ## Schema Libraries

--- a/docs/guide/core-concepts.md
+++ b/docs/guide/core-concepts.md
@@ -58,7 +58,7 @@ const contract = defineContract({
 const client = await TypedAmqpClient.create({
   contract,
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 
 const result = await client.publish("orderCreated", {
   orderId: "ORD-123", // ✅ TypeScript knows!

--- a/docs/guide/defining-contracts.md
+++ b/docs/guide/defining-contracts.md
@@ -444,7 +444,7 @@ const handlers = defineHandlers(contract, {
       `Processing order ${message.payload.orderId} for tenant ${message.headers.tenantId}`,
     );
 
-    return Future.value(Result.Ok(undefined));
+    return okAsync(undefined);
   },
 });
 ```

--- a/docs/guide/error-model.md
+++ b/docs/guide/error-model.md
@@ -30,9 +30,10 @@ The failure is transient. The queue's [retry mode](./retry-strategies.md) decide
 import { RetryableError } from "@amqp-contract/worker";
 
 ({ payload }) =>
-  ResultAsync.fromPromise(callExternalApi(payload))
-    .map(() => undefined)
-    .mapErr((error) => new RetryableError("API unavailable", error));
+  ResultAsync.fromPromise(
+    callExternalApi(payload),
+    (error) => new RetryableError("API unavailable", error),
+  ).map(() => undefined);
 ```
 
 ### `NonRetryableError`
@@ -87,14 +88,14 @@ Any failure of the AMQP transport itself: connection lost, channel closed, broke
 import { TechnicalError } from "@amqp-contract/core";
 
 const result = await client.publish("orderCreated", { orderId: "1" }).toPromise();
-result.match({
-  Ok: () => console.log("ok"),
-  Error: (err) => {
+result.match(
+  () => console.log("ok"),
+  (err) => {
     if (err instanceof TechnicalError) {
       // err.cause holds the original amqplib / amqp-connection-manager error
     }
   },
-});
+);
 ```
 
 ### `MessageValidationError`
@@ -119,15 +120,15 @@ The client was closed (`client.close()`) while a call was still pending. All in-
 import { RpcTimeoutError, RpcCancelledError } from "@amqp-contract/client";
 
 const result = await client.call("calculate", { a: 1, b: 2 }, { timeoutMs: 5_000 }).toPromise();
-result.match({
-  Ok: (response) => /* ... */,
-  Error: (err) => {
+result.match(
+  (response) => /* ... */,
+  (err) => {
     if (err instanceof RpcTimeoutError) /* retry, or fall back */;
     if (err instanceof RpcCancelledError) /* shutting down */;
     if (err instanceof MessageValidationError) /* response shape wrong */;
     if (err instanceof TechnicalError) /* transport problem */;
   },
-});
+  );
 ```
 
 ## Why not just throw?
@@ -136,7 +137,7 @@ Two reasons:
 
 1. **Async errors that don't reject Promises silently.** A handler that throws synchronously inside a ResultAsync chain would normally crash the consume loop. Returning `err(...)` makes failure a value the worker can route deterministically (DLQ, retry, ack).
 
-2. **Type-safe error union.** `ResultAsync<T, MyError | OtherError>` lets TypeScript force you to handle every variant via `.match({ Ok, Error })`. A thrown `unknown` gives no such guarantees.
+2. **Type-safe error union.** `ResultAsync<T, MyError | OtherError>` lets TypeScript force you to handle every variant via `.match(okFn, errFn)`. A thrown `unknown` gives no such guarantees.
 
 ## Defensive guards
 

--- a/docs/guide/error-model.md
+++ b/docs/guide/error-model.md
@@ -87,7 +87,7 @@ Any failure of the AMQP transport itself: connection lost, channel closed, broke
 ```ts
 import { TechnicalError } from "@amqp-contract/core";
 
-const result = await client.publish("orderCreated", { orderId: "1" }).toPromise();
+const result = await client.publish("orderCreated", { orderId: "1" });
 result.match(
   () => console.log("ok"),
   (err) => {
@@ -119,7 +119,7 @@ The client was closed (`client.close()`) while a call was still pending. All in-
 ```ts
 import { RpcTimeoutError, RpcCancelledError } from "@amqp-contract/client";
 
-const result = await client.call("calculate", { a: 1, b: 2 }, { timeoutMs: 5_000 }).toPromise();
+const result = await client.call("calculate", { a: 1, b: 2 }, { timeoutMs: 5_000 });
 result.match(
   (response) => /* ... */,
   (err) => {

--- a/docs/guide/error-model.md
+++ b/docs/guide/error-model.md
@@ -1,6 +1,6 @@
 # Error Model
 
-amqp-contract uses [`@swan-io/boxed`](https://boxed.cool)'s `Future<Result<T, E>>` everywhere — there are no thrown exceptions in the public API, no `try/catch` to remember. Errors are values you propagate, transform, and inspect.
+amqp-contract uses [`neverthrow`](https://github.com/supermacro/neverthrow)'s `ResultAsync<T, E>` everywhere — there are no thrown exceptions in the public API, no `try/catch` to remember. Errors are values you propagate, transform, and inspect.
 
 This page lists every error type the library can produce, where it surfaces, and what you should do with it.
 
@@ -30,9 +30,9 @@ The failure is transient. The queue's [retry mode](./retry-strategies.md) decide
 import { RetryableError } from "@amqp-contract/worker";
 
 ({ payload }) =>
-  Future.fromPromise(callExternalApi(payload))
-    .mapOk(() => undefined)
-    .mapError((error) => new RetryableError("API unavailable", error));
+  ResultAsync.fromPromise(callExternalApi(payload))
+    .map(() => undefined)
+    .mapErr((error) => new RetryableError("API unavailable", error));
 ```
 
 ### `NonRetryableError`
@@ -44,7 +44,7 @@ import { NonRetryableError } from "@amqp-contract/worker";
 
 ({ payload }) => {
   if (payload.amount < 0) {
-    return Future.value(Result.Error(new NonRetryableError("Negative amount")));
+    return errAsync(new NonRetryableError("Negative amount"));
   }
   // ...
 };
@@ -103,13 +103,13 @@ A Standard Schema validation failed (incoming payload, incoming headers, or RPC 
 
 On the worker side, validation failures route directly to the DLQ via `nack(requeue=false)` — they never enter the retry pipeline because retrying a malformed payload cannot succeed. The message body is preserved exactly as the broker delivered it; the worker does not republish, so it does not stamp diagnostic headers like `x-last-error` on this path. The error details (consumer name, schema `issues`) live in the worker's logs. See [Retry Strategies → Inspecting retry state](./retry-strategies.md#inspecting-retry-state) for the full breakdown of which DLQ paths add headers.
 
-On the client side (publisher input or RPC response validation), `MessageValidationError` is returned in the `Result.Error` channel of `publish()` / `call()` so you can decide how to react before sending.
+On the client side (publisher input or RPC response validation), `MessageValidationError` is returned via `err(...)` from `publish()` / `call()` so you can decide how to react before sending.
 
 ## Client-side RPC errors
 
 ### `RpcTimeoutError`
 
-The reply did not arrive within the configured `timeoutMs` (or the server-side default). The pending call is cleared and the future resolves to `Result.Error(RpcTimeoutError)`.
+The reply did not arrive within the configured `timeoutMs` (or the server-side default). The pending call is cleared and the future resolves to `err(RpcTimeoutError)`.
 
 ### `RpcCancelledError`
 
@@ -134,13 +134,13 @@ result.match({
 
 Two reasons:
 
-1. **Async errors that don't reject Promises silently.** A handler that throws synchronously inside a Future chain would normally crash the consume loop. Returning `Result.Error` makes failure a value the worker can route deterministically (DLQ, retry, ack).
+1. **Async errors that don't reject Promises silently.** A handler that throws synchronously inside a ResultAsync chain would normally crash the consume loop. Returning `err(...)` makes failure a value the worker can route deterministically (DLQ, retry, ack).
 
-2. **Type-safe error union.** `Future<Result<T, MyError | OtherError>>` lets TypeScript force you to handle every variant via `.match({ Ok, Error })`. A thrown `unknown` gives no such guarantees.
+2. **Type-safe error union.** `ResultAsync<T, MyError | OtherError>` lets TypeScript force you to handle every variant via `.match({ Ok, Error })`. A thrown `unknown` gives no such guarantees.
 
 ## Defensive guards
 
-The worker still wraps the consume callback in `try/catch` so a buggy handler that throws synchronously cannot leave a message neither acked nor nacked: the worker logs the error and nacks with `requeue=false` (DLQ if configured). Don't rely on it — return `Future.value(Result.Error(...))` instead.
+The worker still wraps the consume callback in `try/catch` so a buggy handler that throws synchronously cannot leave a message neither acked nor nacked: the worker logs the error and nacks with `requeue=false` (DLQ if configured). Don't rely on it — return `errAsync(...)` instead.
 
 ## See also
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -184,10 +184,12 @@ async function main() {
   console.log("🚀 Starting publisher...");
 
   // Create client
-  const client = await TypedAmqpClient.create({
-    contract,
-    urls: ["amqp://localhost"],
-  });
+  const client = (
+    await TypedAmqpClient.create({
+      contract,
+      urls: ["amqp://localhost"],
+    })
+  )._unsafeUnwrap();
 
   console.log("✅ Connected to RabbitMQ");
 
@@ -198,10 +200,10 @@ async function main() {
     body: "This is a type-safe message from amqp-contract.",
   });
 
-  result.match({
-    Ok: () => console.log("📧 Email message published!"),
-    Error: (error) => console.error("❌ Failed:", error.message),
-  });
+  result.match(
+    () => console.log("📧 Email message published!"),
+    (error) => console.error("❌ Failed:", error.message),
+  );
 
   // Clean up
   await client.close();
@@ -225,27 +227,29 @@ async function main() {
   console.log("⚙️ Starting worker...");
 
   // Create worker with handlers
-  const worker = await TypedAmqpWorker.create({
-    contract,
-    handlers: {
-      processEmail: ({ payload }) => {
-        // Payload is fully typed!
-        console.log("\n📬 Received email:");
-        console.log(`  To: ${payload.to}`);
-        console.log(`  Subject: ${payload.subject}`);
-        console.log(`  Body: ${payload.body}`);
+  const worker = (
+    await TypedAmqpWorker.create({
+      contract,
+      handlers: {
+        processEmail: ({ payload }) => {
+          // Payload is fully typed!
+          console.log("\n📬 Received email:");
+          console.log(`  To: ${payload.to}`);
+          console.log(`  Subject: ${payload.subject}`);
+          console.log(`  Body: ${payload.body}`);
 
-        // Simulate sending email
-        return ResultAsync.fromPromise(new Promise((resolve) => setTimeout(resolve, 1000))).map(
-          () => {
-            console.log("✅ Email sent successfully!");
-            return undefined;
-          },
-        );
+          // Simulate sending email
+          return ResultAsync.fromPromise(new Promise((resolve) => setTimeout(resolve, 1000))).map(
+            () => {
+              console.log("✅ Email sent successfully!");
+              return undefined;
+            },
+          );
+        },
       },
-    },
-    urls: ["amqp://localhost"],
-  });
+      urls: ["amqp://localhost"],
+    })
+  )._unsafeUnwrap();
 
   console.log("✅ Worker ready, waiting for messages...\n");
   console.log("Press Ctrl+C to stop\n");

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -187,7 +187,7 @@ async function main() {
   const client = await TypedAmqpClient.create({
     contract,
     urls: ["amqp://localhost"],
-  }).resultToPromise();
+  });
 
   console.log("✅ Connected to RabbitMQ");
 
@@ -218,7 +218,7 @@ Create `consumer.ts` - processes messages:
 ```typescript
 // consumer.ts
 import { TypedAmqpWorker } from "@amqp-contract/worker";
-import { Future, Result } from "@swan-io/boxed";
+import { ResultAsync, Result } from "neverthrow";
 import { contract } from "./contract.js";
 
 async function main() {
@@ -236,14 +236,16 @@ async function main() {
         console.log(`  Body: ${payload.body}`);
 
         // Simulate sending email
-        return Future.fromPromise(new Promise((resolve) => setTimeout(resolve, 1000))).mapOk(() => {
-          console.log("✅ Email sent successfully!");
-          return undefined;
-        });
+        return ResultAsync.fromPromise(new Promise((resolve) => setTimeout(resolve, 1000))).map(
+          () => {
+            console.log("✅ Email sent successfully!");
+            return undefined;
+          },
+        );
       },
     },
     urls: ["amqp://localhost"],
-  }).resultToPromise();
+  });
 
   console.log("✅ Worker ready, waiting for messages...\n");
   console.log("Press Ctrl+C to stop\n");

--- a/docs/guide/logging.md
+++ b/docs/guide/logging.md
@@ -32,11 +32,13 @@ Pass a `logger` to `TypedAmqpClient.create()`:
 ```typescript
 import { TypedAmqpClient } from "@amqp-contract/client";
 
-const client = await TypedAmqpClient.create({
-  contract,
-  urls: ["amqp://localhost"],
-  logger, // [!code highlight]
-});
+const client = (
+  await TypedAmqpClient.create({
+    contract,
+    urls: ["amqp://localhost"],
+    logger, // [!code highlight]
+  })
+)._unsafeUnwrap();
 ```
 
 ## Usage with Worker
@@ -46,12 +48,14 @@ Pass a `logger` to `TypedAmqpWorker.create()`:
 ```typescript
 import { TypedAmqpWorker } from "@amqp-contract/worker";
 
-const worker = await TypedAmqpWorker.create({
-  contract,
-  urls: ["amqp://localhost"],
-  handlers,
-  logger, // [!code highlight]
-});
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    urls: ["amqp://localhost"],
+    handlers,
+    logger, // [!code highlight]
+  })
+)._unsafeUnwrap();
 ```
 
 ## What Gets Logged

--- a/docs/guide/message-compression.md
+++ b/docs/guide/message-compression.md
@@ -39,10 +39,10 @@ Compression is specified in the publish options:
 import { TypedAmqpClient } from "@amqp-contract/client";
 import { contract } from "./contract";
 
-const client = await TypedAmqpClient.create({
+const client = (await TypedAmqpClient.create({
   contract,
   urls: ["amqp://localhost"],
-});
+}))._unsafeUnwrap();
 
 // Publish with gzip compression
 await client
@@ -56,7 +56,6 @@ await client
       compression: "gzip",
     },
   )
-  ;
 
 // Publish with deflate compression
 await client
@@ -70,7 +69,6 @@ await client
       compression: "deflate",
     },
   )
-  ;
 
 // Publish without compression
 await client
@@ -78,7 +76,6 @@ await client
     orderId: "ORD-125",
     items: [],
   })
-  ;
 ```
 
 ### Consuming Compressed Messages
@@ -89,18 +86,20 @@ await client
 import { TypedAmqpWorker } from "@amqp-contract/worker";
 import { contract } from "./contract";
 
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: ({ payload }) => {
-      // Message is automatically decompressed
-      console.log("Processing order:", payload.orderId);
-      console.log("Items:", payload.items); // Already decompressed
-      return okAsync(undefined);
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: ({ payload }) => {
+        // Message is automatically decompressed
+        console.log("Processing order:", payload.orderId);
+        console.log("Items:", payload.items); // Already decompressed
+        return okAsync(undefined);
+      },
     },
-  },
-  urls: ["amqp://localhost"],
-});
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 ```
 
 The worker automatically:

--- a/docs/guide/message-compression.md
+++ b/docs/guide/message-compression.md
@@ -42,7 +42,7 @@ import { contract } from "./contract";
 const client = await TypedAmqpClient.create({
   contract,
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 
 // Publish with gzip compression
 await client
@@ -56,7 +56,7 @@ await client
       compression: "gzip",
     },
   )
-  .resultToPromise();
+  ;
 
 // Publish with deflate compression
 await client
@@ -70,7 +70,7 @@ await client
       compression: "deflate",
     },
   )
-  .resultToPromise();
+  ;
 
 // Publish without compression
 await client
@@ -78,7 +78,7 @@ await client
     orderId: "ORD-125",
     items: [],
   })
-  .resultToPromise();
+  ;
 ```
 
 ### Consuming Compressed Messages
@@ -96,11 +96,11 @@ const worker = await TypedAmqpWorker.create({
       // Message is automatically decompressed
       console.log("Processing order:", payload.orderId);
       console.log("Items:", payload.items); // Already decompressed
-      return Future.value(Result.Ok(undefined));
+      return okAsync(undefined);
     },
   },
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 ```
 
 The worker automatically:
@@ -124,11 +124,9 @@ class OrderPublisher {
     // Compress if message is larger than 1KB
     const shouldCompress = messageSize > 1024;
 
-    await this.client
-      .publish("orderCreated", order, {
-        compression: shouldCompress ? "gzip" : undefined,
-      })
-      .resultToPromise();
+    await this.client.publish("orderCreated", order, {
+      compression: shouldCompress ? "gzip" : undefined,
+    });
   }
 }
 ```
@@ -183,11 +181,9 @@ client.publish("event", data, { compression: "deflate" });
 Compression errors are returned in the Result type:
 
 ```typescript
-await client
-  .publish("event", data, {
-    compression: "gzip",
-  })
-  .resultToPromise();
+await client.publish("event", data, {
+  compression: "gzip",
+});
 ```
 
 ### Decompression Errors
@@ -233,11 +229,9 @@ function shouldCompress(message: unknown): boolean {
   return JSON.stringify(message).length > SIZE_THRESHOLD;
 }
 
-await client
-  .publish("event", data, {
-    compression: shouldCompress(data) ? "gzip" : undefined,
-  })
-  .resultToPromise();
+await client.publish("event", data, {
+  compression: shouldCompress(data) ? "gzip" : undefined,
+});
 ```
 
 ### 3. Monitor Performance
@@ -248,11 +242,9 @@ Track compression ratios and performance:
 const startTime = Date.now();
 const originalSize = JSON.stringify(data).length;
 
-await client
-  .publish("event", data, {
-    compression: "gzip",
-  })
-  .resultToPromise();
+await client.publish("event", data, {
+  compression: "gzip",
+});
 
 const duration = Date.now() - startTime;
 console.log("Published in", duration, "ms");

--- a/docs/guide/opentelemetry-observability.md
+++ b/docs/guide/opentelemetry-observability.md
@@ -155,19 +155,23 @@ const customTelemetryProvider: TelemetryProvider = {
 };
 
 // Use in client
-const client = await TypedAmqpClient.create({
-  contract,
-  connection,
-  telemetry: customTelemetryProvider,
-});
+const client = (
+  await TypedAmqpClient.create({
+    contract,
+    connection,
+    telemetry: customTelemetryProvider,
+  })
+)._unsafeUnwrap();
 
 // Use in worker
-const worker = await TypedAmqpWorker.create({
-  contract,
-  connection,
-  handlers,
-  telemetry: customTelemetryProvider,
-});
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    connection,
+    handlers,
+    telemetry: customTelemetryProvider,
+  })
+)._unsafeUnwrap();
 ```
 
 ## Best Practices
@@ -200,9 +204,9 @@ const processOrder = ({ payload }) => {
   span?.setAttribute("order.id", payload.orderId);
   span?.setAttribute("order.amount", payload.amount);
 
-  return ResultAsync.fromPromise(process(payload))
-    .map(() => undefined)
-    .mapErr((e) => new RetryableError("Failed", e));
+  return ResultAsync.fromPromise(process(payload), (e) => new RetryableError("Failed", e)).map(
+    () => undefined,
+  );
 };
 ```
 

--- a/docs/guide/opentelemetry-observability.md
+++ b/docs/guide/opentelemetry-observability.md
@@ -200,9 +200,9 @@ const processOrder = ({ payload }) => {
   span?.setAttribute("order.id", payload.orderId);
   span?.setAttribute("order.amount", payload.amount);
 
-  return Future.fromPromise(process(payload))
-    .mapOk(() => undefined)
-    .mapError((e) => new RetryableError("Failed", e));
+  return ResultAsync.fromPromise(process(payload))
+    .map(() => undefined)
+    .mapErr((e) => new RetryableError("Failed", e));
 };
 ```
 

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -82,8 +82,8 @@ amqp-contract automatically shares connections across clients and workers with t
 
 ```typescript
 // These share the same underlying connection
-const client = await TypedAmqpClient.create({ contract, urls });
-const worker = await TypedAmqpWorker.create({ contract, handlers, urls });
+const client = (await TypedAmqpClient.create({ contract, urls }))._unsafeUnwrap();
+const worker = (await TypedAmqpWorker.create({ contract, handlers, urls }))._unsafeUnwrap();
 ```
 
 ### Connection Pool Sizing
@@ -92,27 +92,31 @@ For high-throughput scenarios, you may want separate connections:
 
 ```typescript
 // Separate connection for publishing
-const client = await TypedAmqpClient.create({
-  contract,
-  urls,
-  connectionOptions: {
+const client = (
+  await TypedAmqpClient.create({
+    contract,
+    urls,
     connectionOptions: {
-      clientProperties: { connection_name: "publisher" },
+      connectionOptions: {
+        clientProperties: { connection_name: "publisher" },
+      },
     },
-  },
-});
+  })
+)._unsafeUnwrap();
 
 // Separate connection for consuming
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers,
-  urls,
-  connectionOptions: {
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers,
+    urls,
     connectionOptions: {
-      clientProperties: { connection_name: "consumer" },
+      connectionOptions: {
+        clientProperties: { connection_name: "consumer" },
+      },
     },
-  },
-});
+  })
+)._unsafeUnwrap();
 ```
 
 ### Heartbeat Configuration
@@ -120,13 +124,15 @@ const worker = await TypedAmqpWorker.create({
 Heartbeats detect dead connections but add overhead:
 
 ```typescript
-const client = await TypedAmqpClient.create({
-  contract,
-  urls,
-  connectionOptions: {
-    heartbeatIntervalInSeconds: 60, // Default: 0 (disabled)
-  },
-});
+const client = (
+  await TypedAmqpClient.create({
+    contract,
+    urls,
+    connectionOptions: {
+      heartbeatIntervalInSeconds: 60, // Default: 0 (disabled)
+    },
+  })
+)._unsafeUnwrap();
 ```
 
 **Recommendations:**

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -155,8 +155,8 @@ Publisher confirms ensure messages reach RabbitMQ:
 
 ```typescript
 // amqp-contract uses confirms by default
-// Each publish returns a Future that resolves when confirmed
-const result = await client.publish("orderCreated", payload).resultToPromise();
+// Each publish returns a ResultAsync that resolves when confirmed
+const result = await client.publish("orderCreated", payload);
 ```
 
 For maximum throughput without confirms (not recommended for critical messages):

--- a/docs/guide/retry-strategies.md
+++ b/docs/guide/retry-strategies.md
@@ -95,16 +95,14 @@ import { defineHandler, RetryableError, NonRetryableError } from "@amqp-contract
 import { ResultAsync, Result } from "neverthrow";
 
 const processOrder = defineHandler(contract, "processOrder", ({ payload }) =>
-  ResultAsync.fromPromise(callPaymentApi(payload))
-    .map(() => undefined)
-    .mapErr((error) => {
-      // 4xx from a payment provider: retrying won't help.
-      if (error instanceof PaymentValidationError) {
-        return new NonRetryableError("Invalid payment details", error);
-      }
-      // 5xx, timeout, network blip: try again.
-      return new RetryableError("Payment provider unavailable", error);
-    }),
+  ResultAsync.fromPromise(callPaymentApi(payload), (error) => {
+    // 4xx from a payment provider: retrying won't help.
+    if (error instanceof PaymentValidationError) {
+      return new NonRetryableError("Invalid payment details", error);
+    }
+    // 5xx, timeout, network blip: try again.
+    return new RetryableError("Payment provider unavailable", error);
+  }).map(() => undefined),
 );
 ```
 

--- a/docs/guide/retry-strategies.md
+++ b/docs/guide/retry-strategies.md
@@ -8,9 +8,9 @@ This page explains both, and how they compose.
 
 When a worker processes a message, three things can happen:
 
-1. The handler returns `Result.Ok(undefined)` — the message is **acked** and gone.
-2. The handler returns `Result.Error(NonRetryableError)` — the message is sent **straight to the DLQ**, no retries (the queue's retry mode is bypassed).
-3. The handler returns `Result.Error(RetryableError)` — the **queue's retry mode** decides what happens next.
+1. The handler returns `ok(undefined)` — the message is **acked** and gone.
+2. The handler returns `err(NonRetryableError)` — the message is sent **straight to the DLQ**, no retries (the queue's retry mode is bypassed).
+3. The handler returns `err(RetryableError)` — the **queue's retry mode** decides what happens next.
 
 So `RetryableError` is the only path that consults the retry mode. `NonRetryableError` is your way of saying "this will never succeed, don't bother."
 
@@ -92,12 +92,12 @@ Inside a handler, you decide whether a failure is retryable:
 
 ```ts
 import { defineHandler, RetryableError, NonRetryableError } from "@amqp-contract/worker";
-import { Future, Result } from "@swan-io/boxed";
+import { ResultAsync, Result } from "neverthrow";
 
 const processOrder = defineHandler(contract, "processOrder", ({ payload }) =>
-  Future.fromPromise(callPaymentApi(payload))
-    .mapOk(() => undefined)
-    .mapError((error) => {
+  ResultAsync.fromPromise(callPaymentApi(payload))
+    .map(() => undefined)
+    .mapErr((error) => {
       // 4xx from a payment provider: retrying won't help.
       if (error instanceof PaymentValidationError) {
         return new NonRetryableError("Invalid payment details", error);
@@ -137,6 +137,6 @@ If you need the failure context to be visible on poison messages too, prefer a q
 ## Pitfalls
 
 - **No DLX configured.** `nack(requeue=false)` will drop the message. The worker logs a warning, but you'll lose the body. Always set `deadLetter` if you care about poison messages.
-- **Throwing instead of returning.** A handler that throws an exception bypasses the Future/Result framework. The worker has a defensive try/catch that nacks to DLQ, but you've lost the chance to classify the error. Always return `Future.value(Result.Error(...))`.
+- **Throwing instead of returning.** A handler that throws an exception bypasses the ResultAsync/Result framework. The worker has a defensive try/catch that nacks to DLQ, but you've lost the chance to classify the error. Always return `errAsync(...)`.
 - **Mixing modes per handler.** Retry is a property of the queue, not the handler. If you want different policies for different work, give them different queues.
 - **Tuning `maxRetries` without DLQ inspection.** Pick a number that makes sense for your latency budget; the right answer almost always lives in the DLQ telemetry, not in your head.

--- a/docs/guide/schema-libraries.md
+++ b/docs/guide/schema-libraries.md
@@ -341,7 +341,7 @@ const handler: WorkerInferConsumerHandler<typeof contract, "processOrder"> = ({ 
   // payload is fully typed based on your schema
   console.log(payload.orderId); // string
   console.log(payload.amount); // number
-  return Future.value(Result.Ok(undefined));
+  return okAsync(undefined);
 };
 ```
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -111,7 +111,7 @@ import { describe, expect } from "vitest";
 import { it } from "@amqp-contract/testing/extension";
 import { TypedAmqpClient } from "@amqp-contract/client";
 import { TypedAmqpWorker } from "@amqp-contract/worker";
-import { ResultAsync, Result } from "neverthrow";
+import { okAsync, ResultAsync, Result } from "neverthrow";
 import { contract } from "./contract.js";
 
 describe("Order Processing Contract", () => {
@@ -120,23 +120,27 @@ describe("Order Processing Contract", () => {
     amqpConnectionUrl,
   }) => {
     // Create client
-    const client = await TypedAmqpClient.create({
-      contract,
-      urls: [amqpConnectionUrl],
-    });
+    const client = (
+      await TypedAmqpClient.create({
+        contract,
+        urls: [amqpConnectionUrl],
+      })
+    )._unsafeUnwrap();
 
     // Create worker with handler
     const receivedPayloads: unknown[] = [];
-    const worker = await TypedAmqpWorker.create({
-      contract,
-      handlers: {
-        processOrder: ({ payload }) => {
-          receivedPayloads.push(payload);
-          return okAsync(undefined);
+    const worker = (
+      await TypedAmqpWorker.create({
+        contract,
+        handlers: {
+          processOrder: ({ payload }) => {
+            receivedPayloads.push(payload);
+            return okAsync(undefined);
+          },
         },
-      },
-      urls: [amqpConnectionUrl],
-    });
+        urls: [amqpConnectionUrl],
+      })
+    )._unsafeUnwrap();
 
     // Publish message
     const result = await client.publish("orderCreated", {

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -111,7 +111,7 @@ import { describe, expect } from "vitest";
 import { it } from "@amqp-contract/testing/extension";
 import { TypedAmqpClient } from "@amqp-contract/client";
 import { TypedAmqpWorker } from "@amqp-contract/worker";
-import { Future, Result } from "@swan-io/boxed";
+import { ResultAsync, Result } from "neverthrow";
 import { contract } from "./contract.js";
 
 describe("Order Processing Contract", () => {
@@ -123,7 +123,7 @@ describe("Order Processing Contract", () => {
     const client = await TypedAmqpClient.create({
       contract,
       urls: [amqpConnectionUrl],
-    }).resultToPromise();
+    });
 
     // Create worker with handler
     const receivedPayloads: unknown[] = [];
@@ -132,21 +132,18 @@ describe("Order Processing Contract", () => {
       handlers: {
         processOrder: ({ payload }) => {
           receivedPayloads.push(payload);
-          return Future.value(Result.Ok(undefined));
+          return okAsync(undefined);
         },
       },
       urls: [amqpConnectionUrl],
-    }).resultToPromise();
+    });
 
     // Publish message
-    const result = await client
-      .publish("orderCreated", {
-        orderId: "123",
-        customerId: "456",
-        amount: 99.99,
-      })
-      .resultToPromise();
-
+    const result = await client.publish("orderCreated", {
+      orderId: "123",
+      customerId: "456",
+      amount: 99.99,
+    });
     expect(result.isOk()).toBe(true);
 
     // Wait for message to be processed

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -129,13 +129,13 @@ Error: Connection closed: 320 (CONNECTION-FORCED)
    ```typescript
    const result = await client.publish("sendEmail", message);
 
-   result.match({
-     Ok: () => console.log("Published"),
-     Error: (error) => {
+   result.match(
+     () => console.log("Published"),
+     (error) => {
        console.error("Failed:", error);
        // Don't ignore errors!
      },
-   });
+   );
    ```
 
 4. **Graceful shutdown:**
@@ -405,19 +405,23 @@ const orderMessage = defineMessage(
    ```typescript
    // ❌ Creating new connection for each operation
    async function publishMessage() {
-     const client = await TypedAmqpClient.create({
-       contract,
-       urls: ["amqp://localhost"],
-     });
+     const client = (
+       await TypedAmqpClient.create({
+         contract,
+         urls: ["amqp://localhost"],
+       })
+     )._unsafeUnwrap();
      await client.publish("sendEmail", message);
      await client.close();
    }
 
    // ✅ Reuse connection
-   const client = await TypedAmqpClient.create({
-     contract,
-     urls: ["amqp://localhost"],
-   });
+   const client = (
+     await TypedAmqpClient.create({
+       contract,
+       urls: ["amqp://localhost"],
+     })
+   )._unsafeUnwrap();
 
    async function publishMessage() {
      await client.publish("sendEmail", message);
@@ -465,7 +469,7 @@ const orderMessage = defineMessage(
    }
 
    // ✅ Use prefetch to control concurrency
-   const worker = await TypedAmqpWorker.create({
+   const worker = (await TypedAmqpWorker.create({
      contract,
      handlers: {
        processOrder: [
@@ -473,7 +477,7 @@ const orderMessage = defineMessage(
          { prefetch: 10 }, // Process up to 10 messages concurrently
        ],
      },
-   });
+   }))._unsafeUnwrap();
    ```
 
 2. **Heavy computation in handlers:**
@@ -483,9 +487,8 @@ const orderMessage = defineMessage(
    handlers: {
      processImage: ({ payload }) => {
        // Queue heavy work to worker pool
-       return ResultAsync.fromPromise(jobQueue.add("process-image", payload))
-         .map(() => undefined)
-         .mapErr((error) => new RetryableError("Failed to queue job", error));
+       return ResultAsync.fromPromise(jobQueue.add("process-image", payload), (error) => new RetryableError("Failed to queue job", error))
+         .map(() => undefined);
      },
    }
    ```
@@ -535,15 +538,17 @@ Error: Connection timeout
 1. **Increase timeout:**
 
    ```typescript
-   const client = await TypedAmqpClient.create({
-     contract,
-     urls: ["amqp://localhost"],
-     connectionOptions: {
+   const client = (
+     await TypedAmqpClient.create({
+       contract,
+       urls: ["amqp://localhost"],
        connectionOptions: {
-         timeout: 10000, // 10 seconds
+         connectionOptions: {
+           timeout: 10000, // 10 seconds
+         },
        },
-     },
-   });
+     })
+   )._unsafeUnwrap();
    ```
 
 2. **Use connection pooling:**
@@ -587,10 +592,12 @@ Error: Queue 'order-processing' not found
 3. **Let amqp-contract create resources:**
    ```typescript
    // Resources are automatically created when client/worker starts
-   const client = await TypedAmqpClient.create({
-     contract,
-     urls: ["amqp://localhost"],
-   });
+   const client = (
+     await TypedAmqpClient.create({
+       contract,
+       urls: ["amqp://localhost"],
+     })
+   )._unsafeUnwrap();
    ```
 
 ### Messages not routing

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -219,7 +219,7 @@ Property 'orderId' does not exist on type 'never'.
    handlers: {
      processEmail: ({ payload }) => {
        console.log(payload.to);  // Type-safe!
-       return Future.value(Result.Ok(undefined));
+       return okAsync(undefined);
      },
    }
    ```
@@ -408,7 +408,7 @@ const orderMessage = defineMessage(
      const client = await TypedAmqpClient.create({
        contract,
        urls: ["amqp://localhost"],
-     }).resultToPromise();
+     });
      await client.publish("sendEmail", message);
      await client.close();
    }
@@ -417,7 +417,7 @@ const orderMessage = defineMessage(
    const client = await TypedAmqpClient.create({
      contract,
      urls: ["amqp://localhost"],
-   }).resultToPromise();
+   });
 
    async function publishMessage() {
      await client.publish("sendEmail", message);
@@ -457,10 +457,10 @@ const orderMessage = defineMessage(
    // ❌ Blocking operation
    handlers: {
      processOrder: ({ payload }) => {
-       return Future.fromPromise(fetch("http://slow-api.com/process"))  // Slow!
-         .flatMapOk((result) => Future.fromPromise(processResult(result)))
-         .mapOk(() => undefined)
-         .mapError((error) => new RetryableError("Processing failed", error));
+       return ResultAsync.fromPromise(fetch("http://slow-api.com/process"))  // Slow!
+         .andThen((result) => ResultAsync.fromPromise(processResult(result)))
+         .map(() => undefined)
+         .mapErr((error) => new RetryableError("Processing failed", error));
      },
    }
 
@@ -473,7 +473,7 @@ const orderMessage = defineMessage(
          { prefetch: 10 }, // Process up to 10 messages concurrently
        ],
      },
-   }).resultToPromise();
+   });
    ```
 
 2. **Heavy computation in handlers:**
@@ -483,9 +483,9 @@ const orderMessage = defineMessage(
    handlers: {
      processImage: ({ payload }) => {
        // Queue heavy work to worker pool
-       return Future.fromPromise(jobQueue.add("process-image", payload))
-         .mapOk(() => undefined)
-         .mapError((error) => new RetryableError("Failed to queue job", error));
+       return ResultAsync.fromPromise(jobQueue.add("process-image", payload))
+         .map(() => undefined)
+         .mapErr((error) => new RetryableError("Failed to queue job", error));
      },
    }
    ```
@@ -497,15 +497,15 @@ const orderMessage = defineMessage(
    handlers: {
      processOrder: ({ payload }) => {
        // Inefficient - multiple sequential queries
-       return Future.fromPromise(
+       return ResultAsync.fromPromise(
          (async () => {
            for (const item of payload.items) {
              await db.query("SELECT * FROM products WHERE id = ?", [item.id]);
            }
          })()
        )
-         .mapOk(() => undefined)
-         .mapError((error) => new RetryableError("Query failed", error));
+         .map(() => undefined)
+         .mapErr((error) => new RetryableError("Query failed", error));
      },
    }
 
@@ -513,9 +513,9 @@ const orderMessage = defineMessage(
    handlers: {
      processOrder: ({ payload }) => {
        const ids = payload.items.map(item => item.id);
-       return Future.fromPromise(db.query("SELECT * FROM products WHERE id IN (?)", [ids]))
-         .mapOk(() => undefined)
-         .mapError((error) => new RetryableError("Query failed", error));
+       return ResultAsync.fromPromise(db.query("SELECT * FROM products WHERE id IN (?)", [ids]))
+         .map(() => undefined)
+         .mapErr((error) => new RetryableError("Query failed", error));
      },
    }
    ```
@@ -543,7 +543,7 @@ Error: Connection timeout
          timeout: 10000, // 10 seconds
        },
      },
-   }).resultToPromise();
+   });
    ```
 
 2. **Use connection pooling:**
@@ -590,7 +590,7 @@ Error: Queue 'order-processing' not found
    const client = await TypedAmqpClient.create({
      contract,
      urls: ["amqp://localhost"],
-   }).resultToPromise();
+   });
    ```
 
 ### Messages not routing

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -214,7 +214,10 @@ Property 'orderId' does not exist on type 'never'.
    ```
 
 3. **Check consumer handler types:**
+
    ```typescript
+   import { okAsync } from "neverthrow";
+
    // ✅ Payload is automatically typed
    handlers: {
      processEmail: ({ payload }) => {

--- a/docs/guide/why-amqp-contract.md
+++ b/docs/guide/why-amqp-contract.md
@@ -145,10 +145,12 @@ const contract = defineContract({
 });
 
 // 4. Publisher gets full type safety
-const client = await TypedAmqpClient.create({
-  contract,
-  urls: ["amqp://localhost"],
-});
+const client = (
+  await TypedAmqpClient.create({
+    contract,
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 
 await client.publish("orderCreated", {
   orderId: "ORD-123", // ✅ TypeScript knows these fields!
@@ -157,18 +159,20 @@ await client.publish("orderCreated", {
 });
 
 // 5. Consumer gets fully typed payloads
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: ({ payload }) => {
-      console.log(payload.orderId); // ✅ Fully typed!
-      console.log(payload.customerId); // ✅ Autocomplete!
-      console.log(payload.amount); // ✅ Type safe!
-      return okAsync(undefined);
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: ({ payload }) => {
+        console.log(payload.orderId); // ✅ Fully typed!
+        console.log(payload.customerId); // ✅ Autocomplete!
+        console.log(payload.amount); // ✅ Type safe!
+        return okAsync(undefined);
+      },
     },
-  },
-  urls: ["amqp://localhost"],
-});
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 ```
 
 ### 2. Automatic Validation
@@ -183,10 +187,10 @@ const result = await client.publish("orderCreated", {
   amount: -10, // ❌ Validation error: amount must be positive
 });
 
-result.match({
-  Ok: () => console.log("Published"),
-  Error: (error) => console.error("Validation failed:", error),
-});
+result.match(
+  () => console.log("Published"),
+  (error) => console.error("Validation failed:", error),
+);
 ```
 
 ### 3. Compile-Time Checks

--- a/docs/guide/why-amqp-contract.md
+++ b/docs/guide/why-amqp-contract.md
@@ -148,15 +148,13 @@ const contract = defineContract({
 const client = await TypedAmqpClient.create({
   contract,
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 
-await client
-  .publish("orderCreated", {
-    orderId: "ORD-123", // ✅ TypeScript knows these fields!
-    customerId: "CUST-456", // ✅ Autocomplete works!
-    amount: 99.99, // ✅ Type checked at compile time!
-  })
-  .resultToPromise();
+await client.publish("orderCreated", {
+  orderId: "ORD-123", // ✅ TypeScript knows these fields!
+  customerId: "CUST-456", // ✅ Autocomplete works!
+  amount: 99.99, // ✅ Type checked at compile time!
+});
 
 // 5. Consumer gets fully typed payloads
 const worker = await TypedAmqpWorker.create({
@@ -166,11 +164,11 @@ const worker = await TypedAmqpWorker.create({
       console.log(payload.orderId); // ✅ Fully typed!
       console.log(payload.customerId); // ✅ Autocomplete!
       console.log(payload.amount); // ✅ Type safe!
-      return Future.value(Result.Ok(undefined));
+      return okAsync(undefined);
     },
   },
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 ```
 
 ### 2. Automatic Validation
@@ -197,21 +195,17 @@ TypeScript catches errors before runtime:
 
 ```typescript
 // ❌ TypeScript error at compile time
-await client
-  .publish("orderCreated", {
-    orderId: "ORD-123",
-    // Missing customerId and amount - TypeScript error!
-  })
-  .resultToPromise();
+await client.publish("orderCreated", {
+  orderId: "ORD-123",
+  // Missing customerId and amount - TypeScript error!
+});
 
 // ❌ TypeScript error for wrong types
-await client
-  .publish("orderCreated", {
-    orderId: 123, // Error: orderId must be string
-    customerId: "CUST-456",
-    amount: 99.99,
-  })
-  .resultToPromise();
+await client.publish("orderCreated", {
+  orderId: 123, // Error: orderId must be string
+  customerId: "CUST-456",
+  amount: 99.99,
+});
 ```
 
 ### 4. Single Source of Truth

--- a/docs/guide/worker-usage.md
+++ b/docs/guide/worker-usage.md
@@ -13,20 +13,23 @@ import {
   RetryableError,
   NonRetryableError,
 } from "@amqp-contract/worker";
-import { ResultAsync, Result } from "neverthrow";
+import { okAsync, ResultAsync, Result } from "neverthrow";
 import { contract } from "./contract";
 
 const processOrder = defineHandler(contract, "processOrder", ({ payload }) =>
-  ResultAsync.fromPromise(saveOrder(payload))
-    .map(() => undefined)
-    .mapErr((error) => new RetryableError("Database unavailable", error)),
+  ResultAsync.fromPromise(
+    saveOrder(payload),
+    (error) => new RetryableError("Database unavailable", error),
+  ).map(() => undefined),
 );
 
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: { processOrder },
-  urls: ["amqp://localhost"],
-});
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: { processOrder },
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 
 console.log("✅ Worker ready!");
 ```
@@ -41,23 +44,25 @@ For one-file demos, you can inline the handler. The signature and types are iden
 
 ```typescript
 import { TypedAmqpWorker } from "@amqp-contract/worker";
-import { ResultAsync, Result } from "neverthrow";
+import { okAsync, ResultAsync, Result } from "neverthrow";
 import { contract } from "./contract";
 
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: ({ payload }) => {
-      console.log("Processing:", payload.orderId);
-      return okAsync(undefined);
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: ({ payload }) => {
+        console.log("Processing:", payload.orderId);
+        return okAsync(undefined);
+      },
+      notifyOrder: ({ payload }) => {
+        console.log("Notifying:", payload.orderId);
+        return okAsync(undefined);
+      },
     },
-    notifyOrder: ({ payload }) => {
-      console.log("Notifying:", payload.orderId);
-      return okAsync(undefined);
-    },
-  },
-  urls: ["amqp://localhost"],
-});
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 ```
 
 In production code, prefer `defineHandler` so handler logic lives in its own module and can be unit-tested.
@@ -67,25 +72,27 @@ In production code, prefer `defineHandler` so handler logic lives in its own mod
 Handlers receive validated, fully-typed messages with `{ payload, headers }`:
 
 ```typescript
-import { ResultAsync, Result } from "neverthrow";
+import { okAsync, ResultAsync, Result } from "neverthrow";
 
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: ({ payload }) => {
-      // Payload is fully typed!
-      console.log(payload.orderId); // ✅ string
-      console.log(payload.amount); // ✅ number
-      console.log(payload.items); // ✅ array
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: ({ payload }) => {
+        // Payload is fully typed!
+        console.log(payload.orderId); // ✅ string
+        console.log(payload.amount); // ✅ number
+        console.log(payload.items); // ✅ array
 
-      for (const item of payload.items) {
-        console.log(`${item.productId}: ${item.quantity}`);
-      }
-      return okAsync(undefined);
+        for (const item of payload.items) {
+          console.log(`${item.productId}: ${item.quantity}`);
+        }
+        return okAsync(undefined);
+      },
     },
-  },
-  connection,
-});
+    connection,
+  })
+)._unsafeUnwrap();
 ```
 
 ### Type Safety
@@ -98,24 +105,24 @@ The worker enforces:
 
 ```typescript
 // ❌ TypeScript error: missing handler
-const workerResult = await TypedAmqpWorker.create({
+const workerResult = (await TypedAmqpWorker.create({
   contract,
   handlers: {
     notifyOrder: ({ payload }) => { ... },
     // Missing processOrder handler!
   },
   urls: ['amqp://localhost'],
-});
+}))._unsafeUnwrap();
 
 // ✅ All handlers present
-const worker = await TypedAmqpWorker.create({
+const worker = (await TypedAmqpWorker.create({
   contract,
   handlers: {
     processOrder: ({ payload }) => { ... },
     notifyOrder: ({ payload }) => { ... },
   },
   urls: ['amqp://localhost'],
-});
+}))._unsafeUnwrap();
 
 console.log('✅ All handlers present');
 ```
@@ -130,13 +137,14 @@ Safe handlers return `ResultAsync<void, HandlerError>` for explicit error handli
 
 ```typescript
 import { defineHandler, RetryableError, NonRetryableError } from "@amqp-contract/worker";
-import { ResultAsync, Result } from "neverthrow";
+import { okAsync, ResultAsync, Result } from "neverthrow";
 import { contract } from "./contract";
 
 const processOrderHandler = defineHandler(contract, "processOrder", ({ payload }) =>
-  ResultAsync.fromPromise(saveToDatabase(payload))
-    .map(() => undefined)
-    .mapErr((error) => new RetryableError("Database error", error)),
+  ResultAsync.fromPromise(
+    saveToDatabase(payload),
+    (error) => new RetryableError("Database error", error),
+  ).map(() => undefined),
 );
 
 // Non-retryable errors go directly to DLQ
@@ -152,26 +160,30 @@ const validateOrderHandler = defineHandler(contract, "validateOrder", ({ payload
 
 ```typescript
 import { defineHandlers, RetryableError } from "@amqp-contract/worker";
-import { ResultAsync, Result } from "neverthrow";
+import { okAsync, ResultAsync, Result } from "neverthrow";
 import { contract } from "./contract";
 
 // Safe handlers (recommended) - for async operations use ResultAsync.fromPromise
 const handlers = defineHandlers(contract, {
   processOrder: ({ payload }) =>
-    ResultAsync.fromPromise(processPayment(payload))
-      .map(() => undefined)
-      .mapErr((error) => new RetryableError("Payment failed", error)),
+    ResultAsync.fromPromise(
+      processPayment(payload),
+      (error) => new RetryableError("Payment failed", error),
+    ).map(() => undefined),
   notifyOrder: ({ payload }) =>
-    ResultAsync.fromPromise(sendEmail(payload))
-      .map(() => undefined)
-      .mapErr((error) => new RetryableError("Email failed", error)),
+    ResultAsync.fromPromise(
+      sendEmail(payload),
+      (error) => new RetryableError("Email failed", error),
+    ).map(() => undefined),
 });
 
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers,
-  urls: ["amqp://localhost"],
-});
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers,
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 ```
 
 ### Benefits
@@ -192,21 +204,23 @@ Create a dedicated module for handlers with explicit error handling:
 ```typescript
 // handlers/order-handlers.ts
 import { defineHandler, defineHandlers, RetryableError } from "@amqp-contract/worker";
-import { ResultAsync } from "neverthrow";
+import { okAsync, ResultAsync } from "neverthrow";
 import { orderContract } from "../contract";
 import { processPayment } from "../services/payment";
 import { sendEmail } from "../services/email";
 
 export const processOrderHandler = defineHandler(orderContract, "processOrder", ({ payload }) =>
-  ResultAsync.fromPromise(processPayment(payload))
-    .map(() => undefined)
-    .mapErr((error) => new RetryableError("Payment failed", error)),
+  ResultAsync.fromPromise(
+    processPayment(payload),
+    (error) => new RetryableError("Payment failed", error),
+  ).map(() => undefined),
 );
 
 export const notifyOrderHandler = defineHandler(orderContract, "notifyOrder", ({ payload }) =>
-  ResultAsync.fromPromise(sendEmail(payload))
-    .map(() => undefined)
-    .mapErr((error) => new RetryableError("Email failed", error)),
+  ResultAsync.fromPromise(
+    sendEmail(payload),
+    (error) => new RetryableError("Email failed", error),
+  ).map(() => undefined),
 );
 
 // Export all handlers together
@@ -222,11 +236,13 @@ import { TypedAmqpWorker } from "@amqp-contract/worker";
 import { orderContract } from "./contract";
 import { orderHandlers } from "./handlers/order-handlers";
 
-const worker = await TypedAmqpWorker.create({
-  contract: orderContract,
-  handlers: orderHandlers,
-  urls: ["amqp://localhost"],
-});
+const worker = (
+  await TypedAmqpWorker.create({
+    contract: orderContract,
+    handlers: orderHandlers,
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 ```
 
 ## Starting Consumers
@@ -236,14 +252,14 @@ const worker = await TypedAmqpWorker.create({
 By default, `TypedAmqpWorker.create` automatically starts all consumers defined in the contract:
 
 ```typescript
-const worker = await TypedAmqpWorker.create({
+const worker = (await TypedAmqpWorker.create({
   contract,
   handlers: {
     processOrder: ({ payload }) => { ... },
     notifyOrder: ({ payload }) => { ... },
   },
   connection,
-});
+}))._unsafeUnwrap();
 // Worker is already consuming messages from all queues
 console.log('Worker ready, waiting for messages...');
 ```
@@ -255,19 +271,21 @@ console.log('Worker ready, waiting for messages...');
 By default, messages are automatically acknowledged after successful processing:
 
 ```typescript
-import { ResultAsync, Result } from "neverthrow";
+import { okAsync, ResultAsync, Result } from "neverthrow";
 
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: ({ payload }) => {
-      console.log("Processing:", payload.orderId);
-      // Message is automatically acked after this handler completes
-      return okAsync(undefined);
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: ({ payload }) => {
+        console.log("Processing:", payload.orderId);
+        // Message is automatically acked after this handler completes
+        return okAsync(undefined);
+      },
     },
-  },
-  connection,
-});
+    connection,
+  })
+)._unsafeUnwrap();
 ```
 
 ### Manual Acknowledgment
@@ -276,22 +294,25 @@ For more control over acknowledgment, use the raw message parameter and error ty
 
 ```typescript
 import { defineHandler, RetryableError, NonRetryableError } from "@amqp-contract/worker";
-import { ResultAsync, Result } from "neverthrow";
+import { okAsync, ResultAsync, Result } from "neverthrow";
 
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: defineHandler(contract, "processOrder", ({ payload }, rawMessage) => {
-      // Access raw AMQP message properties if needed
-      console.log("Delivery tag:", rawMessage.fields.deliveryTag);
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: defineHandler(contract, "processOrder", ({ payload }, rawMessage) => {
+        // Access raw AMQP message properties if needed
+        console.log("Delivery tag:", rawMessage.fields.deliveryTag);
 
-      return ResultAsync.fromPromise(processOrder(payload))
-        .map(() => undefined) // Success - message will be acked
-        .mapErr((error) => new RetryableError("Processing failed", error)); // Failure - will retry
-    }),
-  },
-  urls: ["amqp://localhost"],
-});
+        return ResultAsync.fromPromise(
+          processOrder(payload),
+          (error) => new RetryableError("Processing failed", error), // Failure - will retry
+        ).map(() => undefined); // Success - message will be acked
+      }),
+    },
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 ```
 
 **Acknowledgment behavior:**
@@ -319,35 +340,38 @@ process.on("SIGINT", shutdown);
 
 ```typescript
 import { TypedAmqpWorker, defineHandlers, RetryableError } from "@amqp-contract/worker";
-import { ResultAsync } from "neverthrow";
+import { okAsync, ResultAsync } from "neverthrow";
 import { contract } from "./contract";
 
 async function main() {
-  const worker = await TypedAmqpWorker.create({
-    contract,
-    handlers: defineHandlers(contract, {
-      processOrder: ({ payload }) => {
-        console.log(`Processing order ${payload.orderId}`);
+  const worker = (
+    await TypedAmqpWorker.create({
+      contract,
+      handlers: defineHandlers(contract, {
+        processOrder: ({ payload }) => {
+          console.log(`Processing order ${payload.orderId}`);
 
-        return ResultAsync.fromPromise(
-          Promise.all([saveToDatabase(payload), sendConfirmation(payload.customerId)]),
-        )
-          .map(() => undefined)
-          .mapErr((error) => {
-            console.error("Processing failed:", error);
-            return new RetryableError("Order processing failed", error);
-          });
-      },
+          return ResultAsync.fromPromise(
+            Promise.all([saveToDatabase(payload), sendConfirmation(payload.customerId)]),
+          )
+            .map(() => undefined)
+            .mapErr((error) => {
+              console.error("Processing failed:", error);
+              return new RetryableError("Order processing failed", error);
+            });
+        },
 
-      notifyOrder: ({ payload }) => {
-        console.log(`Sending notification for ${payload.orderId}`);
-        return ResultAsync.fromPromise(sendEmail(payload))
-          .map(() => undefined)
-          .mapErr((error) => new RetryableError("Email failed", error));
-      },
-    }),
-    urls: ["amqp://localhost"],
-  });
+        notifyOrder: ({ payload }) => {
+          console.log(`Sending notification for ${payload.orderId}`);
+          return ResultAsync.fromPromise(
+            sendEmail(payload),
+            (error) => new RetryableError("Email failed", error),
+          ).map(() => undefined);
+        },
+      }),
+      urls: ["amqp://localhost"],
+    })
+  )._unsafeUnwrap();
 
   console.log("✅ Worker ready!");
 
@@ -374,25 +398,28 @@ Control the number of unacknowledged messages a consumer can have at once. This 
 Use the tuple syntax `[handler, options]` to configure prefetch per-handler:
 
 ```typescript
-import { ResultAsync } from "neverthrow";
+import { okAsync, ResultAsync } from "neverthrow";
 import { RetryableError } from "@amqp-contract/worker";
 
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: [
-      ({ payload }) =>
-        ResultAsync.fromPromise(saveToDatabase(payload))
-          .map(() => {
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: [
+        ({ payload }) =>
+          ResultAsync.fromPromise(
+            saveToDatabase(payload),
+            (error) => new RetryableError("Failed to save order", error),
+          ).map(() => {
             console.log("Order:", payload.orderId);
             return undefined;
-          })
-          .mapErr((error) => new RetryableError("Failed to save order", error)),
-      { prefetch: 10 }, // Process up to 10 messages concurrently
-    ],
-  },
-  urls: ["amqp://localhost"],
-});
+          }),
+        { prefetch: 10 }, // Process up to 10 messages concurrently
+      ],
+    },
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 ```
 
 ### Default Consumer Options
@@ -400,22 +427,25 @@ const worker = await TypedAmqpWorker.create({
 If you want to apply a common consumer configuration across all handlers, use `defaultConsumerOptions` when creating the worker:
 
 ```typescript
-import { ResultAsync } from "neverthrow";
+import { okAsync, ResultAsync } from "neverthrow";
 import { RetryableError } from "@amqp-contract/worker";
 
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: ({ payload }) =>
-      ResultAsync.fromPromise(processOrder(payload))
-        .map(() => undefined)
-        .mapErr((error) => new RetryableError("Processing failed", error)),
-  },
-  urls: ["amqp://localhost"],
-  defaultConsumerOptions: {
-    prefetch: 10,
-  },
-});
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: ({ payload }) =>
+        ResultAsync.fromPromise(
+          processOrder(payload),
+          (error) => new RetryableError("Processing failed", error),
+        ).map(() => undefined),
+    },
+    urls: ["amqp://localhost"],
+    defaultConsumerOptions: {
+      prefetch: 10,
+    },
+  })
+)._unsafeUnwrap();
 ```
 
 `defaultConsumerOptions` are applied to every consumer handler. When a handler is defined with tuple syntax, per-handler options override these defaults.
@@ -473,7 +503,7 @@ A simpler mode that requeues failed messages immediately (no wait queues):
 ```typescript
 import { defineQueue, defineExchange, defineContract } from "@amqp-contract/contract";
 import { TypedAmqpWorker, RetryableError } from "@amqp-contract/worker";
-import { ResultAsync } from "neverthrow";
+import { okAsync, ResultAsync } from "neverthrow";
 
 // 1. Define queue with immediate-requeue retry
 const dlx = defineExchange("orders-dlx");
@@ -487,16 +517,19 @@ const ordersQueue = defineQueue("orders", {
 });
 
 // 2. Worker automatically uses queue's retry configuration
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: ({ payload }) =>
-      ResultAsync.fromPromise(processPayment(payload))
-        .map(() => undefined)
-        .mapErr((error) => new RetryableError("Payment failed", error)),
-  },
-  urls: ["amqp://localhost"],
-});
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: ({ payload }) =>
+        ResultAsync.fromPromise(
+          processPayment(payload),
+          (error) => new RetryableError("Payment failed", error),
+        ).map(() => undefined),
+    },
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 ```
 
 **How Immediate-Requeue works:**
@@ -527,7 +560,7 @@ import {
   defineMessage,
 } from "@amqp-contract/contract";
 import { TypedAmqpWorker, RetryableError } from "@amqp-contract/worker";
-import { ResultAsync } from "neverthrow";
+import { okAsync, ResultAsync } from "neverthrow";
 import { z } from "zod";
 
 // 1. Define queue with TTL-backoff retry - infrastructure auto-generated
@@ -553,16 +586,19 @@ const contract = defineContract({
 });
 
 // 3. Worker automatically uses queue's retry configuration
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: ({ payload }) =>
-      ResultAsync.fromPromise(processPayment(payload))
-        .map(() => undefined)
-        .mapErr((error) => new RetryableError("Payment failed", error)),
-  },
-  urls: ["amqp://localhost"],
-});
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: ({ payload }) =>
+        ResultAsync.fromPromise(
+          processPayment(payload),
+          (error) => new RetryableError("Payment failed", error),
+        ).map(() => undefined),
+    },
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 ```
 
 **How TTL-Backoff works:**
@@ -672,31 +708,32 @@ Use `RetryableError` for transient failures that may succeed on retry:
 
 ```typescript
 import { RetryableError, defineHandler } from "@amqp-contract/worker";
-import { ResultAsync } from "neverthrow";
+import { okAsync, ResultAsync } from "neverthrow";
 
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: [
-      defineHandler(contract, "processOrder", ({ payload }) =>
-        ResultAsync.fromPromise(externalApiCall(payload))
-          .map(() => undefined)
-          .mapErr(
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: [
+        defineHandler(contract, "processOrder", ({ payload }) =>
+          ResultAsync.fromPromise(
+            externalApiCall(payload),
             (error) =>
               // Explicitly signal this should be retried
               new RetryableError("External API temporarily unavailable", error),
-          ),
-      ),
-      {
-        retry: {
-          maxRetries: 5,
-          initialDelayMs: 2000,
+          ).map(() => undefined),
+        ),
+        {
+          retry: {
+            maxRetries: 5,
+            initialDelayMs: 2000,
+          },
         },
-      },
-    ],
-  },
-  urls: ["amqp://localhost"],
-});
+      ],
+    },
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 ```
 
 #### NonRetryableError
@@ -705,23 +742,26 @@ Use `NonRetryableError` for permanent failures that should NOT be retried:
 
 ```typescript
 import { NonRetryableError, RetryableError, defineHandler } from "@amqp-contract/worker";
-import { ResultAsync, Result } from "neverthrow";
+import { okAsync, ResultAsync, Result } from "neverthrow";
 
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: defineHandler(contract, "processOrder", ({ payload }) => {
-      // Validation errors should not be retried
-      if (payload.amount <= 0) {
-        return errAsync(new NonRetryableError("Invalid order amount"));
-      }
-      return ResultAsync.fromPromise(processPayment(payload))
-        .map(() => undefined)
-        .mapErr((error) => new RetryableError("Payment failed", error));
-    }),
-  },
-  urls: ["amqp://localhost"],
-});
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: defineHandler(contract, "processOrder", ({ payload }) => {
+        // Validation errors should not be retried
+        if (payload.amount <= 0) {
+          return errAsync(new NonRetryableError("Invalid order amount"));
+        }
+        return ResultAsync.fromPromise(
+          processPayment(payload),
+          (error) => new RetryableError("Payment failed", error),
+        ).map(() => undefined);
+      }),
+    },
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 ```
 
 **NonRetryableError behavior:**
@@ -736,32 +776,34 @@ For the most explicit error handling, use safe handlers that return `ResultAsync
 
 ```typescript
 import { defineHandler, RetryableError, NonRetryableError } from "@amqp-contract/worker";
-import { ResultAsync, Result } from "neverthrow";
+import { okAsync, ResultAsync, Result } from "neverthrow";
 import { match } from "ts-pattern";
 
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: defineHandler(contract, "processOrder", ({ payload }) => {
-      // Validation - non-retryable
-      if (payload.amount <= 0) {
-        return errAsync(new NonRetryableError("Invalid amount"));
-      }
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: defineHandler(contract, "processOrder", ({ payload }) => {
+        // Validation - non-retryable
+        if (payload.amount <= 0) {
+          return errAsync(new NonRetryableError("Invalid amount"));
+        }
 
-      return ResultAsync.fromPromise(processPayment(payload))
-        .map(() => undefined)
-        .mapErr((error) =>
-          match(error)
-            .when(
-              (e) => e instanceof PaymentDeclinedError,
-              () => new NonRetryableError("Payment declined", error),
-            )
-            .otherwise(() => new RetryableError("Payment failed", error)),
-        );
-    }),
-  },
-  urls: ["amqp://localhost"],
-});
+        return ResultAsync.fromPromise(processPayment(payload))
+          .map(() => undefined)
+          .mapErr((error) =>
+            match(error)
+              .when(
+                (e) => e instanceof PaymentDeclinedError,
+                () => new NonRetryableError("Payment declined", error),
+              )
+              .otherwise(() => new RetryableError("Payment failed", error)),
+          );
+      }),
+    },
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 ```
 
 **When to use which error type:**
@@ -812,7 +854,7 @@ import {
   defineConsumer,
   defineMessage,
 } from "@amqp-contract/contract";
-import { ResultAsync, Result } from "neverthrow";
+import { okAsync, ResultAsync, Result } from "neverthrow";
 import { z } from "zod";
 
 // Define exchanges
@@ -857,29 +899,31 @@ const contract = defineContract({
 });
 
 // Worker automatically uses queue's retry configuration
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: ({ payload }) => {
-      // Validate before processing (don't retry validation errors)
-      if (!payload.amount || payload.amount <= 0) {
-        return errAsync(new NonRetryableError("Invalid order amount"));
-      }
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: ({ payload }) => {
+        // Validate before processing (don't retry validation errors)
+        if (!payload.amount || payload.amount <= 0) {
+          return errAsync(new NonRetryableError("Invalid order amount"));
+        }
 
-      // Process with external service (retry on failure based on queue config)
-      return ResultAsync.fromPromise(
-        Promise.all([
-          paymentService.charge(payload),
-          inventoryService.reserve(payload),
-          notificationService.send(payload),
-        ]),
-      )
-        .map(() => undefined)
-        .mapErr((error) => new RetryableError("Order processing failed", error));
+        // Process with external service (retry on failure based on queue config)
+        return ResultAsync.fromPromise(
+          Promise.all([
+            paymentService.charge(payload),
+            inventoryService.reserve(payload),
+            notificationService.send(payload),
+          ]),
+        )
+          .map(() => undefined)
+          .mapErr((error) => new RetryableError("Order processing failed", error));
+      },
     },
-  },
-  urls: ["amqp://localhost"],
-});
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 
 console.log("✅ Worker ready with retry enabled!");
 ```

--- a/docs/guide/worker-usage.md
+++ b/docs/guide/worker-usage.md
@@ -13,20 +13,20 @@ import {
   RetryableError,
   NonRetryableError,
 } from "@amqp-contract/worker";
-import { Future, Result } from "@swan-io/boxed";
+import { ResultAsync, Result } from "neverthrow";
 import { contract } from "./contract";
 
 const processOrder = defineHandler(contract, "processOrder", ({ payload }) =>
-  Future.fromPromise(saveOrder(payload))
-    .mapOk(() => undefined)
-    .mapError((error) => new RetryableError("Database unavailable", error)),
+  ResultAsync.fromPromise(saveOrder(payload))
+    .map(() => undefined)
+    .mapErr((error) => new RetryableError("Database unavailable", error)),
 );
 
 const worker = await TypedAmqpWorker.create({
   contract,
   handlers: { processOrder },
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 
 console.log("✅ Worker ready!");
 ```
@@ -41,7 +41,7 @@ For one-file demos, you can inline the handler. The signature and types are iden
 
 ```typescript
 import { TypedAmqpWorker } from "@amqp-contract/worker";
-import { Future, Result } from "@swan-io/boxed";
+import { ResultAsync, Result } from "neverthrow";
 import { contract } from "./contract";
 
 const worker = await TypedAmqpWorker.create({
@@ -49,15 +49,15 @@ const worker = await TypedAmqpWorker.create({
   handlers: {
     processOrder: ({ payload }) => {
       console.log("Processing:", payload.orderId);
-      return Future.value(Result.Ok(undefined));
+      return okAsync(undefined);
     },
     notifyOrder: ({ payload }) => {
       console.log("Notifying:", payload.orderId);
-      return Future.value(Result.Ok(undefined));
+      return okAsync(undefined);
     },
   },
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 ```
 
 In production code, prefer `defineHandler` so handler logic lives in its own module and can be unit-tested.
@@ -67,7 +67,7 @@ In production code, prefer `defineHandler` so handler logic lives in its own mod
 Handlers receive validated, fully-typed messages with `{ payload, headers }`:
 
 ```typescript
-import { Future, Result } from "@swan-io/boxed";
+import { ResultAsync, Result } from "neverthrow";
 
 const worker = await TypedAmqpWorker.create({
   contract,
@@ -81,11 +81,11 @@ const worker = await TypedAmqpWorker.create({
       for (const item of payload.items) {
         console.log(`${item.productId}: ${item.quantity}`);
       }
-      return Future.value(Result.Ok(undefined));
+      return okAsync(undefined);
     },
   },
   connection,
-}).resultToPromise();
+});
 ```
 
 ### Type Safety
@@ -115,7 +115,7 @@ const worker = await TypedAmqpWorker.create({
     notifyOrder: ({ payload }) => { ... },
   },
   urls: ['amqp://localhost'],
-}).resultToPromise();
+});
 
 console.log('✅ All handlers present');
 ```
@@ -126,25 +126,25 @@ For better organization, define handlers separately. The library provides two ty
 
 ### Safe Handlers (Recommended)
 
-Safe handlers return `Future<Result<void, HandlerError>>` for explicit error handling:
+Safe handlers return `ResultAsync<void, HandlerError>` for explicit error handling:
 
 ```typescript
 import { defineHandler, RetryableError, NonRetryableError } from "@amqp-contract/worker";
-import { Future, Result } from "@swan-io/boxed";
+import { ResultAsync, Result } from "neverthrow";
 import { contract } from "./contract";
 
 const processOrderHandler = defineHandler(contract, "processOrder", ({ payload }) =>
-  Future.fromPromise(saveToDatabase(payload))
-    .mapOk(() => undefined)
-    .mapError((error) => new RetryableError("Database error", error)),
+  ResultAsync.fromPromise(saveToDatabase(payload))
+    .map(() => undefined)
+    .mapErr((error) => new RetryableError("Database error", error)),
 );
 
 // Non-retryable errors go directly to DLQ
 const validateOrderHandler = defineHandler(contract, "validateOrder", ({ payload }) => {
   if (payload.amount <= 0) {
-    return Future.value(Result.Error(new NonRetryableError("Invalid order amount")));
+    return errAsync(new NonRetryableError("Invalid order amount"));
   }
-  return Future.value(Result.Ok(undefined));
+  return okAsync(undefined);
 });
 ```
 
@@ -152,19 +152,19 @@ const validateOrderHandler = defineHandler(contract, "validateOrder", ({ payload
 
 ```typescript
 import { defineHandlers, RetryableError } from "@amqp-contract/worker";
-import { Future, Result } from "@swan-io/boxed";
+import { ResultAsync, Result } from "neverthrow";
 import { contract } from "./contract";
 
-// Safe handlers (recommended) - for async operations use Future.fromPromise
+// Safe handlers (recommended) - for async operations use ResultAsync.fromPromise
 const handlers = defineHandlers(contract, {
   processOrder: ({ payload }) =>
-    Future.fromPromise(processPayment(payload))
-      .mapOk(() => undefined)
-      .mapError((error) => new RetryableError("Payment failed", error)),
+    ResultAsync.fromPromise(processPayment(payload))
+      .map(() => undefined)
+      .mapErr((error) => new RetryableError("Payment failed", error)),
   notifyOrder: ({ payload }) =>
-    Future.fromPromise(sendEmail(payload))
-      .mapOk(() => undefined)
-      .mapError((error) => new RetryableError("Email failed", error)),
+    ResultAsync.fromPromise(sendEmail(payload))
+      .map(() => undefined)
+      .mapErr((error) => new RetryableError("Email failed", error)),
 });
 
 const worker = await TypedAmqpWorker.create({
@@ -192,21 +192,21 @@ Create a dedicated module for handlers with explicit error handling:
 ```typescript
 // handlers/order-handlers.ts
 import { defineHandler, defineHandlers, RetryableError } from "@amqp-contract/worker";
-import { Future } from "@swan-io/boxed";
+import { ResultAsync } from "neverthrow";
 import { orderContract } from "../contract";
 import { processPayment } from "../services/payment";
 import { sendEmail } from "../services/email";
 
 export const processOrderHandler = defineHandler(orderContract, "processOrder", ({ payload }) =>
-  Future.fromPromise(processPayment(payload))
-    .mapOk(() => undefined)
-    .mapError((error) => new RetryableError("Payment failed", error)),
+  ResultAsync.fromPromise(processPayment(payload))
+    .map(() => undefined)
+    .mapErr((error) => new RetryableError("Payment failed", error)),
 );
 
 export const notifyOrderHandler = defineHandler(orderContract, "notifyOrder", ({ payload }) =>
-  Future.fromPromise(sendEmail(payload))
-    .mapOk(() => undefined)
-    .mapError((error) => new RetryableError("Email failed", error)),
+  ResultAsync.fromPromise(sendEmail(payload))
+    .map(() => undefined)
+    .mapErr((error) => new RetryableError("Email failed", error)),
 );
 
 // Export all handlers together
@@ -255,7 +255,7 @@ console.log('Worker ready, waiting for messages...');
 By default, messages are automatically acknowledged after successful processing:
 
 ```typescript
-import { Future, Result } from "@swan-io/boxed";
+import { ResultAsync, Result } from "neverthrow";
 
 const worker = await TypedAmqpWorker.create({
   contract,
@@ -263,7 +263,7 @@ const worker = await TypedAmqpWorker.create({
     processOrder: ({ payload }) => {
       console.log("Processing:", payload.orderId);
       // Message is automatically acked after this handler completes
-      return Future.value(Result.Ok(undefined));
+      return okAsync(undefined);
     },
   },
   connection,
@@ -276,7 +276,7 @@ For more control over acknowledgment, use the raw message parameter and error ty
 
 ```typescript
 import { defineHandler, RetryableError, NonRetryableError } from "@amqp-contract/worker";
-import { Future, Result } from "@swan-io/boxed";
+import { ResultAsync, Result } from "neverthrow";
 
 const worker = await TypedAmqpWorker.create({
   contract,
@@ -285,20 +285,20 @@ const worker = await TypedAmqpWorker.create({
       // Access raw AMQP message properties if needed
       console.log("Delivery tag:", rawMessage.fields.deliveryTag);
 
-      return Future.fromPromise(processOrder(payload))
-        .mapOk(() => undefined) // Success - message will be acked
-        .mapError((error) => new RetryableError("Processing failed", error)); // Failure - will retry
+      return ResultAsync.fromPromise(processOrder(payload))
+        .map(() => undefined) // Success - message will be acked
+        .mapErr((error) => new RetryableError("Processing failed", error)); // Failure - will retry
     }),
   },
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 ```
 
 **Acknowledgment behavior:**
 
-- Handler returns `Result.Ok(undefined)` → Message is acknowledged
-- Handler returns `Result.Error(RetryableError)` → Message is nacked and retried
-- Handler returns `Result.Error(NonRetryableError)` → Message is sent to DLQ (if configured) or dropped
+- Handler returns `ok(undefined)` → Message is acknowledged
+- Handler returns `err(RetryableError)` → Message is nacked and retried
+- Handler returns `err(NonRetryableError)` → Message is sent to DLQ (if configured) or dropped
 
 ## Graceful Shutdown
 
@@ -319,7 +319,7 @@ process.on("SIGINT", shutdown);
 
 ```typescript
 import { TypedAmqpWorker, defineHandlers, RetryableError } from "@amqp-contract/worker";
-import { Future } from "@swan-io/boxed";
+import { ResultAsync } from "neverthrow";
 import { contract } from "./contract";
 
 async function main() {
@@ -329,11 +329,11 @@ async function main() {
       processOrder: ({ payload }) => {
         console.log(`Processing order ${payload.orderId}`);
 
-        return Future.fromPromise(
+        return ResultAsync.fromPromise(
           Promise.all([saveToDatabase(payload), sendConfirmation(payload.customerId)]),
         )
-          .mapOk(() => undefined)
-          .mapError((error) => {
+          .map(() => undefined)
+          .mapErr((error) => {
             console.error("Processing failed:", error);
             return new RetryableError("Order processing failed", error);
           });
@@ -341,13 +341,13 @@ async function main() {
 
       notifyOrder: ({ payload }) => {
         console.log(`Sending notification for ${payload.orderId}`);
-        return Future.fromPromise(sendEmail(payload))
-          .mapOk(() => undefined)
-          .mapError((error) => new RetryableError("Email failed", error));
+        return ResultAsync.fromPromise(sendEmail(payload))
+          .map(() => undefined)
+          .mapErr((error) => new RetryableError("Email failed", error));
       },
     }),
     urls: ["amqp://localhost"],
-  }).resultToPromise();
+  });
 
   console.log("✅ Worker ready!");
 
@@ -374,7 +374,7 @@ Control the number of unacknowledged messages a consumer can have at once. This 
 Use the tuple syntax `[handler, options]` to configure prefetch per-handler:
 
 ```typescript
-import { Future } from "@swan-io/boxed";
+import { ResultAsync } from "neverthrow";
 import { RetryableError } from "@amqp-contract/worker";
 
 const worker = await TypedAmqpWorker.create({
@@ -382,17 +382,17 @@ const worker = await TypedAmqpWorker.create({
   handlers: {
     processOrder: [
       ({ payload }) =>
-        Future.fromPromise(saveToDatabase(payload))
-          .mapOk(() => {
+        ResultAsync.fromPromise(saveToDatabase(payload))
+          .map(() => {
             console.log("Order:", payload.orderId);
             return undefined;
           })
-          .mapError((error) => new RetryableError("Failed to save order", error)),
+          .mapErr((error) => new RetryableError("Failed to save order", error)),
       { prefetch: 10 }, // Process up to 10 messages concurrently
     ],
   },
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 ```
 
 ### Default Consumer Options
@@ -400,22 +400,22 @@ const worker = await TypedAmqpWorker.create({
 If you want to apply a common consumer configuration across all handlers, use `defaultConsumerOptions` when creating the worker:
 
 ```typescript
-import { Future } from "@swan-io/boxed";
+import { ResultAsync } from "neverthrow";
 import { RetryableError } from "@amqp-contract/worker";
 
 const worker = await TypedAmqpWorker.create({
   contract,
   handlers: {
     processOrder: ({ payload }) =>
-      Future.fromPromise(processOrder(payload))
-        .mapOk(() => undefined)
-        .mapError((error) => new RetryableError("Processing failed", error)),
+      ResultAsync.fromPromise(processOrder(payload))
+        .map(() => undefined)
+        .mapErr((error) => new RetryableError("Processing failed", error)),
   },
   urls: ["amqp://localhost"],
   defaultConsumerOptions: {
     prefetch: 10,
   },
-}).resultToPromise();
+});
 ```
 
 `defaultConsumerOptions` are applied to every consumer handler. When a handler is defined with tuple syntax, per-handler options override these defaults.
@@ -430,7 +430,7 @@ Three configuration patterns are supported:
 handlers: {
   processOrder: ({ payload }) => {
     // Single message processing
-    return Future.value(Result.Ok(undefined));
+    return okAsync(undefined);
   };
 }
 ```
@@ -442,7 +442,7 @@ handlers: {
   processOrder: [
     ({ payload }) => {
       // Single message processing with prefetch
-      return Future.value(Result.Ok(undefined));
+      return okAsync(undefined);
     },
     { prefetch: 10 },
   ];
@@ -473,7 +473,7 @@ A simpler mode that requeues failed messages immediately (no wait queues):
 ```typescript
 import { defineQueue, defineExchange, defineContract } from "@amqp-contract/contract";
 import { TypedAmqpWorker, RetryableError } from "@amqp-contract/worker";
-import { Future } from "@swan-io/boxed";
+import { ResultAsync } from "neverthrow";
 
 // 1. Define queue with immediate-requeue retry
 const dlx = defineExchange("orders-dlx");
@@ -491,12 +491,12 @@ const worker = await TypedAmqpWorker.create({
   contract,
   handlers: {
     processOrder: ({ payload }) =>
-      Future.fromPromise(processPayment(payload))
-        .mapOk(() => undefined)
-        .mapError((error) => new RetryableError("Payment failed", error)),
+      ResultAsync.fromPromise(processPayment(payload))
+        .map(() => undefined)
+        .mapErr((error) => new RetryableError("Payment failed", error)),
   },
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 ```
 
 **How Immediate-Requeue works:**
@@ -527,7 +527,7 @@ import {
   defineMessage,
 } from "@amqp-contract/contract";
 import { TypedAmqpWorker, RetryableError } from "@amqp-contract/worker";
-import { Future } from "@swan-io/boxed";
+import { ResultAsync } from "neverthrow";
 import { z } from "zod";
 
 // 1. Define queue with TTL-backoff retry - infrastructure auto-generated
@@ -557,12 +557,12 @@ const worker = await TypedAmqpWorker.create({
   contract,
   handlers: {
     processOrder: ({ payload }) =>
-      Future.fromPromise(processPayment(payload))
-        .mapOk(() => undefined)
-        .mapError((error) => new RetryableError("Payment failed", error)),
+      ResultAsync.fromPromise(processPayment(payload))
+        .map(() => undefined)
+        .mapErr((error) => new RetryableError("Payment failed", error)),
   },
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 ```
 
 **How TTL-Backoff works:**
@@ -672,16 +672,16 @@ Use `RetryableError` for transient failures that may succeed on retry:
 
 ```typescript
 import { RetryableError, defineHandler } from "@amqp-contract/worker";
-import { Future } from "@swan-io/boxed";
+import { ResultAsync } from "neverthrow";
 
 const worker = await TypedAmqpWorker.create({
   contract,
   handlers: {
     processOrder: [
       defineHandler(contract, "processOrder", ({ payload }) =>
-        Future.fromPromise(externalApiCall(payload))
-          .mapOk(() => undefined)
-          .mapError(
+        ResultAsync.fromPromise(externalApiCall(payload))
+          .map(() => undefined)
+          .mapErr(
             (error) =>
               // Explicitly signal this should be retried
               new RetryableError("External API temporarily unavailable", error),
@@ -696,7 +696,7 @@ const worker = await TypedAmqpWorker.create({
     ],
   },
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 ```
 
 #### NonRetryableError
@@ -705,7 +705,7 @@ Use `NonRetryableError` for permanent failures that should NOT be retried:
 
 ```typescript
 import { NonRetryableError, RetryableError, defineHandler } from "@amqp-contract/worker";
-import { Future, Result } from "@swan-io/boxed";
+import { ResultAsync, Result } from "neverthrow";
 
 const worker = await TypedAmqpWorker.create({
   contract,
@@ -713,15 +713,15 @@ const worker = await TypedAmqpWorker.create({
     processOrder: defineHandler(contract, "processOrder", ({ payload }) => {
       // Validation errors should not be retried
       if (payload.amount <= 0) {
-        return Future.value(Result.Error(new NonRetryableError("Invalid order amount")));
+        return errAsync(new NonRetryableError("Invalid order amount"));
       }
-      return Future.fromPromise(processPayment(payload))
-        .mapOk(() => undefined)
-        .mapError((error) => new RetryableError("Payment failed", error));
+      return ResultAsync.fromPromise(processPayment(payload))
+        .map(() => undefined)
+        .mapErr((error) => new RetryableError("Payment failed", error));
     }),
   },
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 ```
 
 **NonRetryableError behavior:**
@@ -732,11 +732,11 @@ const worker = await TypedAmqpWorker.create({
 
 #### Using Safe Handlers for Better Error Control
 
-For the most explicit error handling, use safe handlers that return `Future<Result>`:
+For the most explicit error handling, use safe handlers that return `ResultAsync<Result>`:
 
 ```typescript
 import { defineHandler, RetryableError, NonRetryableError } from "@amqp-contract/worker";
-import { Future, Result } from "@swan-io/boxed";
+import { ResultAsync, Result } from "neverthrow";
 import { match } from "ts-pattern";
 
 const worker = await TypedAmqpWorker.create({
@@ -745,12 +745,12 @@ const worker = await TypedAmqpWorker.create({
     processOrder: defineHandler(contract, "processOrder", ({ payload }) => {
       // Validation - non-retryable
       if (payload.amount <= 0) {
-        return Future.value(Result.Error(new NonRetryableError("Invalid amount")));
+        return errAsync(new NonRetryableError("Invalid amount"));
       }
 
-      return Future.fromPromise(processPayment(payload))
-        .mapOk(() => undefined)
-        .mapError((error) =>
+      return ResultAsync.fromPromise(processPayment(payload))
+        .map(() => undefined)
+        .mapErr((error) =>
           match(error)
             .when(
               (e) => e instanceof PaymentDeclinedError,
@@ -761,7 +761,7 @@ const worker = await TypedAmqpWorker.create({
     }),
   },
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 ```
 
 **When to use which error type:**
@@ -812,7 +812,7 @@ import {
   defineConsumer,
   defineMessage,
 } from "@amqp-contract/contract";
-import { Future, Result } from "@swan-io/boxed";
+import { ResultAsync, Result } from "neverthrow";
 import { z } from "zod";
 
 // Define exchanges
@@ -863,23 +863,23 @@ const worker = await TypedAmqpWorker.create({
     processOrder: ({ payload }) => {
       // Validate before processing (don't retry validation errors)
       if (!payload.amount || payload.amount <= 0) {
-        return Future.value(Result.Error(new NonRetryableError("Invalid order amount")));
+        return errAsync(new NonRetryableError("Invalid order amount"));
       }
 
       // Process with external service (retry on failure based on queue config)
-      return Future.fromPromise(
+      return ResultAsync.fromPromise(
         Promise.all([
           paymentService.charge(payload),
           inventoryService.reserve(payload),
           notificationService.send(payload),
         ]),
       )
-        .mapOk(() => undefined)
-        .mapError((error) => new RetryableError("Order processing failed", error));
+        .map(() => undefined)
+        .mapErr((error) => new RetryableError("Order processing failed", error));
     },
   },
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 
 console.log("✅ Worker ready with retry enabled!");
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,10 +88,12 @@ export const contract = defineContract({
 import { TypedAmqpClient } from "@amqp-contract/client";
 import { contract } from "./contract";
 
-const client = await TypedAmqpClient.create({
-  contract,
-  urls: ["amqp://localhost"],
-});
+const client = (
+  await TypedAmqpClient.create({
+    contract,
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 
 await client.publish("orderCreated", {
   orderId: "ORD-123", // ✅ TypeScript knows!
@@ -101,19 +103,21 @@ await client.publish("orderCreated", {
 
 ```typescript [3. Consume]
 import { TypedAmqpWorker } from "@amqp-contract/worker";
-import { ResultAsync, Result } from "neverthrow";
+import { okAsync, ResultAsync, Result } from "neverthrow";
 import { contract } from "./contract";
 
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: ({ payload }) => {
-      console.log(payload.orderId); // ✅ Fully typed!
-      return okAsync(undefined);
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: ({ payload }) => {
+        console.log(payload.orderId); // ✅ Fully typed!
+        return okAsync(undefined);
+      },
     },
-  },
-  urls: ["amqp://localhost"],
-});
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 ```
 
 :::

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,7 +91,7 @@ import { contract } from "./contract";
 const client = await TypedAmqpClient.create({
   contract,
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 
 await client.publish("orderCreated", {
   orderId: "ORD-123", // ✅ TypeScript knows!
@@ -101,7 +101,7 @@ await client.publish("orderCreated", {
 
 ```typescript [3. Consume]
 import { TypedAmqpWorker } from "@amqp-contract/worker";
-import { Future, Result } from "@swan-io/boxed";
+import { ResultAsync, Result } from "neverthrow";
 import { contract } from "./contract";
 
 const worker = await TypedAmqpWorker.create({
@@ -109,11 +109,11 @@ const worker = await TypedAmqpWorker.create({
   handlers: {
     processOrder: ({ payload }) => {
       console.log(payload.orderId); // ✅ Fully typed!
-      return Future.value(Result.Ok(undefined));
+      return okAsync(undefined);
     },
   },
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 ```
 
 :::

--- a/examples/basic-order-processing-client/package.json
+++ b/examples/basic-order-processing-client/package.json
@@ -18,8 +18,8 @@
   "devDependencies": {
     "@amqp-contract/testing": "workspace:*",
     "@amqp-contract/tsconfig": "workspace:*",
-    "@swan-io/boxed": "catalog:",
     "@vitest/coverage-v8": "catalog:",
+    "neverthrow": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/examples/basic-order-processing-client/src/index.spec.ts
+++ b/examples/basic-order-processing-client/src/index.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from "vitest";
-import { Result } from "@swan-io/boxed";
+import { ok } from "neverthrow";
 import { TypedAmqpClient } from "@amqp-contract/client";
 import { it } from "@amqp-contract/testing/extension";
 import { orderContract } from "@amqp-contract-examples/basic-order-processing-contract";
@@ -7,10 +7,12 @@ import { orderContract } from "@amqp-contract-examples/basic-order-processing-co
 describe("Basic Order Processing Client Integration", () => {
   it("should publish a new order successfully", async ({ amqpConnectionUrl }) => {
     // GIVEN
-    const client = await TypedAmqpClient.create({
-      contract: orderContract,
-      urls: [amqpConnectionUrl],
-    }).resultToPromise();
+    const client = (
+      await TypedAmqpClient.create({
+        contract: orderContract,
+        urls: [amqpConnectionUrl],
+      })
+    )._unsafeUnwrap();
 
     const newOrder = {
       orderId: "TEST-001",
@@ -27,18 +29,20 @@ describe("Basic Order Processing Client Integration", () => {
     const result = await client.publish("orderCreated", newOrder);
 
     // THEN
-    expect(result).toEqual(Result.Ok(undefined));
+    expect(result).toEqual(ok(undefined));
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
   });
 
   it("should publish order status updates", async ({ amqpConnectionUrl }) => {
     // GIVEN
-    const client = await TypedAmqpClient.create({
-      contract: orderContract,
-      urls: [amqpConnectionUrl],
-    }).resultToPromise();
+    const client = (
+      await TypedAmqpClient.create({
+        contract: orderContract,
+        urls: [amqpConnectionUrl],
+      })
+    )._unsafeUnwrap();
 
     const orderUpdate = {
       orderId: "TEST-001",
@@ -50,18 +54,20 @@ describe("Basic Order Processing Client Integration", () => {
     const result = await client.publish("orderUpdated", orderUpdate);
 
     // THEN
-    expect(result).toEqual(Result.Ok(undefined));
+    expect(result).toEqual(ok(undefined));
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
   });
 
   it("should validate order schema before publishing", async ({ amqpConnectionUrl }) => {
     // GIVEN
-    const client = await TypedAmqpClient.create({
-      contract: orderContract,
-      urls: [amqpConnectionUrl],
-    }).resultToPromise();
+    const client = (
+      await TypedAmqpClient.create({
+        contract: orderContract,
+        urls: [amqpConnectionUrl],
+      })
+    )._unsafeUnwrap();
 
     const invalidOrder = {
       orderId: "TEST-001",
@@ -77,9 +83,9 @@ describe("Basic Order Processing Client Integration", () => {
     const result = await client.publish("orderCreated", invalidOrder);
 
     // THEN
-    expect(result.isError()).toBe(true);
+    expect(result.isErr()).toBe(true);
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
   });
 });

--- a/examples/basic-order-processing-client/src/index.ts
+++ b/examples/basic-order-processing-client/src/index.ts
@@ -22,12 +22,12 @@ const logger = pino({
 
 async function main() {
   // Create type-safe client
-  const client = await TypedAmqpClient.create({
-    contract: orderContract,
-    urls: [env.AMQP_URL],
-  })
-    .tapError((error) => logger.error({ error }, "Failed to create client"))
-    .resultToPromise();
+  const client = (
+    await TypedAmqpClient.create({
+      contract: orderContract,
+      urls: [env.AMQP_URL],
+    }).orTee((error) => logger.error({ error }, "Failed to create client"))
+  )._unsafeUnwrap();
 
   logger.info("Client ready");
   logger.info("=".repeat(60));
@@ -42,11 +42,12 @@ async function main() {
     message: Parameters<typeof client.publish<T>>[1],
     options?: PublishOptions,
   ): Promise<void> => {
-    await client
-      .publish(publisherName, message, options)
-      .tapError((error) => logger.error({ error }, `Failed to publish: ${publisherName}`))
-      .tapOk(() => logger.debug(`Successfully published to ${publisherName}`))
-      .resultToPromise();
+    (
+      await client
+        .publish(publisherName, message, options)
+        .orTee((error) => logger.error({ error }, `Failed to publish: ${publisherName}`))
+        .andTee(() => logger.debug(`Successfully published to ${publisherName}`))
+    )._unsafeUnwrap();
   };
 
   // 1. Publish a new order (routing key: order.created)
@@ -122,7 +123,7 @@ async function main() {
   await new Promise((resolve) => setTimeout(resolve, 2000));
 
   // Clean up
-  await client.close();
+  (await client.close())._unsafeUnwrap();
   logger.info("Publisher stopped");
   process.exit(0);
 }

--- a/examples/basic-order-processing-contract/README.md
+++ b/examples/basic-order-processing-contract/README.md
@@ -18,10 +18,12 @@ This package demonstrates the **recommended approach** for defining contracts:
 import { contract } from "@amqp-contract-examples/basic-order-processing-contract";
 import { TypedAmqpClient } from "@amqp-contract/client";
 
-const client = await TypedAmqpClient.create({
-  contract,
-  urls: ["amqp://localhost"],
-});
+const client = (
+  await TypedAmqpClient.create({
+    contract,
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 
 await client.publish("orderCreated", {
   /* fully typed */

--- a/examples/basic-order-processing-contract/README.md
+++ b/examples/basic-order-processing-contract/README.md
@@ -21,13 +21,11 @@ import { TypedAmqpClient } from "@amqp-contract/client";
 const client = await TypedAmqpClient.create({
   contract,
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 
-await client
-  .publish("orderCreated", {
-    /* fully typed */
-  })
-  .resultToPromise();
+await client.publish("orderCreated", {
+  /* fully typed */
+});
 ```
 
 ## Patterns Demonstrated

--- a/examples/basic-order-processing-worker/README.md
+++ b/examples/basic-order-processing-worker/README.md
@@ -27,20 +27,22 @@ Handlers are defined directly in the worker creation. This approach is suitable 
 - When handlers don't need to be reused
 
 ```typescript
-const worker = await TypedAmqpWorker.create({
-  contract: orderContract,
-  handlers: {
-    processOrder: ({ payload }) => {
-      // Handler logic here
-      return okAsync(undefined);
+const worker = (
+  await TypedAmqpWorker.create({
+    contract: orderContract,
+    handlers: {
+      processOrder: ({ payload }) => {
+        // Handler logic here
+        return okAsync(undefined);
+      },
+      notifyOrder: ({ payload }) => {
+        // Handler logic here
+        return okAsync(undefined);
+      },
     },
-    notifyOrder: ({ payload }) => {
-      // Handler logic here
-      return okAsync(undefined);
-    },
-  },
-  urls: [env.AMQP_URL],
-});
+    urls: [env.AMQP_URL],
+  })
+)._unsafeUnwrap();
 ```
 
 ### External Handlers (src/handlers.ts)
@@ -62,14 +64,16 @@ export const processOrderHandler = defineHandler(orderContract, "processOrder", 
 // index.ts - to use external handlers, import them:
 import { processOrderHandler /* other handlers */ } from "./handlers.js";
 
-const worker = await TypedAmqpWorker.create({
-  contract: orderContract,
-  handlers: {
-    processOrder: processOrderHandler,
-    // ... other handlers
-  },
-  urls: [env.AMQP_URL],
-});
+const worker = (
+  await TypedAmqpWorker.create({
+    contract: orderContract,
+    handlers: {
+      processOrder: processOrderHandler,
+      // ... other handlers
+    },
+    urls: [env.AMQP_URL],
+  })
+)._unsafeUnwrap();
 ```
 
 The main `src/index.ts` file uses inline handlers for simplicity, while `src/handlers.ts` provides an example of how to organize handlers externally for better maintainability.

--- a/examples/basic-order-processing-worker/README.md
+++ b/examples/basic-order-processing-worker/README.md
@@ -32,15 +32,15 @@ const worker = await TypedAmqpWorker.create({
   handlers: {
     processOrder: ({ payload }) => {
       // Handler logic here
-      return Future.value(Result.Ok(undefined));
+      return okAsync(undefined);
     },
     notifyOrder: ({ payload }) => {
       // Handler logic here
-      return Future.value(Result.Ok(undefined));
+      return okAsync(undefined);
     },
   },
   urls: [env.AMQP_URL],
-}).resultToPromise();
+});
 ```
 
 ### External Handlers (src/handlers.ts)
@@ -56,7 +56,7 @@ Handlers can be organized in separate files using `defineHandler` or `defineHand
 // handlers.ts
 export const processOrderHandler = defineHandler(orderContract, "processOrder", ({ payload }) => {
   // Handler logic here
-  return Future.value(Result.Ok(undefined));
+  return okAsync(undefined);
 });
 
 // index.ts - to use external handlers, import them:
@@ -69,7 +69,7 @@ const worker = await TypedAmqpWorker.create({
     // ... other handlers
   },
   urls: [env.AMQP_URL],
-}).resultToPromise();
+});
 ```
 
 The main `src/index.ts` file uses inline handlers for simplicity, while `src/handlers.ts` provides an example of how to organize handlers externally for better maintainability.

--- a/examples/basic-order-processing-worker/package.json
+++ b/examples/basic-order-processing-worker/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@amqp-contract-examples/basic-order-processing-contract": "workspace:*",
     "@amqp-contract/worker": "workspace:*",
-    "@swan-io/boxed": "catalog:",
+    "neverthrow": "catalog:",
     "pino": "catalog:",
     "pino-pretty": "catalog:",
     "zod": "catalog:"

--- a/examples/basic-order-processing-worker/src/index.spec.ts
+++ b/examples/basic-order-processing-worker/src/index.spec.ts
@@ -1,4 +1,4 @@
-import { Future, Result } from "@swan-io/boxed";
+import { okAsync } from "neverthrow";
 import { TypedAmqpWorker, defineHandlers } from "@amqp-contract/worker";
 import { describe, expect, vi } from "vitest";
 import { it } from "@amqp-contract/testing/extension";
@@ -11,21 +11,23 @@ describe("Basic Order Processing Worker Integration", () => {
   }) => {
     // GIVEN
     const processedOrders: Array<unknown> = [];
-    const worker = await TypedAmqpWorker.create({
-      contract: orderContract,
-      handlers: defineHandlers(orderContract, {
-        processOrder: ({ payload }) => {
-          processedOrders.push(payload);
-          return Future.value(Result.Ok(undefined));
-        },
-        notifyOrder: () => Future.value(Result.Ok(undefined)),
-        shipOrder: () => Future.value(Result.Ok(undefined)),
-        handleUrgentOrder: () => Future.value(Result.Ok(undefined)),
+    const worker = (
+      await TypedAmqpWorker.create({
+        contract: orderContract,
+        handlers: defineHandlers(orderContract, {
+          processOrder: ({ payload }) => {
+            processedOrders.push(payload);
+            return okAsync(undefined);
+          },
+          notifyOrder: () => okAsync(undefined),
+          shipOrder: () => okAsync(undefined),
+          handleUrgentOrder: () => okAsync(undefined),
 
-        handleFailedOrders: () => Future.value(Result.Ok(undefined)),
-      }),
-      urls: [amqpConnectionUrl],
-    }).resultToPromise();
+          handleFailedOrders: () => okAsync(undefined),
+        }),
+        urls: [amqpConnectionUrl],
+      })
+    )._unsafeUnwrap();
 
     try {
       const newOrder = {
@@ -51,7 +53,7 @@ describe("Basic Order Processing Worker Integration", () => {
       });
       expect(processedOrders).toEqual([newOrder]);
     } finally {
-      await worker.close().resultToPromise();
+      (await worker.close())._unsafeUnwrap();
     }
   });
 
@@ -61,21 +63,22 @@ describe("Basic Order Processing Worker Integration", () => {
   }) => {
     // GIVEN
     const notifications: Array<unknown> = [];
-    const worker = await TypedAmqpWorker.create({
+    const workerResult = await TypedAmqpWorker.create({
       contract: orderContract,
       handlers: defineHandlers(orderContract, {
-        processOrder: () => Future.value(Result.Ok(undefined)),
+        processOrder: () => okAsync(undefined),
         notifyOrder: ({ payload }) => {
           notifications.push(payload);
-          return Future.value(Result.Ok(undefined));
+          return okAsync(undefined);
         },
-        shipOrder: () => Future.value(Result.Ok(undefined)),
-        handleUrgentOrder: () => Future.value(Result.Ok(undefined)),
+        shipOrder: () => okAsync(undefined),
+        handleUrgentOrder: () => okAsync(undefined),
 
-        handleFailedOrders: () => Future.value(Result.Ok(undefined)),
+        handleFailedOrders: () => okAsync(undefined),
       }),
       urls: [amqpConnectionUrl],
-    }).resultToPromise();
+    });
+    const worker = workerResult._unsafeUnwrap();
 
     try {
       // WHEN
@@ -112,7 +115,7 @@ describe("Basic Order Processing Worker Integration", () => {
       });
       expect(notifications.length).toBeGreaterThanOrEqual(2);
     } finally {
-      await worker.close().resultToPromise();
+      (await worker.close())._unsafeUnwrap();
     }
   });
 
@@ -123,24 +126,25 @@ describe("Basic Order Processing Worker Integration", () => {
     // GIVEN
     const processedOrders: Array<unknown> = [];
     const notifications: Array<unknown> = [];
-    const worker = await TypedAmqpWorker.create({
+    const workerResult = await TypedAmqpWorker.create({
       contract: orderContract,
       handlers: defineHandlers(orderContract, {
         processOrder: ({ payload }) => {
           processedOrders.push(payload);
-          return Future.value(Result.Ok(undefined));
+          return okAsync(undefined);
         },
         notifyOrder: ({ payload }) => {
           notifications.push(payload);
-          return Future.value(Result.Ok(undefined));
+          return okAsync(undefined);
         },
-        shipOrder: () => Future.value(Result.Ok(undefined)),
-        handleUrgentOrder: () => Future.value(Result.Ok(undefined)),
+        shipOrder: () => okAsync(undefined),
+        handleUrgentOrder: () => okAsync(undefined),
 
-        handleFailedOrders: () => Future.value(Result.Ok(undefined)),
+        handleFailedOrders: () => okAsync(undefined),
       }),
       urls: [amqpConnectionUrl],
-    }).resultToPromise();
+    });
+    const worker = workerResult._unsafeUnwrap();
 
     try {
       const newOrder = {
@@ -167,7 +171,7 @@ describe("Basic Order Processing Worker Integration", () => {
       expect(processedOrders.length).toBeGreaterThanOrEqual(1);
       expect(notifications.length).toBeGreaterThan(0); // Receives all events
     } finally {
-      await worker.close().resultToPromise();
+      (await worker.close())._unsafeUnwrap();
     }
   });
 });

--- a/examples/basic-order-processing-worker/src/index.ts
+++ b/examples/basic-order-processing-worker/src/index.ts
@@ -1,6 +1,6 @@
 import { orderContract } from "@amqp-contract-examples/basic-order-processing-contract";
 import { RetryableError, TypedAmqpWorker, defineHandlers } from "@amqp-contract/worker";
-import { Future } from "@swan-io/boxed";
+import { ResultAsync } from "neverthrow";
 import pino from "pino";
 import { z } from "zod";
 
@@ -23,7 +23,7 @@ const logger = pino({
 
 async function main() {
   // Create type-safe worker with handlers for each consumer
-  const worker = await TypedAmqpWorker.create({
+  const workerResult = await TypedAmqpWorker.create({
     contract: orderContract,
     handlers: defineHandlers(orderContract, {
       // Handler for processing NEW orders (order.created)
@@ -43,11 +43,12 @@ async function main() {
           "[PROCESSING] New order received",
         );
 
-        return Future.fromPromise(new Promise<void>((resolve) => setTimeout(resolve, 500)))
-          .mapOk(() => {
-            logger.info({ orderId: payload.orderId }, "Order processed successfully");
-          })
-          .mapError((e) => new RetryableError("Processing failed", e));
+        return ResultAsync.fromPromise(
+          new Promise<void>((resolve) => setTimeout(resolve, 500)),
+          (e) => new RetryableError("Processing failed", e),
+        ).map(() => {
+          logger.info({ orderId: payload.orderId }, "Order processed successfully");
+        });
       },
 
       // Handler for ALL order notifications (order.#)
@@ -77,11 +78,12 @@ async function main() {
           );
         }
 
-        return Future.fromPromise(new Promise<void>((resolve) => setTimeout(resolve, 300)))
-          .mapOk(() => {
-            logger.info("Notification sent");
-          })
-          .mapError((e) => new RetryableError("Notification failed", e));
+        return ResultAsync.fromPromise(
+          new Promise<void>((resolve) => setTimeout(resolve, 300)),
+          (e) => new RetryableError("Notification failed", e),
+        ).map(() => {
+          logger.info("Notification sent");
+        });
       },
 
       // Handler for SHIPPED orders (order.shipped)
@@ -95,11 +97,12 @@ async function main() {
           "[SHIPPING] Shipment notification received",
         );
 
-        return Future.fromPromise(new Promise<void>((resolve) => setTimeout(resolve, 400)))
-          .mapOk(() => {
-            logger.info({ orderId: payload.orderId }, "Shipping label prepared");
-          })
-          .mapError((e) => new RetryableError("Shipping failed", e));
+        return ResultAsync.fromPromise(
+          new Promise<void>((resolve) => setTimeout(resolve, 400)),
+          (e) => new RetryableError("Shipping failed", e),
+        ).map(() => {
+          logger.info({ orderId: payload.orderId }, "Shipping label prepared");
+        });
       },
 
       // Handler for URGENT orders (order.*.urgent)
@@ -113,11 +116,12 @@ async function main() {
           "[URGENT] Priority order update received!",
         );
 
-        return Future.fromPromise(new Promise<void>((resolve) => setTimeout(resolve, 200)))
-          .mapOk(() => {
-            logger.warn({ orderId: payload.orderId }, "Urgent update handled");
-          })
-          .mapError((e) => new RetryableError("Urgent handling failed", e));
+        return ResultAsync.fromPromise(
+          new Promise<void>((resolve) => setTimeout(resolve, 200)),
+          (e) => new RetryableError("Urgent handling failed", e),
+        ).map(() => {
+          logger.warn({ orderId: payload.orderId }, "Urgent update handled");
+        });
       },
 
       // Handler for FAILED orders (from dead letter exchange)
@@ -132,17 +136,17 @@ async function main() {
           "[DLX] Failed order received from dead letter exchange",
         );
 
-        return Future.fromPromise(new Promise<void>((resolve) => setTimeout(resolve, 200)))
-          .mapOk(() => {
-            logger.error({ orderId: payload.orderId }, "Failed order logged for investigation");
-          })
-          .mapError((e) => new RetryableError("Failed order handling failed", e));
+        return ResultAsync.fromPromise(
+          new Promise<void>((resolve) => setTimeout(resolve, 200)),
+          (e) => new RetryableError("Failed order handling failed", e),
+        ).map(() => {
+          logger.error({ orderId: payload.orderId }, "Failed order logged for investigation");
+        });
       },
     }),
     urls: [env.AMQP_URL],
-  })
-    .tapError((error) => logger.error({ error }, "Failed to create worker"))
-    .resultToPromise();
+  }).orTee((error) => logger.error({ error }, "Failed to create worker"));
+  const worker = workerResult._unsafeUnwrap();
 
   logger.info("Worker ready, waiting for messages...");
   logger.info("=".repeat(60));
@@ -160,7 +164,7 @@ async function main() {
   // Handle graceful shutdown
   process.on("SIGINT", async () => {
     logger.info("Shutting down worker...");
-    await worker.close().resultToPromise();
+    (await worker.close())._unsafeUnwrap();
     process.exit(0);
   });
 }

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -23,17 +23,22 @@ import { TypedAmqpClient } from "@amqp-contract/client";
 import { contract } from "./contract";
 
 // Create client from contract (automatically connects and waits for connection)
-const client = await TypedAmqpClient.create({
-  contract,
-  urls: ["amqp://localhost"],
-});
+const client = (
+  await TypedAmqpClient.create({
+    contract,
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 
 // Publish message with explicit error handling
 const result = await client.publish("orderCreated", {
   orderId: "ORD-123",
   amount: 99.99,
 });
-console.log("Published successfully");
+result.match(
+  () => console.log("Published successfully"),
+  (error) => console.error("Publish failed:", error),
+);
 
 // Clean up
 await client.close();

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -26,16 +26,13 @@ import { contract } from "./contract";
 const client = await TypedAmqpClient.create({
   contract,
   urls: ["amqp://localhost"],
-}).resultToPromise();
+});
 
 // Publish message with explicit error handling
-const result = await client
-  .publish("orderCreated", {
-    orderId: "ORD-123",
-    amount: 99.99,
-  })
-  .resultToPromise();
-
+const result = await client.publish("orderCreated", {
+  orderId: "ORD-123",
+  amount: 99.99,
+});
 console.log("Published successfully");
 
 // Clean up
@@ -44,7 +41,7 @@ await client.close();
 
 ## Error Handling
 
-The client uses `Result` types from [@swan-io/boxed](https://github.com/swan-io/boxed) for explicit error handling. Runtime errors are part of the type signature:
+The client uses `Result` types from [neverthrow](https://github.com/supermacro/neverthrow) for explicit error handling. Runtime errors are part of the type signature:
 
 ```typescript
 publish(): Result<boolean, TechnicalError | MessageValidationError>

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -61,7 +61,7 @@
     "@amqp-contract/contract": "workspace:*",
     "@amqp-contract/core": "workspace:*",
     "@standard-schema/spec": "catalog:",
-    "@swan-io/boxed": "catalog:",
+    "neverthrow": "catalog:",
     "ts-pattern": "catalog:"
   },
   "devDependencies": {

--- a/packages/client/src/__tests__/client.spec.ts
+++ b/packages/client/src/__tests__/client.spec.ts
@@ -132,10 +132,10 @@ describe("AmqpClient Integration", () => {
       });
 
       // THEN
-      expect(result).toMatchObject({
-        tag: "Error",
-        error: { name: "MessageValidationError" },
-      });
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error).toMatchObject({ name: "MessageValidationError" });
+      }
     });
 
     it("should publish messages with default values", async ({ clientFactory, initConsumer }) => {

--- a/packages/client/src/__tests__/client.spec.ts
+++ b/packages/client/src/__tests__/client.spec.ts
@@ -9,7 +9,7 @@ import {
   defineQueue,
 } from "@amqp-contract/contract";
 import { it as baseIt } from "@amqp-contract/testing/extension";
-import { Result } from "@swan-io/boxed";
+import { err, ok } from "neverthrow";
 import { describe, expect } from "vitest";
 import { z } from "zod";
 import { CreateClientOptions, TypedAmqpClient } from "../client.js";
@@ -30,11 +30,13 @@ const it = baseIt.extend<{
           contract: TContract,
           options?: Omit<CreateClientOptions<TContract>, "contract" | "urls">,
         ) => {
-          const client = await TypedAmqpClient.create({
-            contract,
-            urls: [amqpConnectionUrl],
-            ...options,
-          }).resultToPromise();
+          const client = (
+            await TypedAmqpClient.create({
+              contract,
+              urls: [amqpConnectionUrl],
+              ...options,
+            })
+          )._unsafeUnwrap();
 
           clients.push(client);
           return client;
@@ -45,7 +47,7 @@ const it = baseIt.extend<{
       await Promise.all(
         clients.map(async (client) => {
           try {
-            await client.close().resultToPromise();
+            (await client.close())._unsafeUnwrap();
           } catch (error) {
             // Swallow errors during cleanup to avoid unhandled rejections
             // eslint-disable-next-line no-console
@@ -93,7 +95,7 @@ describe("AmqpClient Integration", () => {
       });
 
       // THEN
-      expect(result).toEqual(Result.Ok(undefined));
+      expect(result).toEqual(ok(undefined));
 
       await expect(pendingMessages()).resolves.toEqual([
         expect.objectContaining({
@@ -169,7 +171,7 @@ describe("AmqpClient Integration", () => {
       });
 
       // THEN
-      expect(result).toEqual(Result.Ok(undefined));
+      expect(result).toEqual(ok(undefined));
 
       await expect(pendingMessages()).resolves.toEqual([
         expect.objectContaining({
@@ -214,7 +216,7 @@ describe("AmqpClient Integration", () => {
       );
 
       // THEN
-      expect(result).toEqual(Result.Ok(undefined));
+      expect(result).toEqual(ok(undefined));
 
       await expect(pendingMessages()).resolves.toEqual([
         expect.objectContaining({
@@ -256,7 +258,7 @@ describe("AmqpClient Integration", () => {
       const result = await client.publish("testPublisher", { content: "default publish" });
 
       // THEN
-      expect(result).toEqual(Result.Ok(undefined));
+      expect(result).toEqual(ok(undefined));
 
       await expect(pendingMessages()).resolves.toEqual([
         expect.objectContaining({
@@ -268,7 +270,7 @@ describe("AmqpClient Integration", () => {
         }),
       ]);
 
-      await client.close().resultToPromise();
+      (await client.close())._unsafeUnwrap();
     });
 
     it("should override default publish options with publish-specific options", async ({
@@ -309,7 +311,7 @@ describe("AmqpClient Integration", () => {
       );
 
       // THEN
-      expect(result).toEqual(Result.Ok(undefined));
+      expect(result).toEqual(ok(undefined));
 
       await expect(pendingMessages()).resolves.toEqual([
         expect.objectContaining({
@@ -322,7 +324,7 @@ describe("AmqpClient Integration", () => {
         }),
       ]);
 
-      await client.close().resultToPromise();
+      (await client.close())._unsafeUnwrap();
     });
   });
 
@@ -578,9 +580,7 @@ describe("AmqpClient Integration", () => {
       });
 
       // THEN
-      expect(result).toEqual(
-        Result.Error(new MessageValidationError("testPublisher", expect.any(Array))),
-      );
+      expect(result).toEqual(err(new MessageValidationError("testPublisher", expect.any(Array))));
     });
   });
 });

--- a/packages/client/src/client-cleanup.spec.ts
+++ b/packages/client/src/client-cleanup.spec.ts
@@ -17,9 +17,9 @@ describe("TypedAmqpClient.create cleanup", () => {
       contract,
       urls: ["amqp://localhost:1"],
       connectTimeoutMs: 200,
-    }).toPromise();
+    });
 
-    expect(result.isError()).toBe(true);
+    expect(result.isErr()).toBe(true);
     expect(_getConnectionCountForTesting()).toBe(0);
   });
 });

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -20,8 +20,8 @@ import {
   startPublishSpan,
 } from "@amqp-contract/core";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
-import { Future, Result } from "@swan-io/boxed";
 import type { AmqpConnectionManagerOptions, ConnectionUrl } from "amqp-connection-manager";
+import { err, errAsync, ok, okAsync, Result, ResultAsync } from "neverthrow";
 import { randomUUID } from "node:crypto";
 import { compressBuffer } from "./compression.js";
 import { MessageValidationError, RpcCancelledError, RpcTimeoutError } from "./errors.js";
@@ -91,7 +91,7 @@ export type CreateClientOptions<TContract extends ContractDefinition> = {
   defaultPublishOptions?: PublishOptions | undefined;
   /**
    * Maximum time in ms to wait for the AMQP connection to become ready before
-   * `create()` resolves to `Result.Error<TechnicalError>`. Defaults to 30s
+   * `create()` resolves to an `err(TechnicalError)`. Defaults to 30s
    * (the {@link AmqpClient}'s `DEFAULT_CONNECT_TIMEOUT_MS`). Pass `null` to
    * disable the timeout and let amqp-connection-manager retry indefinitely.
    */
@@ -104,8 +104,8 @@ export type CreateClientOptions<TContract extends ContractDefinition> = {
 export type CallOptions = {
   /**
    * Maximum time in ms to wait for an RPC reply. If exceeded, the call resolves
-   * to `Result.Error<RpcTimeoutError>` and the in-memory correlation entry is
-   * cleared. A late reply arriving after the timeout is silently dropped.
+   * to `err(RpcTimeoutError)` and the in-memory correlation entry is cleared.
+   * A late reply arriving after the timeout is silently dropped.
    *
    * Required: RPC without a timeout is a footgun.
    */
@@ -160,7 +160,7 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
     logger,
     telemetry,
     connectTimeoutMs,
-  }: CreateClientOptions<TContract>): Future<Result<TypedAmqpClient<TContract>, TechnicalError>> {
+  }: CreateClientOptions<TContract>): ResultAsync<TypedAmqpClient<TContract>, TechnicalError> {
     const client = new TypedAmqpClient(
       contract,
       new AmqpClient(contract, { urls, connectionOptions, connectTimeoutMs }),
@@ -169,24 +169,25 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
       telemetry ?? defaultTelemetryProvider,
     );
 
-    return client
+    const setup = client
       .waitForConnectionReady()
-      .flatMapOk(() => client.setupReplyConsumerIfNeeded())
-      .flatMap((result) =>
-        result.match({
-          Ok: () => Future.value(Result.Ok<TypedAmqpClient<TContract>, TechnicalError>(client)),
-          // Release the AmqpClient's connection ref-count so a failed create() does not leak.
-          Error: (error) =>
-            client
-              .close()
-              .tapError((closeError) => {
-                logger?.warn("Failed to close client after connection failure", {
-                  error: closeError,
-                });
-              })
-              .map(() => Result.Error<TypedAmqpClient<TContract>, TechnicalError>(error)),
-        }),
-      );
+      .andThen(() => client.setupReplyConsumerIfNeeded());
+
+    return new ResultAsync<TypedAmqpClient<TContract>, TechnicalError>(
+      (async () => {
+        const setupResult = await setup;
+        if (setupResult.isOk()) {
+          return ok(client);
+        }
+        const closeResult = await client.close();
+        if (closeResult.isErr()) {
+          logger?.warn("Failed to close client after connection failure", {
+            error: closeResult.error,
+          });
+        }
+        return err(setupResult.error);
+      })(),
+    );
   }
 
   /**
@@ -194,18 +195,18 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
    * once. Replies for every in-flight call arrive on this single consumer and
    * are demultiplexed by `correlationId`.
    */
-  private setupReplyConsumerIfNeeded(): Future<Result<void, TechnicalError>> {
+  private setupReplyConsumerIfNeeded(): ResultAsync<void, TechnicalError> {
     const rpcs = this.contract.rpcs ?? {};
     if (Object.keys(rpcs).length === 0) {
-      return Future.value(Result.Ok(undefined));
+      return okAsync(undefined);
     }
 
     return this.amqpClient
       .consume(DIRECT_REPLY_TO, (msg) => this.handleRpcReply(msg), { noAck: true })
-      .tapOk((tag) => {
+      .andTee((tag) => {
         this.replyConsumerTag = tag;
       })
-      .mapOk(() => undefined);
+      .map(() => undefined);
   }
 
   /**
@@ -244,9 +245,7 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
       parsed = JSON.parse(msg.content.toString());
     } catch (error: unknown) {
       pending.resolve(
-        Result.Error(
-          new TechnicalError(`Failed to parse RPC reply JSON for "${pending.rpcName}"`, error),
-        ),
+        err(new TechnicalError(`Failed to parse RPC reply JSON for "${pending.rpcName}"`, error)),
       );
       return;
     }
@@ -259,9 +258,7 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
       rawValidation = pending.responseSchema["~standard"].validate(parsed);
     } catch (error: unknown) {
       pending.resolve(
-        Result.Error(
-          new TechnicalError(`RPC reply validation threw for "${pending.rpcName}"`, error),
-        ),
+        err(new TechnicalError(`RPC reply validation threw for "${pending.rpcName}"`, error)),
       );
       return;
     }
@@ -271,25 +268,21 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
     validationPromise.then(
       (validation) => {
         if (validation.issues) {
-          pending.resolve(
-            Result.Error(new MessageValidationError(pending.rpcName, validation.issues)),
-          );
+          pending.resolve(err(new MessageValidationError(pending.rpcName, validation.issues)));
           return;
         }
-        pending.resolve(Result.Ok(validation.value));
+        pending.resolve(ok(validation.value));
       },
       (error: unknown) => {
         pending.resolve(
-          Result.Error(
-            new TechnicalError(`RPC reply validation threw for "${pending.rpcName}"`, error),
-          ),
+          err(new TechnicalError(`RPC reply validation threw for "${pending.rpcName}"`, error)),
         );
       },
     );
   }
 
   /**
-   * Publish a message using a defined publisher
+   * Publish a message using a defined publisher.
    *
    * @param publisherName - The name of the publisher to use
    * @param message - The message to publish
@@ -299,18 +292,12 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
    * If `options.compression` is specified, the message will be compressed before publishing
    * and the `contentEncoding` property will be set automatically. Any `contentEncoding`
    * value already in options will be overwritten by the compression algorithm.
-   *
-   * @returns Result.Ok(void) on success, or Result.Error with specific error on failure
-   */
-  /**
-   * Publish a message using a defined publisher.
-   * TypeScript guarantees publisher exists for valid publisher names.
    */
   publish<TName extends InferPublisherNames<TContract>>(
     publisherName: TName,
     message: ClientInferPublisherInput<TContract, TName>,
     options?: PublishOptions,
-  ): Future<Result<void, TechnicalError | MessageValidationError>> {
+  ): ResultAsync<void, TechnicalError | MessageValidationError> {
     const startTime = Date.now();
     // Non-null assertions safe: TypeScript guarantees these exist for valid TName
     const publisher = this.contract.publishers![publisherName as string]!;
@@ -321,24 +308,25 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
       [MessagingSemanticConventions.AMQP_PUBLISHER_NAME]: String(publisherName),
     });
 
-    const validateMessage = () => {
+    const validateMessage = (): ResultAsync<unknown, TechnicalError | MessageValidationError> => {
       const validationResult = publisher.message.payload["~standard"].validate(message);
-      return Future.fromPromise(
-        validationResult instanceof Promise ? validationResult : Promise.resolve(validationResult),
-      )
-        .mapError((error) => new TechnicalError(`Validation failed`, error))
-        .mapOkToResult((validation) => {
-          if (validation.issues) {
-            return Result.Error(
-              new MessageValidationError(String(publisherName), validation.issues),
-            );
-          }
-
-          return Result.Ok(validation.value);
-        });
+      const promise =
+        validationResult instanceof Promise ? validationResult : Promise.resolve(validationResult);
+      return ResultAsync.fromPromise(
+        promise,
+        (error): TechnicalError | MessageValidationError =>
+          new TechnicalError("Validation failed", error),
+      ).andThen((validation) => {
+        if (validation.issues) {
+          return err<unknown, TechnicalError | MessageValidationError>(
+            new MessageValidationError(String(publisherName), validation.issues),
+          );
+        }
+        return ok<unknown, TechnicalError | MessageValidationError>(validation.value);
+      });
     };
 
-    const publishMessage = (validatedMessage: unknown): Future<Result<void, TechnicalError>> => {
+    const publishMessage = (validatedMessage: unknown): ResultAsync<void, TechnicalError> => {
       // Merge default options with provided options
       const mergedOptions = { ...this.defaultPublishOptions, ...options };
 
@@ -347,26 +335,24 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
       const publishOptions: AmqpClientPublishOptions = { ...restOptions };
 
       // Prepare payload and options based on compression configuration
-      const preparePayload = (): Future<Result<Buffer | unknown, TechnicalError>> => {
+      const preparePayload = (): ResultAsync<Buffer | unknown, TechnicalError> => {
         if (compression) {
           // Compress the message payload
           const messageBuffer = Buffer.from(JSON.stringify(validatedMessage));
           publishOptions.contentEncoding = compression;
-
           return compressBuffer(messageBuffer, compression);
         }
 
         // No compression: use the channel's built-in JSON serialization
-        return Future.value(Result.Ok(validatedMessage));
+        return okAsync(validatedMessage);
       };
 
-      // Publish the prepared payload
-      return preparePayload().flatMapOk((payload) =>
+      return preparePayload().andThen((payload) =>
         this.amqpClient
           .publish(publisher.exchange.name, publisher.routingKey ?? "", payload, publishOptions)
-          .mapOkToResult((published) => {
+          .andThen((published) => {
             if (!published) {
-              return Result.Error(
+              return err<void, TechnicalError>(
                 new TechnicalError(
                   `Failed to publish message for publisher "${String(publisherName)}": Channel rejected the message (buffer full or other channel issue)`,
                 ),
@@ -380,20 +366,19 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
               compressed: !!compression,
             });
 
-            return Result.Ok(undefined);
+            return ok<void, TechnicalError>(undefined);
           }),
       );
     };
 
-    // Validate message using schema
     return validateMessage()
-      .flatMapOk((validatedMessage) => publishMessage(validatedMessage))
-      .tapOk(() => {
+      .andThen((validatedMessage) => publishMessage(validatedMessage))
+      .andTee(() => {
         const durationMs = Date.now() - startTime;
         endSpanSuccess(span);
         recordPublishMetric(this.telemetry, exchange.name, routingKey, true, durationMs);
       })
-      .tapError((error) => {
+      .orTee((error) => {
         const durationMs = Date.now() - startTime;
         endSpanError(span, error);
         recordPublishMetric(this.telemetry, exchange.name, routingKey, false, durationMs);
@@ -406,23 +391,13 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
    * The request payload is validated against the RPC's request schema, then
    * published to the AMQP default exchange with the server's queue name as
    * routing key, `replyTo` set to `amq.rabbitmq.reply-to`, and a fresh UUID
-   * `correlationId`. The returned Future resolves once a matching reply
+   * `correlationId`. The returned ResultAsync resolves once a matching reply
    * arrives and validates against the response schema, or once `timeoutMs`
    * elapses (whichever comes first).
    *
-   * @typeParam TName - An RPC name from `contract.rpcs`.
-   * @param rpcName - The RPC name from the contract.
-   * @param request - The request payload, validated against the request schema.
-   * @param options - Per-call options. `timeoutMs` is required.
-   *
-   * @returns `Result.Ok(response)` on a successful round-trip; `Result.Error`
-   *   on validation, transport, timeout, or cancel.
-   *
    * @example
    * ```typescript
-   * const result = await client
-   *   .call('calculate', { a: 1, b: 2 }, { timeoutMs: 5_000 })
-   *   .toPromise();
+   * const result = await client.call('calculate', { a: 1, b: 2 }, { timeoutMs: 5_000 });
    * if (result.isOk()) console.log(result.value.sum); // 3
    * ```
    */
@@ -430,16 +405,13 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
     rpcName: TName,
     request: ClientInferRpcRequestInput<TContract, TName>,
     options: CallOptions,
-  ): Future<
-    Result<
-      ClientInferRpcResponseOutput<TContract, TName>,
-      TechnicalError | MessageValidationError | RpcTimeoutError | RpcCancelledError
-    >
+  ): ResultAsync<
+    ClientInferRpcResponseOutput<TContract, TName>,
+    TechnicalError | MessageValidationError | RpcTimeoutError | RpcCancelledError
   > {
-    type CallResult = Result<
-      ClientInferRpcResponseOutput<TContract, TName>,
-      TechnicalError | MessageValidationError | RpcTimeoutError | RpcCancelledError
-    >;
+    type ResponseType = ClientInferRpcResponseOutput<TContract, TName>;
+    type CallError = TechnicalError | MessageValidationError | RpcTimeoutError | RpcCancelledError;
+    type CallResult = Result<ResponseType, CallError>;
 
     // setTimeout truncates fractional ms and clamps anything outside the
     // 32-bit signed integer range (~24.8 days) to 1ms, so reject those up
@@ -451,12 +423,10 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
       options.timeoutMs <= 0 ||
       options.timeoutMs > TIMEOUT_MAX_MS
     ) {
-      return Future.value(
-        Result.Error(
-          new TechnicalError(
-            `Invalid timeoutMs for RPC call to "${String(rpcName)}": expected a finite positive number ≤ ${TIMEOUT_MAX_MS}, got ${String(options.timeoutMs)}`,
-          ),
-        ) as CallResult,
+      return errAsync<ResponseType, CallError>(
+        new TechnicalError(
+          `Invalid timeoutMs for RPC call to "${String(rpcName)}": expected a finite positive number ≤ ${TIMEOUT_MAX_MS}, got ${String(options.timeoutMs)}`,
+        ),
       );
     }
 
@@ -473,52 +443,57 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
     });
 
     const correlationId = randomUUID();
-    const callFuture = Future.make<CallResult>((resolve) => {
-      const timer = setTimeout(() => {
-        const pending = this.pendingCalls.get(correlationId);
-        if (!pending) return;
-        this.pendingCalls.delete(correlationId);
-        resolve(Result.Error(new RpcTimeoutError(String(rpcName), options.timeoutMs)));
-      }, options.timeoutMs);
 
-      this.pendingCalls.set(correlationId, {
-        rpcName: String(rpcName),
-        responseSchema,
-        resolve: resolve as PendingCall["resolve"],
-        timer,
-      });
+    // Set up the reply future + pending entry up front so a reply that arrives
+    // racing the publish round-trip can find a slot. Cleanup on preflight
+    // failure happens in the `.orElse` below.
+    let resolveCall!: (result: CallResult) => void;
+    const callPromise = new Promise<CallResult>((res) => {
+      resolveCall = res;
+    });
+    const callResultAsync = new ResultAsync<ResponseType, CallError>(callPromise);
+
+    const timer = setTimeout(() => {
+      if (!this.pendingCalls.has(correlationId)) return;
+      this.pendingCalls.delete(correlationId);
+      resolveCall(err(new RpcTimeoutError(String(rpcName), options.timeoutMs)));
+    }, options.timeoutMs);
+
+    this.pendingCalls.set(correlationId, {
+      rpcName: String(rpcName),
+      responseSchema,
+      resolve: resolveCall as PendingCall["resolve"],
+      timer,
     });
 
-    const validateRequest = (): Future<
-      Result<unknown, TechnicalError | MessageValidationError>
-    > => {
+    const validateRequest = (): ResultAsync<unknown, TechnicalError | MessageValidationError> => {
       // Wrap the validate call — a Standard Schema implementation may throw
-      // synchronously, and that throw would otherwise escape the Future chain
-      // and leave the pending-call entry/timer dangling until timeout.
+      // synchronously, and that throw would otherwise escape the chain and
+      // leave the pending-call entry/timer dangling until timeout.
       let rawValidation: ReturnType<StandardSchemaV1["~standard"]["validate"]>;
       try {
         rawValidation = requestSchema["~standard"].validate(request);
       } catch (error: unknown) {
-        return Future.value(
-          Result.Error<unknown, TechnicalError | MessageValidationError>(
-            new TechnicalError("RPC request validation threw", error),
-          ),
+        return errAsync<unknown, TechnicalError | MessageValidationError>(
+          new TechnicalError("RPC request validation threw", error),
         );
       }
       const validationPromise =
         rawValidation instanceof Promise ? rawValidation : Promise.resolve(rawValidation);
-      return Future.fromPromise(validationPromise)
-        .mapError((error) => new TechnicalError("RPC request validation threw", error))
-        .mapOkToResult((validation) =>
-          validation.issues
-            ? Result.Error<unknown, TechnicalError | MessageValidationError>(
-                new MessageValidationError(String(rpcName), validation.issues),
-              )
-            : Result.Ok<unknown, TechnicalError | MessageValidationError>(validation.value),
-        );
+      return ResultAsync.fromPromise(
+        validationPromise,
+        (error): TechnicalError | MessageValidationError =>
+          new TechnicalError("RPC request validation threw", error),
+      ).andThen((validation) =>
+        validation.issues
+          ? err<unknown, TechnicalError | MessageValidationError>(
+              new MessageValidationError(String(rpcName), validation.issues),
+            )
+          : ok<unknown, TechnicalError | MessageValidationError>(validation.value),
+      );
     };
 
-    const publishRequest = (validatedRequest: unknown): Future<Result<void, TechnicalError>> => {
+    const publishRequest = (validatedRequest: unknown): ResultAsync<void, TechnicalError> => {
       // Merge `defaultPublishOptions` (persistent, priority, headers, …) with
       // the per-call options, then layer the RPC-managed fields on top so they
       // cannot be overridden. `compression` is intentionally dropped: RPC v1
@@ -535,10 +510,10 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
       };
       return this.amqpClient
         .publish("", queueName, validatedRequest, publishOptions)
-        .mapOkToResult((published) =>
+        .andThen((published) =>
           published
-            ? Result.Ok<void, TechnicalError>(undefined)
-            : Result.Error<void, TechnicalError>(
+            ? ok<void, TechnicalError>(undefined)
+            : err<void, TechnicalError>(
                 new TechnicalError(
                   `Failed to publish RPC request for "${String(rpcName)}": channel buffer full`,
                 ),
@@ -546,28 +521,26 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
         );
     };
 
-    // Validate the request, publish it, and await the reply (or timeout).
     return validateRequest()
-      .flatMapOk((validated) => publishRequest(validated))
-      .flatMap((preflight) => {
-        if (preflight.isError()) {
-          // Publish/validation failed before the request hit the broker — clean
-          // up the pending entry so the timer never fires.
-          const pending = this.pendingCalls.get(correlationId);
-          if (pending) {
-            clearTimeout(pending.timer);
-            this.pendingCalls.delete(correlationId);
-          }
-          return Future.value(Result.Error(preflight.error) as CallResult);
+      .andThen((validated) => publishRequest(validated))
+      .andThen(() => callResultAsync)
+      .orElse((error: CallError) => {
+        // If preflight failed (validate or publish), the pending entry still
+        // exists and the timer is alive. Clean both up so the call doesn't
+        // leak. Timer-fired errors and reply-resolved errors have already
+        // cleaned the entry, so the .has() check guards against double cleanup.
+        if (this.pendingCalls.has(correlationId)) {
+          clearTimeout(timer);
+          this.pendingCalls.delete(correlationId);
         }
-        return callFuture;
+        return errAsync<ResponseType, CallError>(error);
       })
-      .tapOk(() => {
+      .andTee(() => {
         const durationMs = Date.now() - startTime;
         endSpanSuccess(span);
         recordPublishMetric(this.telemetry, "", queueName, true, durationMs);
       })
-      .tapError((error) => {
+      .orTee((error) => {
         const durationMs = Date.now() - startTime;
         endSpanError(span, error);
         recordPublishMetric(this.telemetry, "", queueName, false, durationMs);
@@ -578,24 +551,25 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
    * Close the channel and connection. Cancels the reply consumer (if any) and
    * rejects every in-flight RPC call with `RpcCancelledError`.
    */
-  close(): Future<Result<void, TechnicalError>> {
+  close(): ResultAsync<void, TechnicalError> {
     // Reject pending calls first — once close() runs, no reply will arrive.
     for (const [, pending] of this.pendingCalls) {
       clearTimeout(pending.timer);
-      pending.resolve(Result.Error(new RpcCancelledError(pending.rpcName)));
+      pending.resolve(err(new RpcCancelledError(pending.rpcName)));
     }
     this.pendingCalls.clear();
 
-    const cancelReply = this.replyConsumerTag
-      ? this.amqpClient.cancel(this.replyConsumerTag).tapError((error) => {
+    const cancelReply: ResultAsync<void, TechnicalError> = this.replyConsumerTag
+      ? this.amqpClient.cancel(this.replyConsumerTag).orElse((error) => {
           this.logger?.warn("Failed to cancel RPC reply consumer during close", { error });
+          return ok<void, TechnicalError>(undefined);
         })
-      : Future.value(Result.Ok<void, TechnicalError>(undefined));
+      : okAsync<void, TechnicalError>(undefined);
 
-    return cancelReply.flatMap(() => this.amqpClient.close()).mapOk(() => undefined);
+    return cancelReply.andThen(() => this.amqpClient.close());
   }
 
-  private waitForConnectionReady(): Future<Result<void, TechnicalError>> {
+  private waitForConnectionReady(): ResultAsync<void, TechnicalError> {
     return this.amqpClient.waitForConnect();
   }
 }

--- a/packages/client/src/compression.spec.ts
+++ b/packages/client/src/compression.spec.ts
@@ -10,7 +10,7 @@ describe("Compression utilities", () => {
       const gunzipAsync = promisify(gunzip);
 
       const testData = Buffer.from(JSON.stringify({ message: "Hello, World!" }));
-      const compressed = await compressBuffer(testData, "gzip").resultToPromise();
+      const compressed = (await compressBuffer(testData, "gzip"))._unsafeUnwrap();
       const decompressed = await gunzipAsync(compressed);
 
       expect(decompressed).toEqual(testData);
@@ -22,7 +22,7 @@ describe("Compression utilities", () => {
       const inflateAsync = promisify(inflate);
 
       const testData = Buffer.from(JSON.stringify({ message: "Hello, World!" }));
-      const compressed = await compressBuffer(testData, "deflate").resultToPromise();
+      const compressed = (await compressBuffer(testData, "deflate"))._unsafeUnwrap();
       const decompressed = await inflateAsync(compressed);
 
       expect(decompressed).toEqual(testData);
@@ -40,7 +40,7 @@ describe("Compression utilities", () => {
         }),
       );
 
-      const compressed = await compressBuffer(largeData, "gzip").resultToPromise();
+      const compressed = (await compressBuffer(largeData, "gzip"))._unsafeUnwrap();
 
       // Compressed data should be significantly smaller
       expect(compressed.length).toBeLessThan(largeData.length);

--- a/packages/client/src/compression.ts
+++ b/packages/client/src/compression.ts
@@ -1,9 +1,9 @@
-import { Future, Result } from "@swan-io/boxed";
-import { deflate, gzip } from "node:zlib";
 import type { CompressionAlgorithm } from "@amqp-contract/contract";
 import { TechnicalError } from "@amqp-contract/core";
-import { match } from "ts-pattern";
+import { ResultAsync } from "neverthrow";
+import { deflate, gzip } from "node:zlib";
 import { promisify } from "node:util";
+import { match } from "ts-pattern";
 
 const gzipAsync = promisify(gzip);
 const deflateAsync = promisify(deflate);
@@ -13,22 +13,24 @@ const deflateAsync = promisify(deflate);
  *
  * @param buffer - The buffer to compress
  * @param algorithm - The compression algorithm to use
- * @returns A Future with the compressed buffer or a TechnicalError
+ * @returns A ResultAsync resolving to the compressed buffer or a TechnicalError
  *
  * @internal
  */
 export function compressBuffer(
   buffer: Buffer,
   algorithm: CompressionAlgorithm,
-): Future<Result<Buffer, TechnicalError>> {
+): ResultAsync<Buffer, TechnicalError> {
   return match(algorithm)
     .with("gzip", () =>
-      Future.fromPromise(gzipAsync(buffer)).mapError(
+      ResultAsync.fromPromise(
+        gzipAsync(buffer),
         (error) => new TechnicalError("Failed to compress with gzip", error),
       ),
     )
     .with("deflate", () =>
-      Future.fromPromise(deflateAsync(buffer)).mapError(
+      ResultAsync.fromPromise(
+        deflateAsync(buffer),
         (error) => new TechnicalError("Failed to compress with deflate", error),
       ),
     )

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -34,7 +34,7 @@ export class RpcTimeoutError extends Error {
 /**
  * Returned from any in-flight RPC call when the client is closed before the
  * reply is received. The correlation map is cleared on close and every pending
- * caller's promise resolves with `Result.Error(RpcCancelledError)`.
+ * caller's promise resolves with `err(RpcCancelledError)`.
  */
 export class RpcCancelledError extends Error {
   constructor(public readonly rpcName: string) {

--- a/packages/client/tsdown.config.ts
+++ b/packages/client/tsdown.config.ts
@@ -1,9 +1,9 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  // Prevent @swan-io/boxed types from being inlined into the declaration files
-  // This ensures type compatibility across packages that use boxed types
-  external: ["@swan-io/boxed"],
+  // Prevent neverthrow types from being inlined into the declaration files.
+  // This ensures type compatibility across packages that re-export them.
+  external: ["neverthrow"],
   // Suppress warnings about bundled dependencies in declaration files
   inlineOnly: false,
 });

--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -102,7 +102,7 @@ const contract = defineContract({
 //   handlers: { calculate: ({ payload }) => okAsync({ sum: payload.a + payload.b }) }
 //
 // Client invokes with a required timeout:
-//   const result = await client.call("calculate", { a: 1, b: 2 }, { timeoutMs: 5_000 }).toPromise();
+//   const result = await client.call("calculate", { a: 1, b: 2 }, { timeoutMs: 5_000 });
 ```
 
 **Benefits:**

--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -99,7 +99,7 @@ const contract = defineContract({
 });
 
 // Server handler returns the response value, not void:
-//   handlers: { calculate: ({ payload }) => Future.value(Result.Ok({ sum: payload.a + payload.b })) }
+//   handlers: { calculate: ({ payload }) => okAsync({ sum: payload.a + payload.b }) }
 //
 // Client invokes with a required timeout:
 //   const result = await client.call("calculate", { a: 1, b: 2 }, { timeoutMs: 5_000 }).toPromise();

--- a/packages/contract/src/builder/rpc.ts
+++ b/packages/contract/src/builder/rpc.ts
@@ -35,7 +35,7 @@ import type { MessageDefinition, QueueEntry, RpcDefinition } from "../types.js";
  * //   handlers: { calculate: ({ payload }) => okAsync({ sum: payload.a + payload.b }) }
  *
  * // Client: typed call with required timeout
- * //   const result = await client.call('calculate', { a: 1, b: 2 }, { timeoutMs: 5_000 }).toPromise();
+ * //   const result = await client.call('calculate', { a: 1, b: 2 }, { timeoutMs: 5_000 });
  * ```
  */
 export function defineRpc<

--- a/packages/contract/src/builder/rpc.ts
+++ b/packages/contract/src/builder/rpc.ts
@@ -32,7 +32,7 @@ import type { MessageDefinition, QueueEntry, RpcDefinition } from "../types.js";
  * const contract = defineContract({ rpcs: { calculate } });
  *
  * // Server (worker): handler returns the typed response
- * //   handlers: { calculate: ({ payload }) => Future.value(Result.Ok({ sum: payload.a + payload.b })) }
+ * //   handlers: { calculate: ({ payload }) => okAsync({ sum: payload.a + payload.b }) }
  *
  * // Client: typed call with required timeout
  * //   const result = await client.call('calculate', { a: 1, b: 2 }, { timeoutMs: 5_000 }).toPromise();

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -87,11 +87,13 @@ const logger: Logger = {
 // Pass the logger to client or worker
 import { TypedAmqpClient } from "@amqp-contract/client";
 
-const client = await TypedAmqpClient.create({
-  contract,
-  urls: ["amqp://localhost"],
-  logger, // Optional: logs published messages
-});
+const client = (
+  await TypedAmqpClient.create({
+    contract,
+    urls: ["amqp://localhost"],
+    logger, // Optional: logs published messages
+  })
+)._unsafeUnwrap();
 ```
 
 ## API

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,9 +59,9 @@
   },
   "dependencies": {
     "@amqp-contract/contract": "workspace:*",
-    "@swan-io/boxed": "catalog:",
     "amqp-connection-manager": "catalog:",
-    "amqplib": "catalog:"
+    "amqplib": "catalog:",
+    "neverthrow": "catalog:"
   },
   "devDependencies": {
     "@amqp-contract/testing": "workspace:*",

--- a/packages/core/src/__tests__/amqp-client.spec.ts
+++ b/packages/core/src/__tests__/amqp-client.spec.ts
@@ -35,14 +35,14 @@ describe("AmqpClient Integration", () => {
     });
 
     // Wait for setup to complete
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // THEN - Verify exchanges exist by checking them
     await expect(amqpChannel.checkExchange("orders")).resolves.toBeDefined();
     await expect(amqpChannel.checkExchange("notifications")).resolves.toBeDefined();
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
   });
 
   it("should setup queues from contract", async ({ amqpConnectionUrl, amqpChannel }) => {
@@ -59,14 +59,14 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // THEN - Verify queues exist by checking them
     await expect(amqpChannel.checkQueue("order-processing")).resolves.toBeDefined();
     await expect(amqpChannel.checkQueue("notifications")).resolves.toBeDefined();
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
   });
 
   it("should setup queue bindings from contract", async ({
@@ -95,7 +95,7 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // Setup consumer before publishing
     const waitForMessages = await initConsumer("orders", "order.created");
@@ -111,7 +111,7 @@ describe("AmqpClient Integration", () => {
     ]);
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
   });
 
   it("should setup exchange-to-exchange bindings", async ({
@@ -138,7 +138,7 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // Setup consumer on destination exchange
     const waitForMessages = await initConsumer("destination", "test.important");
@@ -154,7 +154,7 @@ describe("AmqpClient Integration", () => {
     ]);
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
   });
 
   it("should setup complete contract with all resources", async ({
@@ -192,7 +192,7 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // Setup consumers
     const waitForOrderMessages = await initConsumer("orders", "order.created");
@@ -215,7 +215,7 @@ describe("AmqpClient Integration", () => {
     ]);
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
   });
 
   it("should handle empty contract", async ({ amqpConnectionUrl }) => {
@@ -227,13 +227,13 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // THEN - Should not throw and client should be usable
     expect(client.getConnection()).toBeDefined();
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
   });
 
   it("should handle fanout exchange binding without routing key", async ({
@@ -260,7 +260,7 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // Setup consumer
     const waitForMessages = await initConsumer("fanout", "");
@@ -276,7 +276,7 @@ describe("AmqpClient Integration", () => {
     ]);
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
   });
 
   it("should pass custom arguments to exchanges", async ({ amqpConnectionUrl, amqpChannel }) => {
@@ -295,13 +295,13 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // THEN - Exchange should exist (arguments would have been passed to RabbitMQ)
     await expect(amqpChannel.checkExchange("orders")).resolves.toBeDefined();
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
   });
 
   it("should pass custom arguments to queues", async ({ amqpConnectionUrl, amqpChannel }) => {
@@ -321,13 +321,13 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // THEN - Queue should exist with custom arguments
     await expect(amqpChannel.checkQueue("orders")).resolves.toBeDefined();
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
   });
 
   it("should setup bridged exchange-to-exchange bindings from contract", async ({
@@ -357,7 +357,7 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // Setup consumer on the local queue via bridge exchange
     const waitForMessages = await initConsumer(bridgeExchange.name, "order.created");
@@ -373,7 +373,7 @@ describe("AmqpClient Integration", () => {
     ]);
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
   });
 
   it("should close channel and connection properly", async ({ amqpConnectionUrl }) => {
@@ -388,10 +388,10 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // WHEN
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
 
     // THEN - Client should have been properly closed
     // Note: We can't easily verify connection closure in isolation due to singleton

--- a/packages/core/src/__tests__/channel-config.spec.ts
+++ b/packages/core/src/__tests__/channel-config.spec.ts
@@ -27,14 +27,14 @@ describe("AmqpClient Channel Configuration", () => {
       },
     });
 
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // THEN - Channel should be created with json: false
     // We can't directly test the internal json setting, but we can verify the client was created
     expect(client.getConnection()).toBeDefined();
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
   });
 
   it("should keep json as true by default", async ({ amqpConnectionUrl }) => {
@@ -50,13 +50,13 @@ describe("AmqpClient Channel Configuration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // THEN - Default json: true should be used
     expect(client.getConnection()).toBeDefined();
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
   });
 
   it("should call custom setup function after topology setup", async ({
@@ -83,7 +83,7 @@ describe("AmqpClient Channel Configuration", () => {
       },
     });
 
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // THEN - Custom setup should have been called
     expect(customSetupMock).toHaveBeenCalledTimes(1);
@@ -94,7 +94,7 @@ describe("AmqpClient Channel Configuration", () => {
     await expect(amqpChannel.checkQueue("custom-queue")).resolves.toBeDefined();
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
   });
 
   it("should support callback-based custom setup function", async ({
@@ -124,7 +124,7 @@ describe("AmqpClient Channel Configuration", () => {
       },
     });
 
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // THEN - Callback setup should have been called
     expect(callbackSetupMock).toHaveBeenCalledTimes(1);
@@ -134,7 +134,7 @@ describe("AmqpClient Channel Configuration", () => {
     await expect(amqpChannel.checkQueue("callback-queue")).resolves.toBeDefined();
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
   });
 
   it("should override default channel name", async ({ amqpConnectionUrl }) => {
@@ -155,13 +155,13 @@ describe("AmqpClient Channel Configuration", () => {
       },
     });
 
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // THEN - Channel should be created
     expect(client.getConnection()).toBeDefined();
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
   });
 
   it("should allow disabling confirmChannel option", async ({ amqpConnectionUrl }) => {
@@ -180,13 +180,13 @@ describe("AmqpClient Channel Configuration", () => {
       },
     });
 
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // THEN - Regular channel should be created
     expect(client.getConnection()).toBeDefined();
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
   });
 
   it("should combine user channel options with defaults", async ({ amqpConnectionUrl }) => {
@@ -206,12 +206,12 @@ describe("AmqpClient Channel Configuration", () => {
       },
     });
 
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // THEN - All options should be applied
     expect(client.getConnection()).toBeDefined();
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
   });
 });

--- a/packages/core/src/__tests__/connection-sharing.spec.ts
+++ b/packages/core/src/__tests__/connection-sharing.spec.ts
@@ -24,15 +24,15 @@ describe("AmqpClient Connection Sharing Integration", () => {
     const client1 = new AmqpClient(contract, { urls });
     const client2 = new AmqpClient(contract, { urls });
 
-    await client1.waitForConnect().resultToPromise();
-    await client2.waitForConnect().resultToPromise();
+    (await client1.waitForConnect())._unsafeUnwrap();
+    (await client2.waitForConnect())._unsafeUnwrap();
 
     // THEN - Both clients should share the same connection instance
     expect(client1.getConnection()).toBe(client2.getConnection());
 
     // CLEANUP
-    await client1.close().resultToPromise();
-    await client2.close().resultToPromise();
+    (await client1.close())._unsafeUnwrap();
+    (await client2.close())._unsafeUnwrap();
   });
 
   it("should create separate connections for different URLs", async ({ amqpConnectionUrl }) => {
@@ -48,7 +48,7 @@ describe("AmqpClient Connection Sharing Integration", () => {
     const client1 = new AmqpClient(contract, { urls: [amqpConnectionUrl] });
     const client2 = new AmqpClient(contract, { urls: [`${amqpConnectionUrl}-different`] });
 
-    await client1.waitForConnect().resultToPromise();
+    (await client1.waitForConnect())._unsafeUnwrap();
     // client2 will fail to connect due to invalid URL, but that's okay for this test
 
     // THEN - Connections should be different instances
@@ -57,8 +57,8 @@ describe("AmqpClient Connection Sharing Integration", () => {
     expect(client1.getConnection()).not.toBe(client2.getConnection());
 
     // CLEANUP
-    await client1.close().resultToPromise();
-    await client2.close().resultToPromise();
+    (await client1.close())._unsafeUnwrap();
+    (await client2.close())._unsafeUnwrap();
   });
 
   it("should maintain connection when only one client closes", async ({ amqpConnectionUrl }) => {
@@ -73,19 +73,19 @@ describe("AmqpClient Connection Sharing Integration", () => {
     const client1 = new AmqpClient(contract, { urls });
     const client2 = new AmqpClient(contract, { urls });
 
-    await client1.waitForConnect().resultToPromise();
-    await client2.waitForConnect().resultToPromise();
+    (await client1.waitForConnect())._unsafeUnwrap();
+    (await client2.waitForConnect())._unsafeUnwrap();
 
     const sharedConnection = client1.getConnection();
 
     // WHEN - Close first client
-    await client1.close().resultToPromise();
+    (await client1.close())._unsafeUnwrap();
 
     // THEN - Connection should still be alive (used by client2)
     expect(sharedConnection.isConnected()).toBe(true);
 
     // CLEANUP
-    await client2.close().resultToPromise();
+    (await client2.close())._unsafeUnwrap();
   });
 
   it("should close connection when last client closes", async ({ amqpConnectionUrl }) => {
@@ -100,14 +100,14 @@ describe("AmqpClient Connection Sharing Integration", () => {
     const client1 = new AmqpClient(contract, { urls });
     const client2 = new AmqpClient(contract, { urls });
 
-    await client1.waitForConnect().resultToPromise();
-    await client2.waitForConnect().resultToPromise();
+    (await client1.waitForConnect())._unsafeUnwrap();
+    (await client2.waitForConnect())._unsafeUnwrap();
 
     const sharedConnection = client1.getConnection();
 
     // WHEN - Close both clients
-    await client1.close().resultToPromise();
-    await client2.close().resultToPromise();
+    (await client1.close())._unsafeUnwrap();
+    (await client2.close())._unsafeUnwrap();
 
     // Give connection a moment to close
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -132,8 +132,8 @@ describe("AmqpClient Connection Sharing Integration", () => {
     const client1b = new AmqpClient(contract, { urls: urls1 });
     const client2a = new AmqpClient(contract, { urls: urls2 });
 
-    await client1a.waitForConnect().resultToPromise();
-    await client1b.waitForConnect().resultToPromise();
+    (await client1a.waitForConnect())._unsafeUnwrap();
+    (await client1b.waitForConnect())._unsafeUnwrap();
     // client2a will fail to connect but that's okay
 
     // THEN - Clients with same URLs should share connection
@@ -141,9 +141,9 @@ describe("AmqpClient Connection Sharing Integration", () => {
     expect(client1a.getConnection()).not.toBe(client2a.getConnection());
 
     // CLEANUP
-    await client1a.close().resultToPromise();
-    await client1b.close().resultToPromise();
-    await client2a.close().resultToPromise();
+    (await client1a.close())._unsafeUnwrap();
+    (await client1b.close())._unsafeUnwrap();
+    (await client2a.close())._unsafeUnwrap();
   });
 
   it("should handle rapid create and close cycles", async ({ amqpConnectionUrl }) => {
@@ -159,16 +159,16 @@ describe("AmqpClient Connection Sharing Integration", () => {
     // WHEN - Rapidly create and close clients
     for (let i = 0; i < 5; i++) {
       const client = new AmqpClient(contract, { urls });
-      await client.waitForConnect().resultToPromise();
-      await client.close().resultToPromise();
+      (await client.waitForConnect())._unsafeUnwrap();
+      (await client.close())._unsafeUnwrap();
     }
 
     // THEN - Should not throw errors and last close should clean up connection
     const finalClient = new AmqpClient(contract, { urls });
-    await finalClient.waitForConnect().resultToPromise();
+    (await finalClient.waitForConnect())._unsafeUnwrap();
     expect(finalClient.getConnection()).toBeDefined();
 
     // CLEANUP
-    await finalClient.close().resultToPromise();
+    (await finalClient.close())._unsafeUnwrap();
   });
 });

--- a/packages/core/src/__tests__/dead-letter.spec.ts
+++ b/packages/core/src/__tests__/dead-letter.spec.ts
@@ -36,7 +36,7 @@ describe("Dead Letter Exchange Support", () => {
       urls: [amqpConnectionUrl],
     });
 
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // THEN - Check that the queue was created with dead letter configuration
     const queueInfo = await amqpChannel.checkQueue("test-queue-with-dlx");
@@ -48,7 +48,7 @@ describe("Dead Letter Exchange Support", () => {
     );
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
     await amqpChannel.deleteQueue("test-queue-with-dlx");
     await amqpChannel.deleteExchange("test-dlx");
   });
@@ -81,7 +81,7 @@ describe("Dead Letter Exchange Support", () => {
       urls: [amqpConnectionUrl],
     });
 
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // THEN - Check that the queue was created
     const queueInfo = await amqpChannel.checkQueue("test-queue-dlx-no-key");
@@ -92,7 +92,7 @@ describe("Dead Letter Exchange Support", () => {
     );
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
     await amqpChannel.deleteQueue("test-queue-dlx-no-key");
     await amqpChannel.deleteExchange("test-dlx-no-key");
   });
@@ -118,7 +118,7 @@ describe("Dead Letter Exchange Support", () => {
       urls: [amqpConnectionUrl],
     });
 
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // THEN - Check that the queue was created normally
     const queueInfo = await amqpChannel.checkQueue("test-queue-no-dlx");
@@ -129,7 +129,7 @@ describe("Dead Letter Exchange Support", () => {
     );
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
     await amqpChannel.deleteQueue("test-queue-no-dlx");
   });
 
@@ -166,7 +166,7 @@ describe("Dead Letter Exchange Support", () => {
       urls: [amqpConnectionUrl],
     });
 
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // THEN - All resources should be created with correct structure
     const mainQueueInfo = await amqpChannel.checkQueue("test-main-queue");
@@ -195,7 +195,7 @@ describe("Dead Letter Exchange Support", () => {
     expect(dlxInfo).toBeDefined();
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
     await amqpChannel.deleteQueue("test-main-queue");
     await amqpChannel.deleteQueue("test-dlx-queue");
     await amqpChannel.deleteExchange("test-main-exchange");
@@ -247,6 +247,6 @@ describe("Dead Letter Exchange Support", () => {
     });
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
   });
 });

--- a/packages/core/src/__tests__/priority-queue.spec.ts
+++ b/packages/core/src/__tests__/priority-queue.spec.ts
@@ -43,14 +43,14 @@ describe("Priority Queue", () => {
       urls: [amqpConnectionUrl],
     });
 
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // THEN - Verify queue was created with x-max-priority
     const queueInfo = await amqpChannel.checkQueue("test-priority-queue");
     expect(queueInfo.queue).toBe("test-priority-queue");
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
     await amqpChannel.deleteQueue("test-priority-queue");
   });
 
@@ -98,21 +98,31 @@ describe("Priority Queue", () => {
       urls: [amqpConnectionUrl],
     });
 
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // Publish messages with different priorities
     // Publishing in this order: low (1), medium (5), high (10)
-    await client
-      .publish(exchange.name, "test", { id: "msg-low", priority: 1 }, { priority: 1 })
-      .resultToPromise();
+    (
+      await client.publish(exchange.name, "test", { id: "msg-low", priority: 1 }, { priority: 1 })
+    )._unsafeUnwrap();
 
-    await client
-      .publish(exchange.name, "test", { id: "msg-medium", priority: 5 }, { priority: 5 })
-      .resultToPromise();
+    (
+      await client.publish(
+        exchange.name,
+        "test",
+        { id: "msg-medium", priority: 5 },
+        { priority: 5 },
+      )
+    )._unsafeUnwrap();
 
-    await client
-      .publish(exchange.name, "test", { id: "msg-high", priority: 10 }, { priority: 10 })
-      .resultToPromise();
+    (
+      await client.publish(
+        exchange.name,
+        "test",
+        { id: "msg-high", priority: 10 },
+        { priority: 10 },
+      )
+    )._unsafeUnwrap();
 
     // Give RabbitMQ time to order the messages
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -151,7 +161,7 @@ describe("Priority Queue", () => {
     ]);
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
     await amqpChannel.deleteQueue(extractQueue(priorityQueue).name);
     await amqpChannel.deleteExchange(exchange.name);
   });
@@ -205,15 +215,15 @@ describe("Priority Queue", () => {
       urls: [amqpConnectionUrl],
     });
 
-    await client.waitForConnect().resultToPromise();
+    (await client.waitForConnect())._unsafeUnwrap();
 
     // Publish message without priority (defaults to 0)
-    await client.publish(exchange.name, "test", { id: "msg-default" }).resultToPromise();
+    (await client.publish(exchange.name, "test", { id: "msg-default" }))._unsafeUnwrap();
 
     // Publish message with priority 5
-    await client
-      .publish(exchange.name, "test", { id: "msg-priority" }, { priority: 5 })
-      .resultToPromise();
+    (
+      await client.publish(exchange.name, "test", { id: "msg-priority" }, { priority: 5 })
+    )._unsafeUnwrap();
 
     // Give RabbitMQ time to order the messages
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -248,7 +258,7 @@ describe("Priority Queue", () => {
     expect(consumedMessages).toEqual([{ id: "msg-priority" }, { id: "msg-default" }]);
 
     // CLEANUP
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
     await amqpChannel.deleteQueue(extractQueue(priorityQueue).name);
     await amqpChannel.deleteExchange(exchange.name);
   });

--- a/packages/core/src/amqp-client.ts
+++ b/packages/core/src/amqp-client.ts
@@ -1,5 +1,4 @@
 import type { ContractDefinition } from "@amqp-contract/contract";
-import { Future, Result } from "@swan-io/boxed";
 import type {
   AmqpConnectionManager,
   AmqpConnectionManagerOptions,
@@ -8,6 +7,7 @@ import type {
   CreateChannelOpts,
 } from "amqp-connection-manager";
 import type { Channel, ConsumeMessage, Options } from "amqplib";
+import { err, ok, Result, ResultAsync } from "neverthrow";
 import { ConnectionManagerSingleton } from "./connection-manager.js";
 import { TechnicalError } from "./errors.js";
 import { setupAmqpTopology } from "./setup.js";
@@ -39,7 +39,7 @@ function callSetupFunc(
  * Default time `waitForConnect` will wait for the broker before erroring out.
  * Defaulting to a finite value (rather than waiting forever) means a fail-fast
  * developer experience: a misconfigured URL, a down broker, or wrong
- * credentials surface as a Result.Error within 30 seconds. Pass `null`
+ * credentials surface as an `err` within 30 seconds. Pass `null`
  * explicitly to disable the timeout — `Infinity` and other non-finite values
  * are also coerced to "no timeout" because Node's `setTimeout` clamps large
  * delays to ~24.8 days and silently fires near-immediately on `Infinity`.
@@ -107,7 +107,7 @@ export type ConsumerOptions = Options.Consume & {
  * - Automatic AMQP topology setup (exchanges, queues, bindings) from contract
  * - Channel creation with JSON serialization enabled by default
  *
- * All operations return `Future<Result<T, TechnicalError>>` for consistent error handling.
+ * All operations return `ResultAsync<T, TechnicalError>` for consistent error handling.
  *
  * @example
  * ```typescript
@@ -116,14 +116,14 @@ export type ConsumerOptions = Options.Consume & {
  *   connectionOptions: { heartbeatIntervalInSeconds: 30 }
  * });
  *
- * // Wait for connection
- * await client.waitForConnect().resultToPromise();
+ * // Wait for connection (ResultAsync is thenable)
+ * await client.waitForConnect();
  *
  * // Publish a message
- * const result = await client.publish('exchange', 'routingKey', { data: 'value' }).resultToPromise();
+ * const result = await client.publish('exchange', 'routingKey', { data: 'value' });
  *
  * // Close when done
- * await client.close().resultToPromise();
+ * await client.close();
  * ```
  */
 export class AmqpClient {
@@ -208,7 +208,7 @@ export class AmqpClient {
    * Wait for the channel to be connected and ready.
    *
    * If `connectTimeoutMs` was provided in the constructor options, the returned
-   * Future resolves to `Result.Error<TechnicalError>` once the timeout elapses.
+   * ResultAsync resolves to `err(TechnicalError)` once the timeout elapses.
    * Without a timeout, this waits forever — amqp-connection-manager retries
    * connections indefinitely and never errors on its own.
    *
@@ -217,11 +217,8 @@ export class AmqpClient {
    * connection's reference count. Callers must invoke `close()` on the error
    * path to release the connection — `waitForConnect` does not do this
    * automatically. The typed factories handle this cleanup for you.
-   *
-   * @returns A Future resolving to `Result.Ok(void)` on connect, or
-   *   `Result.Error(TechnicalError)` on timeout / connection failure.
    */
-  waitForConnect(): Future<Result<void, TechnicalError>> {
+  waitForConnect(): ResultAsync<void, TechnicalError> {
     const connectPromise = this.channelWrapper.waitForConnect();
     const timeoutMs = this.connectTimeoutMs;
 
@@ -244,7 +241,8 @@ export class AmqpClient {
             );
           });
 
-    return Future.fromPromise(racedPromise).mapError(
+    return ResultAsync.fromPromise(
+      racedPromise,
       (error: unknown) => new TechnicalError("Failed to connect to AMQP broker", error),
     );
   }
@@ -252,37 +250,32 @@ export class AmqpClient {
   /**
    * Publish a message to an exchange.
    *
-   * @param exchange - The exchange name
-   * @param routingKey - The routing key
-   * @param content - The message content (will be JSON serialized if json: true)
-   * @param options - Optional publish options
-   * @returns A Future with `Result<boolean>` - true if message was sent, false if channel buffer is full
+   * @returns ResultAsync resolving to `true` if the message was sent, `false` if the channel buffer is full.
    */
   publish(
     exchange: string,
     routingKey: string,
     content: Buffer | unknown,
     options?: PublishOptions,
-  ): Future<Result<boolean, TechnicalError>> {
-    return Future.fromPromise(
+  ): ResultAsync<boolean, TechnicalError> {
+    return ResultAsync.fromPromise(
       this.channelWrapper.publish(exchange, routingKey, content, options),
-    ).mapError((error: unknown) => new TechnicalError("Failed to publish message", error));
+      (error: unknown) => new TechnicalError("Failed to publish message", error),
+    );
   }
 
   /**
    * Publish a message directly to a queue.
    *
-   * @param queue - The queue name
-   * @param content - The message content (will be JSON serialized if json: true)
-   * @param options - Optional publish options
-   * @returns A Future with `Result<boolean>` - true if message was sent, false if channel buffer is full
+   * @returns ResultAsync resolving to `true` if the message was sent, `false` if the channel buffer is full.
    */
   sendToQueue(
     queue: string,
     content: Buffer | unknown,
     options?: PublishOptions,
-  ): Future<Result<boolean, TechnicalError>> {
-    return Future.fromPromise(this.channelWrapper.sendToQueue(queue, content, options)).mapError(
+  ): ResultAsync<boolean, TechnicalError> {
+    return ResultAsync.fromPromise(
+      this.channelWrapper.sendToQueue(queue, content, options),
       (error: unknown) => new TechnicalError("Failed to publish message to queue", error),
     );
   }
@@ -290,31 +283,27 @@ export class AmqpClient {
   /**
    * Start consuming messages from a queue.
    *
-   * @param queue - The queue name
-   * @param callback - The callback to invoke for each message
-   * @param options - Optional consume options
-   * @returns A Future with `Result<string>` - the consumer tag
+   * @returns ResultAsync resolving to the consumer tag.
    */
   consume(
     queue: string,
     callback: ConsumeCallback,
     options?: ConsumerOptions,
-  ): Future<Result<string, TechnicalError>> {
-    return Future.fromPromise(this.channelWrapper.consume(queue, callback, options))
-      .mapError((error: unknown) => new TechnicalError("Failed to start consuming messages", error))
-      .mapOk((reply: { consumerTag: string }) => reply.consumerTag);
+  ): ResultAsync<string, TechnicalError> {
+    return ResultAsync.fromPromise(
+      this.channelWrapper.consume(queue, callback, options),
+      (error: unknown) => new TechnicalError("Failed to start consuming messages", error),
+    ).map((reply: { consumerTag: string }) => reply.consumerTag);
   }
 
   /**
    * Cancel a consumer by its consumer tag.
-   *
-   * @param consumerTag - The consumer tag to cancel
-   * @returns A Future that resolves when the consumer is cancelled
    */
-  cancel(consumerTag: string): Future<Result<void, TechnicalError>> {
-    return Future.fromPromise(this.channelWrapper.cancel(consumerTag))
-      .mapError((error: unknown) => new TechnicalError("Failed to cancel consumer", error))
-      .mapOk(() => undefined);
+  cancel(consumerTag: string): ResultAsync<void, TechnicalError> {
+    return ResultAsync.fromPromise(
+      this.channelWrapper.cancel(consumerTag),
+      (error: unknown) => new TechnicalError("Failed to cancel consumer", error),
+    ).map(() => undefined);
   }
 
   /**
@@ -372,35 +361,41 @@ export class AmqpClient {
    * - Decrease the reference count on the shared connection
    * - Close the connection if this was the last client using it
    *
-   * @returns A Future that resolves when the channel and connection are closed
+   * Both steps run regardless of each other's outcome; if both fail, the
+   * errors are wrapped in an AggregateError.
    */
-  close(): Future<Result<void, TechnicalError>> {
-    return Future.fromPromise(this.channelWrapper.close())
-      .mapError((error: unknown) => new TechnicalError("Failed to close channel", error))
-      .flatMap((channelResult) =>
-        Future.fromPromise(
-          ConnectionManagerSingleton.getInstance().releaseConnection(
-            this.urls,
-            this.connectionOptions,
-          ),
-        )
-          .mapError((error: unknown) => new TechnicalError("Failed to release connection", error))
-          .map((releaseResult) => {
-            if (channelResult.isError() && releaseResult.isError()) {
-              return Result.Error(
-                new TechnicalError(
-                  "Failed to close channel and release connection",
-                  new AggregateError(
-                    [channelResult.error, releaseResult.error],
-                    "Failed to close channel and release connection",
-                  ),
-                ),
-              );
-            }
-
-            return channelResult.isError() ? channelResult : releaseResult;
-          }),
+  close(): ResultAsync<void, TechnicalError> {
+    const inner = (async (): Promise<Result<void, TechnicalError>> => {
+      const channelResult = await ResultAsync.fromPromise(
+        this.channelWrapper.close(),
+        (error: unknown) => new TechnicalError("Failed to close channel", error),
       );
+      const releaseResult = await ResultAsync.fromPromise(
+        ConnectionManagerSingleton.getInstance().releaseConnection(
+          this.urls,
+          this.connectionOptions,
+        ),
+        (error: unknown) => new TechnicalError("Failed to release connection", error),
+      );
+
+      if (channelResult.isErr() && releaseResult.isErr()) {
+        return err(
+          new TechnicalError(
+            "Failed to close channel and release connection",
+            new AggregateError(
+              [channelResult.error, releaseResult.error],
+              "Failed to close channel and release connection",
+            ),
+          ),
+        );
+      }
+
+      if (channelResult.isErr()) return channelResult;
+      if (releaseResult.isErr()) return releaseResult;
+      return ok(undefined);
+    })();
+
+    return new ResultAsync(inner);
   }
 
   /**

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -1,9 +1,9 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  // Prevent @swan-io/boxed types from being inlined into the declaration files
-  // This ensures type compatibility across packages that use boxed types
-  external: ["@swan-io/boxed"],
+  // Prevent neverthrow types from being inlined into the declaration files.
+  // This ensures type compatibility across packages that re-export them.
+  external: ["neverthrow"],
   // Suppress warnings about bundled dependencies in declaration files
   inlineOnly: false,
 });

--- a/packages/worker/README.md
+++ b/packages/worker/README.md
@@ -43,23 +43,24 @@ const logger: Logger = {
 };
 
 // Create worker from contract with handlers (automatically connects and starts consuming)
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: ({ payload }) => {
-      console.log("Processing order:", payload.orderId);
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: ({ payload }) => {
+        console.log("Processing order:", payload.orderId);
 
-      // Your business logic here
-      return ResultAsync.fromPromise(
-        Promise.all([processPayment(payload), updateInventory(payload)]),
-      )
-        .map(() => undefined)
-        .mapErr((error) => new RetryableError("Order processing failed", error));
+        // Your business logic here
+        return ResultAsync.fromPromise(
+          Promise.all([processPayment(payload), updateInventory(payload)]),
+          (error) => new RetryableError("Order processing failed", error),
+        ).map(() => undefined);
+      },
     },
-  },
-  urls: ["amqp://localhost"],
-  logger, // Optional: logs message consumption and errors
-});
+    urls: ["amqp://localhost"],
+    logger, // Optional: logs message consumption and errors
+  })
+)._unsafeUnwrap();
 
 // Worker is already consuming messages
 
@@ -100,17 +101,20 @@ Then use `RetryableError` in your handlers:
 import { TypedAmqpWorker, RetryableError } from "@amqp-contract/worker";
 import { ResultAsync } from "neverthrow";
 
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: ({ payload }) =>
-      // If this fails with RetryableError, message is automatically retried
-      ResultAsync.fromPromise(processPayment(payload))
-        .map(() => undefined)
-        .mapErr((error) => new RetryableError("Payment failed", error)),
-  },
-  urls: ["amqp://localhost"],
-});
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: ({ payload }) =>
+        // If this fails with RetryableError, message is automatically retried
+        ResultAsync.fromPromise(
+          processPayment(payload),
+          (error) => new RetryableError("Payment failed", error),
+        ).map(() => undefined),
+    },
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 ```
 
 See the [Error Handling and Retry](https://btravers.github.io/amqp-contract/guide/worker-usage#error-handling-and-retry) section in the guide for complete details.
@@ -135,9 +139,8 @@ handlers: {
     }
 
     // Transient errors - retryable
-    return ResultAsync.fromPromise(process(payload))
-      .map(() => undefined)
-      .mapErr((error) => new RetryableError("Processing failed", error));
+    return ResultAsync.fromPromise(process(payload), (error) => new RetryableError("Processing failed", error))
+      .map(() => undefined);
   },
 }
 ```

--- a/packages/worker/README.md
+++ b/packages/worker/README.md
@@ -129,7 +129,7 @@ Worker handlers return `ResultAsync<void, HandlerError>` for explicit error hand
 
 ```typescript
 import { RetryableError, NonRetryableError } from "@amqp-contract/worker";
-import { ResultAsync, Result } from "neverthrow";
+import { errAsync, ResultAsync } from "neverthrow";
 
 handlers: {
   processOrder: ({ payload }) => {

--- a/packages/worker/README.md
+++ b/packages/worker/README.md
@@ -1,6 +1,6 @@
 # @amqp-contract/worker
 
-**Type-safe AMQP worker for consuming messages using amqp-contract with Future/Result error handling.**
+**Type-safe AMQP worker for consuming messages using amqp-contract with ResultAsync/Result error handling.**
 
 [![CI](https://github.com/btravers/amqp-contract/actions/workflows/ci.yml/badge.svg)](https://github.com/btravers/amqp-contract/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/@amqp-contract/worker.svg?logo=npm)](https://www.npmjs.com/package/@amqp-contract/worker)
@@ -31,7 +31,7 @@ pnpm add @amqp-contract/worker
 ```typescript
 import { TypedAmqpWorker, RetryableError } from "@amqp-contract/worker";
 import type { Logger } from "@amqp-contract/core";
-import { Future } from "@swan-io/boxed";
+import { ResultAsync } from "neverthrow";
 import { contract } from "./contract";
 
 // Optional: Create a logger implementation
@@ -50,9 +50,11 @@ const worker = await TypedAmqpWorker.create({
       console.log("Processing order:", payload.orderId);
 
       // Your business logic here
-      return Future.fromPromise(Promise.all([processPayment(payload), updateInventory(payload)]))
-        .mapOk(() => undefined)
-        .mapError((error) => new RetryableError("Order processing failed", error));
+      return ResultAsync.fromPromise(
+        Promise.all([processPayment(payload), updateInventory(payload)]),
+      )
+        .map(() => undefined)
+        .mapErr((error) => new RetryableError("Order processing failed", error));
     },
   },
   urls: ["amqp://localhost"],
@@ -96,16 +98,16 @@ Then use `RetryableError` in your handlers:
 
 ```typescript
 import { TypedAmqpWorker, RetryableError } from "@amqp-contract/worker";
-import { Future } from "@swan-io/boxed";
+import { ResultAsync } from "neverthrow";
 
 const worker = await TypedAmqpWorker.create({
   contract,
   handlers: {
     processOrder: ({ payload }) =>
       // If this fails with RetryableError, message is automatically retried
-      Future.fromPromise(processPayment(payload))
-        .mapOk(() => undefined)
-        .mapError((error) => new RetryableError("Payment failed", error)),
+      ResultAsync.fromPromise(processPayment(payload))
+        .map(() => undefined)
+        .mapErr((error) => new RetryableError("Payment failed", error)),
   },
   urls: ["amqp://localhost"],
 });
@@ -119,23 +121,23 @@ You can define handlers outside of the worker creation using `defineHandler` and
 
 ## Error Handling
 
-Worker handlers return `Future<Result<void, HandlerError>>` for explicit error handling:
+Worker handlers return `ResultAsync<void, HandlerError>` for explicit error handling:
 
 ```typescript
 import { RetryableError, NonRetryableError } from "@amqp-contract/worker";
-import { Future, Result } from "@swan-io/boxed";
+import { ResultAsync, Result } from "neverthrow";
 
 handlers: {
   processOrder: ({ payload }) => {
     // Validation errors - non-retryable
     if (payload.amount <= 0) {
-      return Future.value(Result.Error(new NonRetryableError("Invalid amount")));
+      return errAsync(new NonRetryableError("Invalid amount"));
     }
 
     // Transient errors - retryable
-    return Future.fromPromise(process(payload))
-      .mapOk(() => undefined)
-      .mapError((error) => new RetryableError("Processing failed", error));
+    return ResultAsync.fromPromise(process(payload))
+      .map(() => undefined)
+      .mapErr((error) => new RetryableError("Processing failed", error));
   },
 }
 ```

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -61,7 +61,7 @@
     "@amqp-contract/contract": "workspace:*",
     "@amqp-contract/core": "workspace:*",
     "@standard-schema/spec": "catalog:",
-    "@swan-io/boxed": "catalog:"
+    "neverthrow": "catalog:"
   },
   "devDependencies": {
     "@amqp-contract/testing": "workspace:*",

--- a/packages/worker/src/__tests__/fixture.ts
+++ b/packages/worker/src/__tests__/fixture.ts
@@ -20,12 +20,14 @@ export const it = baseIt.extend<{
         ) => {
           // Topology setup (exchanges, queues, bindings, wait queues) is done automatically
           // by AmqpClient in the channel setup callback
-          const worker = await TypedAmqpWorker.create({
-            contract,
-            handlers,
-            urls: [amqpConnectionUrl],
-            logger: console,
-          }).resultToPromise();
+          const worker = (
+            await TypedAmqpWorker.create({
+              contract,
+              handlers,
+              urls: [amqpConnectionUrl],
+              logger: console,
+            })
+          )._unsafeUnwrap();
 
           workers.push(worker);
           return worker;
@@ -36,7 +38,7 @@ export const it = baseIt.extend<{
       await Promise.all(
         workers.map(async (worker) => {
           try {
-            await worker.close().resultToPromise();
+            (await worker.close())._unsafeUnwrap();
           } catch (error) {
             // Swallow errors during cleanup to avoid unhandled rejections
             // eslint-disable-next-line no-console

--- a/packages/worker/src/__tests__/worker-retry.spec.ts
+++ b/packages/worker/src/__tests__/worker-retry.spec.ts
@@ -6,7 +6,7 @@ import {
   defineMessage,
   defineQueue,
 } from "@amqp-contract/contract";
-import { Future, Result } from "@swan-io/boxed";
+import { errAsync, okAsync } from "neverthrow";
 import { describe, expect, vi } from "vitest";
 import { z } from "zod";
 import { RetryableError } from "../errors.js";
@@ -56,9 +56,9 @@ describe("Worker Retry Mechanism", () => {
         testConsumer: () => {
           attemptCount++;
           if (attemptCount === 1) {
-            return Future.value(Result.Error(new RetryableError("First attempt failed")));
+            return errAsync(new RetryableError("First attempt failed"));
           }
-          return Future.value(Result.Ok(undefined));
+          return okAsync(undefined);
         },
       });
 
@@ -155,7 +155,7 @@ describe("Worker Retry Mechanism", () => {
       });
 
       await workerFactory(contract, {
-        testConsumer: () => Future.value(Result.Error(new RetryableError("Always fails"))),
+        testConsumer: () => errAsync(new RetryableError("Always fails")),
       });
 
       // Set up DLQ manually for verification (after worker creates the DLX exchange)
@@ -247,7 +247,7 @@ describe("Worker Retry Mechanism", () => {
       await workerFactory(contract, {
         testConsumer: () => {
           attemptCount++;
-          return Future.value(Result.Error(new RetryableError("Always fails")));
+          return errAsync(new RetryableError("Always fails"));
         },
       });
 
@@ -323,7 +323,7 @@ describe("Worker Retry Mechanism", () => {
       });
 
       await workerFactory(contract, {
-        testConsumer: () => Future.value(Result.Error(new RetryableError("Test error message"))),
+        testConsumer: () => errAsync(new RetryableError("Test error message")),
       });
 
       // WHEN publishing a message that fails
@@ -383,7 +383,7 @@ describe("Worker Retry Mechanism", () => {
       await workerFactory(contract, {
         testConsumer: () => {
           attemptCount++;
-          return Future.value(Result.Error(new RetryableError("Will not retry")));
+          return errAsync(new RetryableError("Will not retry"));
         },
       });
 
@@ -438,7 +438,7 @@ describe("Worker Retry Mechanism", () => {
       await workerFactory(contract, {
         testConsumer: () => {
           attemptCount++;
-          return Future.value(Result.Error(new RetryableError("No retry")));
+          return errAsync(new RetryableError("No retry"));
         },
       });
 
@@ -516,9 +516,9 @@ describe("Worker Retry Mechanism", () => {
             attemptCount++;
             if (attemptCount < 2) {
               // This triggers a requeue in immediate-requeue mode
-              return Future.value(Result.Error(new RetryableError("Simulated failure")));
+              return errAsync(new RetryableError("Simulated failure"));
             }
-            return Future.value(Result.Ok(undefined));
+            return okAsync(undefined);
           },
         });
 
@@ -579,7 +579,7 @@ describe("Worker Retry Mechanism", () => {
           testConsumer: () => {
             attemptCount++;
             // Always fail - message should be dead-lettered after exceeding maxRetries
-            return Future.value(Result.Error(new RetryableError("Always fails")));
+            return errAsync(new RetryableError("Always fails"));
           },
         });
 
@@ -653,9 +653,9 @@ describe("Worker Retry Mechanism", () => {
             attemptCount++;
             if (attemptCount < 2) {
               // This triggers a requeue in immediate-requeue mode
-              return Future.value(Result.Error(new RetryableError("Simulated failure")));
+              return errAsync(new RetryableError("Simulated failure"));
             }
-            return Future.value(Result.Ok(undefined));
+            return okAsync(undefined);
           },
         });
 
@@ -717,7 +717,7 @@ describe("Worker Retry Mechanism", () => {
           testConsumer: () => {
             attemptCount++;
             // Always fail - message should be dead-lettered after exceeding maxRetries
-            return Future.value(Result.Error(new RetryableError("Always fails")));
+            return errAsync(new RetryableError("Always fails"));
           },
         });
 
@@ -788,9 +788,9 @@ describe("Worker Retry Mechanism", () => {
           testConsumer: () => {
             attemptCount++;
             if (attemptCount < 2) {
-              return Future.value(Result.Error(new RetryableError("Fail once")));
+              return errAsync(new RetryableError("Fail once"));
             }
-            return Future.value(Result.Ok(undefined));
+            return okAsync(undefined);
           },
         });
 
@@ -868,13 +868,13 @@ describe("Worker Retry Mechanism", () => {
 
             // Fail first two attempts to trigger retries
             if (attemptCount === 1) {
-              return Future.value(Result.Error(new RetryableError("First failure")));
+              return errAsync(new RetryableError("First failure"));
             } else if (attemptCount === 2) {
-              return Future.value(Result.Error(new RetryableError("Second failure")));
+              return errAsync(new RetryableError("Second failure"));
             }
 
             // Succeed on third attempt
-            return Future.value(Result.Ok(undefined));
+            return okAsync(undefined);
           },
         });
 
@@ -948,9 +948,9 @@ describe("Worker Retry Mechanism", () => {
         testConsumer: () => {
           attemptCount++;
           if (attemptCount === 1) {
-            return Future.value(Result.Error(new RetryableError("First attempt failed")));
+            return errAsync(new RetryableError("First attempt failed"));
           }
-          return Future.value(Result.Ok(undefined));
+          return okAsync(undefined);
         },
       });
 
@@ -1047,9 +1047,9 @@ describe("Worker Retry Mechanism", () => {
         testConsumer: () => {
           attemptCount++;
           if (attemptCount === 1) {
-            return Future.value(Result.Error(new RetryableError("First attempt failed")));
+            return errAsync(new RetryableError("First attempt failed"));
           }
-          return Future.value(Result.Ok(undefined));
+          return okAsync(undefined);
         },
       });
 
@@ -1132,9 +1132,9 @@ describe("Worker Retry Mechanism", () => {
           // Capture the routing key from the message
           capturedRoutingKeys.push(msg.fields.routingKey);
           if (attemptCount === 1) {
-            return Future.value(Result.Error(new RetryableError("First attempt failed")));
+            return errAsync(new RetryableError("First attempt failed"));
           }
-          return Future.value(Result.Ok(undefined));
+          return okAsync(undefined);
         },
       });
 
@@ -1192,7 +1192,7 @@ describe("Worker Retry Mechanism", () => {
         testConsumer: () => {
           attemptCount++;
           // Always fail
-          return Future.value(Result.Error(new RetryableError("Always fails")));
+          return errAsync(new RetryableError("Always fails"));
         },
       });
 

--- a/packages/worker/src/__tests__/worker.spec.ts
+++ b/packages/worker/src/__tests__/worker.spec.ts
@@ -7,7 +7,7 @@ import {
   defineQueue,
   extractQueue,
 } from "@amqp-contract/contract";
-import { Future, Result } from "@swan-io/boxed";
+import { errAsync, okAsync } from "neverthrow";
 import { describe, expect, vi } from "vitest";
 import { z } from "zod";
 import { RetryableError } from "../errors.js";
@@ -44,7 +44,7 @@ describe("AmqpWorker Integration", () => {
       defineHandlers(contract, {
         testConsumer: ({ payload }) => {
           messages.push(payload);
-          return Future.value(Result.Ok(undefined));
+          return okAsync(undefined);
         },
       }),
     );
@@ -95,7 +95,7 @@ describe("AmqpWorker Integration", () => {
       defineHandlers(contract, {
         testConsumer: ({ payload }) => {
           messages.push(payload);
-          return Future.value(Result.Ok(undefined));
+          return okAsync(undefined);
         },
       }),
     );
@@ -152,7 +152,7 @@ describe("AmqpWorker Integration", () => {
         testConsumer: ({ payload, headers }) => {
           messages.push(payload);
           messageHeaders.push(headers);
-          return Future.value(Result.Ok(undefined));
+          return okAsync(undefined);
         },
       }),
     );
@@ -219,7 +219,7 @@ describe("AmqpWorker Integration", () => {
       defineHandlers(contract, {
         testConsumer: ({ payload }) => {
           messages.push(payload);
-          return Future.value(Result.Ok(undefined));
+          return okAsync(undefined);
         },
       }),
     );
@@ -270,11 +270,11 @@ describe("AmqpWorker Integration", () => {
       defineHandlers(contract, {
         consumer1: ({ payload }) => {
           messages1.push(payload);
-          return Future.value(Result.Ok(undefined));
+          return okAsync(undefined);
         },
         consumer2: ({ payload }) => {
           messages2.push(payload);
-          return Future.value(Result.Ok(undefined));
+          return okAsync(undefined);
         },
       }),
     );
@@ -324,7 +324,7 @@ describe("AmqpWorker Integration", () => {
       defineHandlers(contract, {
         testConsumer: ({ payload }) => {
           messages.push(payload);
-          return Future.value(Result.Ok(undefined));
+          return okAsync(undefined);
         },
       }),
     );
@@ -371,10 +371,10 @@ describe("AmqpWorker Integration", () => {
         testConsumer: ({ payload }) => {
           attemptCount++;
           if (payload.shouldFail && attemptCount === 1) {
-            return Future.value(Result.Error(new RetryableError("Handler error on first attempt")));
+            return errAsync(new RetryableError("Handler error on first attempt"));
           }
           messages.push(payload);
-          return Future.value(Result.Ok(undefined));
+          return okAsync(undefined);
         },
       }),
     );
@@ -422,7 +422,7 @@ describe("AmqpWorker Integration", () => {
       defineHandlers(contract, {
         destConsumer: ({ payload }) => {
           messages.push(payload);
-          return Future.value(Result.Ok(undefined));
+          return okAsync(undefined);
         },
       }),
     );
@@ -467,7 +467,7 @@ describe("AmqpWorker Integration", () => {
       defineHandlers(contract, {
         testConsumer: ({ payload }) => {
           messages.push(payload);
-          return Future.value(Result.Ok(undefined));
+          return okAsync(undefined);
         },
       }),
     );
@@ -534,11 +534,11 @@ describe("AmqpWorker Integration", () => {
       defineHandlers(contract, {
         orderConsumer: ({ payload }) => {
           orders.push(payload);
-          return Future.value(Result.Ok(undefined));
+          return okAsync(undefined);
         },
         notificationConsumer: ({ payload }) => {
           notifications.push(payload);
-          return Future.value(Result.Ok(undefined));
+          return okAsync(undefined);
         },
       }),
     );
@@ -637,16 +637,16 @@ describe("AmqpWorker Integration", () => {
     };
 
     // Create worker with mock logger
-    const worker = await TypedAmqpWorker.create({
-      contract,
-      handlers: {
-        testConsumer: defineHandler(contract, "testConsumer", (_msg) =>
-          Future.value(Result.Ok(undefined)),
-        ),
-      },
-      urls: [amqpConnectionUrl],
-      logger: mockLogger,
-    }).resultToPromise();
+    const worker = (
+      await TypedAmqpWorker.create({
+        contract,
+        handlers: {
+          testConsumer: defineHandler(contract, "testConsumer", (_msg) => okAsync(undefined)),
+        },
+        urls: [amqpConnectionUrl],
+        logger: mockLogger,
+      })
+    )._unsafeUnwrap();
 
     // Wait for worker setup
     const WORKER_SETUP_WAIT_MS = 500;
@@ -684,6 +684,6 @@ describe("AmqpWorker Integration", () => {
     expect(unexpectedWarnings).toHaveLength(0);
 
     // Clean up
-    await worker.close().resultToPromise();
+    (await worker.close())._unsafeUnwrap();
   });
 });

--- a/packages/worker/src/decompression.spec.ts
+++ b/packages/worker/src/decompression.spec.ts
@@ -10,7 +10,7 @@ describe("Decompression utilities", () => {
   describe("decompressBuffer", () => {
     it("should return buffer as-is when no content-encoding is provided", async () => {
       const testData = Buffer.from(JSON.stringify({ message: "Hello, World!" }));
-      const result = await decompressBuffer(testData, undefined).resultToPromise();
+      const result = (await decompressBuffer(testData, undefined))._unsafeUnwrap();
 
       expect(result).toEqual(testData);
     });
@@ -19,7 +19,7 @@ describe("Decompression utilities", () => {
       const testData = Buffer.from(JSON.stringify({ message: "Hello, World!" }));
       const compressed = await gzipAsync(testData);
 
-      const decompressed = await decompressBuffer(compressed, "gzip").resultToPromise();
+      const decompressed = (await decompressBuffer(compressed, "gzip"))._unsafeUnwrap();
 
       expect(decompressed).toEqual(testData);
     });
@@ -28,7 +28,7 @@ describe("Decompression utilities", () => {
       const testData = Buffer.from(JSON.stringify({ message: "Hello, World!" }));
       const compressed = await deflateAsync(testData);
 
-      const decompressed = await decompressBuffer(compressed, "deflate").resultToPromise();
+      const decompressed = (await decompressBuffer(compressed, "deflate"))._unsafeUnwrap();
 
       expect(decompressed).toEqual(testData);
     });
@@ -37,7 +37,7 @@ describe("Decompression utilities", () => {
       const testData = Buffer.from(JSON.stringify({ message: "Hello, World!" }));
       const compressed = await gzipAsync(testData);
 
-      const decompressed = await decompressBuffer(compressed, "GZIP").resultToPromise();
+      const decompressed = (await decompressBuffer(compressed, "GZIP"))._unsafeUnwrap();
 
       expect(decompressed).toEqual(testData);
     });
@@ -45,17 +45,17 @@ describe("Decompression utilities", () => {
     it("should return error for unknown content-encoding with helpful message", async () => {
       const testData = Buffer.from(JSON.stringify({ message: "Hello, World!" }));
 
-      const result = await decompressBuffer(testData, "brotli").toPromise();
+      const result = await decompressBuffer(testData, "brotli");
 
-      expect(result.isError()).toBe(true);
-      result.match({
-        Ok: () => expect.fail("Expected error"),
-        Error: (error) => {
+      expect(result.isErr()).toBe(true);
+      result.match(
+        () => expect.fail("Expected error"),
+        (error) => {
           expect(error.message).toContain('Unsupported content-encoding: "brotli"');
           expect(error.message).toContain("Supported encodings are: gzip, deflate");
           expect(error.message).toContain("Please check your publisher configuration");
         },
-      });
+      );
     });
 
     it("should decompress large data correctly", async () => {
@@ -70,7 +70,7 @@ describe("Decompression utilities", () => {
       );
 
       const compressed = await gzipAsync(largeData);
-      const decompressed = await decompressBuffer(compressed, "gzip").resultToPromise();
+      const decompressed = (await decompressBuffer(compressed, "gzip"))._unsafeUnwrap();
 
       expect(decompressed).toEqual(largeData);
     });

--- a/packages/worker/src/decompression.ts
+++ b/packages/worker/src/decompression.ts
@@ -1,6 +1,6 @@
-import { Future, Result } from "@swan-io/boxed";
-import { gunzip, inflate } from "node:zlib";
 import { TechnicalError } from "@amqp-contract/core";
+import { errAsync, okAsync, ResultAsync } from "neverthrow";
+import { gunzip, inflate } from "node:zlib";
 import { promisify } from "node:util";
 
 const gunzipAsync = promisify(gunzip);
@@ -28,39 +28,39 @@ function isSupportedEncoding(encoding: string): encoding is SupportedEncoding {
  *
  * @param buffer - The buffer to decompress
  * @param contentEncoding - The content-encoding header value (e.g., 'gzip', 'deflate')
- * @returns A Future with the decompressed buffer or a TechnicalError
+ * @returns A ResultAsync resolving to the decompressed buffer or a TechnicalError
  *
  * @internal
  */
 export function decompressBuffer(
   buffer: Buffer,
   contentEncoding: string | undefined,
-): Future<Result<Buffer, TechnicalError>> {
+): ResultAsync<Buffer, TechnicalError> {
   if (!contentEncoding) {
-    return Future.value(Result.Ok(buffer));
+    return okAsync(buffer);
   }
 
   const normalizedEncoding = contentEncoding.toLowerCase();
 
   if (!isSupportedEncoding(normalizedEncoding)) {
-    return Future.value(
-      Result.Error(
-        new TechnicalError(
-          `Unsupported content-encoding: "${contentEncoding}". ` +
-            `Supported encodings are: ${SUPPORTED_ENCODINGS.join(", ")}. ` +
-            `Please check your publisher configuration.`,
-        ),
+    return errAsync(
+      new TechnicalError(
+        `Unsupported content-encoding: "${contentEncoding}". ` +
+          `Supported encodings are: ${SUPPORTED_ENCODINGS.join(", ")}. ` +
+          `Please check your publisher configuration.`,
       ),
     );
   }
 
   switch (normalizedEncoding) {
     case "gzip":
-      return Future.fromPromise(gunzipAsync(buffer)).mapError(
+      return ResultAsync.fromPromise(
+        gunzipAsync(buffer),
         (error) => new TechnicalError("Failed to decompress gzip", error),
       );
     case "deflate":
-      return Future.fromPromise(inflateAsync(buffer)).mapError(
+      return ResultAsync.fromPromise(
+        inflateAsync(buffer),
         (error) => new TechnicalError("Failed to decompress deflate", error),
       );
   }

--- a/packages/worker/src/errors.ts
+++ b/packages/worker/src/errors.ts
@@ -149,15 +149,16 @@ export function isHandlerError(error: unknown): error is HandlerError {
  * @example
  * ```typescript
  * import { retryable } from '@amqp-contract/worker';
- * import { Future, Result } from '@swan-io/boxed';
+ * import { ResultAsync } from 'neverthrow';
  *
  * const handler = ({ payload }) =>
- *   Future.fromPromise(processPayment(payload))
- *     .mapOk(() => undefined)
- *     .mapError((e) => retryable('Payment service unavailable', e));
+ *   ResultAsync.fromPromise(
+ *     processPayment(payload),
+ *     (e) => retryable('Payment service unavailable', e),
+ *   ).map(() => undefined);
  *
  * // Equivalent to:
- * // .mapError((e) => new RetryableError('Payment service unavailable', e));
+ * // ResultAsync.fromPromise(processPayment(payload), (e) => new RetryableError('...', e))
  * ```
  */
 export function retryable(message: string, cause?: unknown): RetryableError {
@@ -177,17 +178,17 @@ export function retryable(message: string, cause?: unknown): RetryableError {
  * @example
  * ```typescript
  * import { nonRetryable } from '@amqp-contract/worker';
- * import { Future, Result } from '@swan-io/boxed';
+ * import { errAsync, okAsync } from 'neverthrow';
  *
  * const handler = ({ payload }) => {
  *   if (!isValidPayload(payload)) {
- *     return Future.value(Result.Error(nonRetryable('Invalid payload format')));
+ *     return errAsync(nonRetryable('Invalid payload format'));
  *   }
- *   return Future.value(Result.Ok(undefined));
+ *   return okAsync(undefined);
  * };
  *
  * // Equivalent to:
- * // return Future.value(Result.Error(new NonRetryableError('Invalid payload format')));
+ * // return errAsync(new NonRetryableError('Invalid payload format'));
  * ```
  */
 export function nonRetryable(message: string, cause?: unknown): NonRetryableError {

--- a/packages/worker/src/handlers.spec.ts
+++ b/packages/worker/src/handlers.spec.ts
@@ -1,4 +1,4 @@
-import { Future, Result } from "@swan-io/boxed";
+import { errAsync, okAsync } from "neverthrow";
 import { NonRetryableError, RetryableError } from "./errors.js";
 import {
   defineConsumer,
@@ -65,7 +65,7 @@ describe("handlers", () => {
       // GIVEN
       const handler = ({ payload }: { payload: { id: string; data: string } }) => {
         console.log(payload.id);
-        return Future.value(Result.Ok(undefined));
+        return okAsync(undefined);
       };
 
       // WHEN
@@ -79,7 +79,7 @@ describe("handlers", () => {
       // GIVEN
       const handler = ({ payload }: { payload: { id: string; data: string } }) => {
         console.log(payload.id);
-        return Future.value(Result.Ok(undefined));
+        return okAsync(undefined);
       };
 
       // WHEN
@@ -93,7 +93,7 @@ describe("handlers", () => {
       // GIVEN
       const handler = ({ payload }: { payload: { id: string; data: string } }) => {
         console.log(payload.id);
-        return Future.value(Result.Ok(undefined));
+        return okAsync(undefined);
       };
 
       // WHEN/THEN
@@ -112,11 +112,11 @@ describe("handlers", () => {
       const handlers = {
         testConsumer: ({ payload }: { payload: { id: string; data: string } }) => {
           console.log(payload.id);
-          return Future.value(Result.Ok(undefined));
+          return okAsync(undefined);
         },
         anotherConsumer: ({ payload }: { payload: { id: string; data: string } }) => {
           console.log(payload.data);
-          return Future.value(Result.Ok(undefined));
+          return okAsync(undefined);
         },
       };
 
@@ -132,11 +132,11 @@ describe("handlers", () => {
       const handlers = {
         testConsumer: ({ payload }: { payload: { id: string; data: string } }) => {
           console.log(payload.id);
-          return Future.value(Result.Ok(undefined));
+          return okAsync(undefined);
         },
         nonExistentConsumer: ({ payload }: { payload: { id: string; data: string } }) => {
           console.log(payload.data);
-          return Future.value(Result.Ok(undefined));
+          return okAsync(undefined);
         },
       };
 
@@ -157,7 +157,7 @@ describe("handlers", () => {
         _message: { payload: { id: string; data: string } },
         _rawMessage: ConsumeMessage,
       ) => {
-        return Future.value(Result.Error(new RetryableError("Transient failure")));
+        return errAsync(new RetryableError("Transient failure"));
       };
 
       // WHEN
@@ -180,7 +180,7 @@ describe("handlers", () => {
         _message: { payload: { id: string; data: string } },
         _rawMessage: ConsumeMessage,
       ) => {
-        return Future.value(Result.Error(new NonRetryableError("Invalid message")));
+        return errAsync(new NonRetryableError("Invalid message"));
       };
 
       // WHEN

--- a/packages/worker/src/handlers.ts
+++ b/packages/worker/src/handlers.ts
@@ -56,7 +56,7 @@ function validateHandlers<TContract extends ContractDefinition>(
 /**
  * Define a type-safe handler for a specific consumer in a contract.
  *
- * **Recommended:** This function creates handlers that return `Future<Result<void, HandlerError>>`,
+ * **Recommended:** This function creates handlers that return `ResultAsync<void, HandlerError>`,
  * providing explicit error handling and better control over retry behavior.
  *
  * Supports two patterns:
@@ -67,24 +67,25 @@ function validateHandlers<TContract extends ContractDefinition>(
  * @template TName - The consumer name from the contract
  * @param contract - The contract definition containing the consumer
  * @param consumerName - The name of the consumer from the contract
- * @param handler - The handler function that returns `Future<Result<void, HandlerError>>`
+ * @param handler - The handler function that returns `ResultAsync<void, HandlerError>`
  * @param options - Optional consumer options (prefetch)
  * @returns A type-safe handler that can be used with TypedAmqpWorker
  *
  * @example
  * ```typescript
  * import { defineHandler, RetryableError, NonRetryableError } from '@amqp-contract/worker';
- * import { Future, Result } from '@swan-io/boxed';
+ * import { errAsync, okAsync, ResultAsync } from 'neverthrow';
  * import { orderContract } from './contract';
  *
- * // Simple handler with explicit error handling using mapError
+ * // Simple handler with explicit error handling
  * const processOrderHandler = defineHandler(
  *   orderContract,
  *   'processOrder',
  *   ({ payload }) =>
- *     Future.fromPromise(processPayment(payload))
- *       .mapOk(() => undefined)
- *       .mapError((error) => new RetryableError('Payment failed', error))
+ *     ResultAsync.fromPromise(
+ *       processPayment(payload),
+ *       (error) => new RetryableError('Payment failed', error),
+ *     ).map(() => undefined),
  * );
  *
  * // Handler with validation (non-retryable error)
@@ -94,10 +95,10 @@ function validateHandlers<TContract extends ContractDefinition>(
  *   ({ payload }) => {
  *     if (payload.amount < 1) {
  *       // Won't be retried - goes directly to DLQ
- *       return Future.value(Result.Error(new NonRetryableError('Invalid order amount')));
+ *       return errAsync(new NonRetryableError('Invalid order amount'));
  *     }
- *     return Future.value(Result.Ok(undefined));
- *   }
+ *     return okAsync(undefined);
+ *   },
  * );
  * ```
  */
@@ -138,7 +139,7 @@ export function defineHandler<
 /**
  * Define multiple type-safe handlers for consumers in a contract.
  *
- * **Recommended:** This function creates handlers that return `Future<Result<void, HandlerError>>`,
+ * **Recommended:** This function creates handlers that return `ResultAsync<void, HandlerError>`,
  * providing explicit error handling and better control over retry behavior.
  *
  * @template TContract - The contract definition type
@@ -149,18 +150,20 @@ export function defineHandler<
  * @example
  * ```typescript
  * import { defineHandlers, RetryableError } from '@amqp-contract/worker';
- * import { Future } from '@swan-io/boxed';
+ * import { ResultAsync } from 'neverthrow';
  * import { orderContract } from './contract';
  *
  * const handlers = defineHandlers(orderContract, {
  *   processOrder: ({ payload }) =>
- *     Future.fromPromise(processPayment(payload))
- *       .mapOk(() => undefined)
- *       .mapError((error) => new RetryableError('Payment failed', error)),
+ *     ResultAsync.fromPromise(
+ *       processPayment(payload),
+ *       (error) => new RetryableError('Payment failed', error),
+ *     ).map(() => undefined),
  *   notifyOrder: ({ payload }) =>
- *     Future.fromPromise(sendNotification(payload))
- *       .mapOk(() => undefined)
- *       .mapError((error) => new RetryableError('Notification failed', error)),
+ *     ResultAsync.fromPromise(
+ *       sendNotification(payload),
+ *       (error) => new RetryableError('Notification failed', error),
+ *     ).map(() => undefined),
  * });
  * ```
  */

--- a/packages/worker/src/retry.ts
+++ b/packages/worker/src/retry.ts
@@ -6,8 +6,8 @@ import {
   isQueueWithTtlBackoffInfrastructure,
 } from "@amqp-contract/contract";
 import { type AmqpClient, type Logger, TechnicalError } from "@amqp-contract/core";
-import { Future, Result } from "@swan-io/boxed";
 import type { ConsumeMessage } from "amqplib";
+import { err, errAsync, ok, okAsync, ResultAsync } from "neverthrow";
 import { NonRetryableError } from "./errors.js";
 
 type RetryContext = {
@@ -39,7 +39,7 @@ export function handleError(
   msg: ConsumeMessage,
   consumerName: string,
   consumer: ConsumerDefinition,
-): Future<Result<void, TechnicalError>> {
+): ResultAsync<void, TechnicalError> {
   // NonRetryableError -> send directly to DLQ without retrying
   if (error instanceof NonRetryableError) {
     ctx.logger?.error("Non-retryable error, sending to DLQ immediately", {
@@ -48,7 +48,7 @@ export function handleError(
       error: error.message,
     });
     sendToDLQ(ctx, msg, consumer);
-    return Future.value(Result.Ok(undefined));
+    return okAsync(undefined);
   }
 
   // Get retry config from the queue definition in the contract
@@ -70,7 +70,7 @@ export function handleError(
     error: error.message,
   });
   sendToDLQ(ctx, msg, consumer);
-  return Future.value(Result.Ok(undefined));
+  return okAsync(undefined);
 }
 
 /**
@@ -89,7 +89,7 @@ function handleErrorImmediateRequeue(
   consumerName: string,
   consumer: ConsumerDefinition,
   config: ResolvedImmediateRequeueRetryOptions,
-): Future<Result<void, TechnicalError>> {
+): ResultAsync<void, TechnicalError> {
   const queue = extractQueue(consumer.queue);
   const queueName = queue.name;
 
@@ -111,7 +111,7 @@ function handleErrorImmediateRequeue(
       error: error.message,
     });
     sendToDLQ(ctx, msg, consumer);
-    return Future.value(Result.Ok(undefined));
+    return okAsync(undefined);
   }
 
   ctx.logger?.warn("Retrying message (immediate-requeue mode)", {
@@ -125,7 +125,7 @@ function handleErrorImmediateRequeue(
   if (queue.type === "quorum") {
     // For quorum queues, nack with requeue=true to trigger native retry mechanism
     ctx.amqpClient.nack(msg, false, true);
-    return Future.value(Result.Ok(undefined));
+    return okAsync(undefined);
   } else {
     // For classic queues, re-publish the message to the same exchange / routing key immediately with an incremented x-retry-count header
     return publishForRetry(ctx, {
@@ -171,15 +171,13 @@ function handleErrorTtlBackoff(
   consumerName: string,
   consumer: ConsumerDefinition,
   config: ResolvedTtlBackoffRetryOptions,
-): Future<Result<void, TechnicalError>> {
+): ResultAsync<void, TechnicalError> {
   if (!isQueueWithTtlBackoffInfrastructure(consumer.queue)) {
     ctx.logger?.error("Queue does not have TTL-backoff infrastructure", {
       consumerName,
       queueName: consumer.queue.name,
     });
-    return Future.value(
-      Result.Error(new TechnicalError("Queue does not have TTL-backoff infrastructure")),
-    );
+    return errAsync(new TechnicalError("Queue does not have TTL-backoff infrastructure"));
   }
 
   const queueEntry = consumer.queue;
@@ -199,7 +197,7 @@ function handleErrorTtlBackoff(
       error: error.message,
     });
     sendToDLQ(ctx, msg, consumer);
-    return Future.value(Result.Ok(undefined));
+    return okAsync(undefined);
   }
 
   // Retry with exponential backoff
@@ -277,10 +275,10 @@ function parseMessageContentForRetry(
 
   try {
     return JSON.parse(msg.content.toString());
-  } catch (err) {
+  } catch (parseErr) {
     ctx.logger?.warn("Failed to parse JSON message for retry, using original buffer", {
       queueName,
-      error: err,
+      error: parseErr,
     });
     return msg.content;
   }
@@ -308,7 +306,7 @@ function publishForRetry(
     delayMs?: number;
     error: Error;
   },
-): Future<Result<void, TechnicalError>> {
+): ResultAsync<void, TechnicalError> {
   // Get retry count from headers
   const retryCount = (msg.properties.headers?.["x-retry-count"] as number) ?? 0;
   const newRetryCount = retryCount + 1;
@@ -337,16 +335,14 @@ function publishForRetry(
           : {}),
       },
     })
-    .mapOkToResult((published) => {
+    .andThen((published) => {
       if (!published) {
         ctx.logger?.error("Failed to publish message for retry (write buffer full)", {
           queueName,
           retryCount: newRetryCount,
           ...(delayMs !== undefined ? { delayMs } : {}),
         });
-        return Result.Error(
-          new TechnicalError("Failed to publish message for retry (write buffer full)"),
-        );
+        return err(new TechnicalError("Failed to publish message for retry (write buffer full)"));
       }
 
       ctx.logger?.info("Message published for retry", {
@@ -354,7 +350,7 @@ function publishForRetry(
         retryCount: newRetryCount,
         ...(delayMs !== undefined ? { delayMs } : {}),
       });
-      return Result.Ok(undefined);
+      return ok<void, TechnicalError>(undefined);
     });
 }
 

--- a/packages/worker/src/types.ts
+++ b/packages/worker/src/types.ts
@@ -8,8 +8,8 @@ import type {
   RpcDefinition,
 } from "@amqp-contract/contract";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
-import type { Future, Result } from "@swan-io/boxed";
 import type { ConsumeMessage } from "amqplib";
+import type { ResultAsync } from "neverthrow";
 import type { HandlerError } from "./errors.js";
 import { ConsumerOptions } from "./worker.js";
 
@@ -118,7 +118,7 @@ export type WorkerInferRpcHeaders<
 
 /**
  * Infer the response payload type for an RPC. The handler must return a
- * `Future<Result<TResponse, HandlerError>>` matching this shape.
+ * `ResultAsync<TResponse, HandlerError>` matching this shape.
  */
 export type WorkerInferRpcResponse<
   TContract extends ContractDefinition,
@@ -149,7 +149,7 @@ export type WorkerInferRpcResponse<
  *   console.log(message.payload.orderId);  // Typed payload
  *   console.log(message.headers?.priority); // Typed headers (if defined)
  *   console.log(rawMessage.fields.deliveryTag); // Raw AMQP message
- *   return Future.value(Result.Ok(undefined));
+ *   return okAsync(undefined);
  * });
  * ```
  */
@@ -186,13 +186,13 @@ export type WorkerInferRpcConsumedMessage<
 // =============================================================================
 // Handler Types
 // =============================================================================
-// All handlers return `Future<Result<TResponse, HandlerError>>` for explicit
+// All handlers return `ResultAsync<TResponse, HandlerError>` for explicit
 // error handling. Regular consumers return `void`; RPC handlers return the
 // response payload. RetryableError → exponential backoff retry; NonRetryableError → DLQ.
 
 /**
  * Handler signature for a regular consumer (event/command). Returns
- * `Future<Result<void, HandlerError>>` — there is no response message.
+ * `ResultAsync<void, HandlerError>` — there is no response message.
  */
 export type WorkerInferConsumerHandler<
   TContract extends ContractDefinition,
@@ -200,11 +200,11 @@ export type WorkerInferConsumerHandler<
 > = (
   message: WorkerInferConsumedMessage<TContract, TName>,
   rawMessage: ConsumeMessage,
-) => Future<Result<void, HandlerError>>;
+) => ResultAsync<void, HandlerError>;
 
 /**
  * Handler signature for an RPC. Returns
- * `Future<Result<TResponse, HandlerError>>` where `TResponse` is the inferred
+ * `ResultAsync<TResponse, HandlerError>` where `TResponse` is the inferred
  * response payload. The worker validates the response against the RPC's
  * response schema and publishes it back to `msg.properties.replyTo` with the
  * same `correlationId`.
@@ -215,7 +215,7 @@ export type WorkerInferRpcHandler<
 > = (
   message: WorkerInferRpcConsumedMessage<TContract, TName>,
   rawMessage: ConsumeMessage,
-) => Future<Result<WorkerInferRpcResponse<TContract, TName>, HandlerError>>;
+) => ResultAsync<WorkerInferRpcResponse<TContract, TName>, HandlerError>;
 
 /**
  * Handler entry for a regular consumer — function or `[handler, options]`.
@@ -246,11 +246,11 @@ export type WorkerInferRpcHandlerEntry<
  * ```typescript
  * const handlers: WorkerInferHandlers<typeof contract> = {
  *   processOrder: ({ payload }) =>
- *     Future.fromPromise(processPayment(payload))
- *       .mapOk(() => undefined)
- *       .mapError((error) => new RetryableError('Payment failed', error)),
- *   calculate: ({ payload }) =>
- *     Future.value(Result.Ok({ sum: payload.a + payload.b })),
+ *     ResultAsync.fromPromise(
+ *       processPayment(payload),
+ *       (error) => new RetryableError('Payment failed', error),
+ *     ).map(() => undefined),
+ *   calculate: ({ payload }) => okAsync({ sum: payload.a + payload.b }),
  * };
  * ```
  */

--- a/packages/worker/src/worker-cleanup.spec.ts
+++ b/packages/worker/src/worker-cleanup.spec.ts
@@ -18,9 +18,9 @@ describe("TypedAmqpWorker.create cleanup", () => {
       handlers: {},
       urls: ["amqp://localhost:1"],
       connectTimeoutMs: 200,
-    }).toPromise();
+    });
 
-    expect(result.isError()).toBe(true);
+    expect(result.isErr()).toBe(true);
     expect(_getConnectionCountForTesting()).toBe(0);
   });
 });

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -19,9 +19,9 @@ import {
   startConsumeSpan,
 } from "@amqp-contract/core";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
-import { Future, Result } from "@swan-io/boxed";
 import type { AmqpConnectionManagerOptions, ConnectionUrl } from "amqp-connection-manager";
 import type { ConsumeMessage } from "amqplib";
+import { err, errAsync, ok, okAsync, Result, ResultAsync } from "neverthrow";
 import { decompressBuffer } from "./decompression.js";
 import type { HandlerError } from "./errors.js";
 import { MessageValidationError, NonRetryableError } from "./errors.js";
@@ -44,7 +44,7 @@ type HandlerName<TContract extends ContractDefinition> =
 type StoredHandler = (
   message: { payload: unknown; headers: unknown },
   rawMessage: ConsumeMessage,
-) => Future<Result<unknown, HandlerError>>;
+) => ResultAsync<unknown, HandlerError>;
 
 export type ConsumerOptions = AmqpClientConsumerOptions;
 
@@ -68,13 +68,13 @@ function isHandlerTuple(entry: unknown): entry is [unknown, ConsumerOptions] {
  *     // Simple handler
  *     processOrder: ({ payload }) => {
  *       console.log('Processing order:', payload.orderId);
- *       return Future.value(Result.Ok(undefined));
+ *       return okAsync(undefined);
  *     },
  *     // Handler with prefetch configuration
  *     processPayment: [
  *       ({ payload }) => {
  *         console.log('Processing payment:', payload.paymentId);
- *         return Future.value(Result.Ok(undefined));
+ *         return okAsync(undefined);
  *       },
  *       { prefetch: 10 }
  *     ]
@@ -99,8 +99,8 @@ export type CreateWorkerOptions<TContract extends ContractDefinition> = {
   /**
    * Handlers for each `consumers` and `rpcs` entry in the contract.
    *
-   * - Regular consumers return `Future<Result<void, HandlerError>>`.
-   * - RPC handlers return `Future<Result<TResponse, HandlerError>>` where
+   * - Regular consumers return `ResultAsync<void, HandlerError>`.
+   * - RPC handlers return `ResultAsync<TResponse, HandlerError>` where
    *   `TResponse` is inferred from the RPC's response message schema.
    *
    * Use `defineHandler` / `defineHandlers` to create handlers with full type
@@ -126,7 +126,7 @@ export type CreateWorkerOptions<TContract extends ContractDefinition> = {
   defaultConsumerOptions?: ConsumerOptions | undefined;
   /**
    * Maximum time in ms to wait for the AMQP connection to become ready before
-   * `create()` resolves to `Result.Error<TechnicalError>`. Defaults to 30s
+   * `create()` resolves to an `err(TechnicalError)`. Defaults to 30s
    * (the {@link AmqpClient}'s `DEFAULT_CONNECT_TIMEOUT_MS`). Pass `null` to
    * disable the timeout and let amqp-connection-manager retry indefinitely.
    */
@@ -145,6 +145,7 @@ export type CreateWorkerOptions<TContract extends ContractDefinition> = {
  * ```typescript
  * import { TypedAmqpWorker } from '@amqp-contract/worker';
  * import { defineQueue, defineMessage, defineContract, defineConsumer } from '@amqp-contract/contract';
+ * import { okAsync } from 'neverthrow';
  * import { z } from 'zod';
  *
  * const orderQueue = defineQueue('order-processing');
@@ -159,19 +160,22 @@ export type CreateWorkerOptions<TContract extends ContractDefinition> = {
  *   }
  * });
  *
- * const worker = await TypedAmqpWorker.create({
+ * const result = await TypedAmqpWorker.create({
  *   contract,
  *   handlers: {
- *     processOrder: async (message) => {
- *       console.log('Processing order', message.orderId);
- *       // Process the order...
- *     }
+ *     processOrder: ({ payload }) => {
+ *       console.log('Processing order', payload.orderId);
+ *       return okAsync(undefined);
+ *     },
  *   },
- *   urls: ['amqp://localhost']
- * }).resultToPromise();
+ *   urls: ['amqp://localhost'],
+ * });
+ *
+ * if (result.isErr()) throw result.error;
+ * const worker = result.value;
  *
  * // Close when done
- * await worker.close().resultToPromise();
+ * await worker.close();
  * ```
  */
 export class TypedAmqpWorker<TContract extends ContractDefinition> {
@@ -260,18 +264,17 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
    * Connections are automatically shared across clients and workers with the same
    * URLs and connection options, following RabbitMQ best practices.
    *
-   * @param options - Configuration options for the worker
-   * @returns A Future that resolves to a Result containing the worker or an error
+   * @returns A ResultAsync that resolves to the worker or a TechnicalError.
    *
    * @example
    * ```typescript
-   * const worker = await TypedAmqpWorker.create({
+   * const result = await TypedAmqpWorker.create({
    *   contract: myContract,
    *   handlers: {
-   *     processOrder: async ({ payload }) => console.log('Order:', payload.orderId)
+   *     processOrder: ({ payload }) => okAsync(undefined),
    *   },
-   *   urls: ['amqp://localhost']
-   * }).resultToPromise();
+   *   urls: ['amqp://localhost'],
+   * });
    * ```
    */
   static create<TContract extends ContractDefinition>({
@@ -283,7 +286,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
     logger,
     telemetry,
     connectTimeoutMs,
-  }: CreateWorkerOptions<TContract>): Future<Result<TypedAmqpWorker<TContract>, TechnicalError>> {
+  }: CreateWorkerOptions<TContract>): ResultAsync<TypedAmqpWorker<TContract>, TechnicalError> {
     const worker = new TypedAmqpWorker(
       contract,
       new AmqpClient(contract, {
@@ -299,25 +302,26 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
 
     // Note: Wait queues are now created by the core package in setupAmqpTopology
     // when the queue's retry mode is "ttl-backoff"
-    return worker
-      .waitForConnectionReady()
-      .flatMapOk(() => worker.consumeAll())
-      .flatMap((result) =>
-        result.match({
-          Ok: () => Future.value(Result.Ok<TypedAmqpWorker<TContract>, TechnicalError>(worker)),
-          // Release the AmqpClient's connection ref-count and cancel any consumers
-          // that registered before the failure, so a failed create() does not leak.
-          Error: (error) =>
-            worker
-              .close()
-              .tapError((closeError) => {
-                logger?.warn("Failed to close worker after setup failure", {
-                  error: closeError,
-                });
-              })
-              .map(() => Result.Error<TypedAmqpWorker<TContract>, TechnicalError>(error)),
-        }),
-      );
+    const setup = worker.waitForConnectionReady().andThen(() => worker.consumeAll());
+
+    // If setup fails, release the AmqpClient's connection ref-count and cancel
+    // any consumers that registered before the failure, so a failed create()
+    // does not leak.
+    return new ResultAsync<TypedAmqpWorker<TContract>, TechnicalError>(
+      (async () => {
+        const setupResult = await setup;
+        if (setupResult.isOk()) {
+          return ok(worker);
+        }
+        const closeResult = await worker.close();
+        if (closeResult.isErr()) {
+          logger?.warn("Failed to close worker after setup failure", {
+            error: closeResult.error,
+          });
+        }
+        return err(setupResult.error);
+      })(),
+    );
   }
 
   /**
@@ -326,50 +330,46 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
    * This gracefully closes the connection to the AMQP broker,
    * stopping all message consumption and cleaning up resources.
    *
-   * @returns A Future that resolves to a Result indicating success or failure
-   *
    * @example
    * ```typescript
-   * const closeResult = await worker.close().resultToPromise();
+   * const closeResult = await worker.close();
    * if (closeResult.isOk()) {
    *   console.log('Worker closed successfully');
    * }
    * ```
    */
-  close(): Future<Result<void, TechnicalError>> {
-    return Future.all(
-      Array.from(this.consumerTags).map((consumerTag) =>
-        this.amqpClient.cancel(consumerTag).mapErrorToResult((error) => {
-          this.logger?.warn("Failed to cancel consumer during close", { consumerTag, error });
-          return Result.Ok(undefined);
-        }),
-      ),
-    )
-      .map(Result.all)
-      .tapOk(() => {
-        // Clear consumer tags after successful cancellation
+  close(): ResultAsync<void, TechnicalError> {
+    const cancellations = Array.from(this.consumerTags).map((consumerTag) =>
+      // Swallow per-consumer cancel errors during close — they are best-effort
+      // cleanup and we still want to release the underlying connection.
+      this.amqpClient.cancel(consumerTag).orElse((error) => {
+        this.logger?.warn("Failed to cancel consumer during close", { consumerTag, error });
+        return ok<void, TechnicalError>(undefined);
+      }),
+    );
+
+    return ResultAsync.combine(cancellations)
+      .andTee(() => {
         this.consumerTags.clear();
       })
-      .flatMapOk(() => this.amqpClient.close())
-      .mapOk(() => undefined);
+      .andThen(() => this.amqpClient.close())
+      .map(() => undefined);
   }
 
   /**
    * Start consuming for every entry in `contract.consumers` and `contract.rpcs`.
    */
-  private consumeAll(): Future<Result<void, TechnicalError>> {
+  private consumeAll(): ResultAsync<void, TechnicalError> {
     const consumerNames = Object.keys(
       this.contract.consumers ?? {},
     ) as InferConsumerNames<TContract>[];
     const rpcNames = Object.keys(this.contract.rpcs ?? {}) as InferRpcNames<TContract>[];
     const allNames = [...consumerNames, ...rpcNames] as HandlerName<TContract>[];
 
-    return Future.all(allNames.map((name) => this.consume(name)))
-      .map(Result.all)
-      .mapOk(() => undefined);
+    return ResultAsync.combine(allNames.map((name) => this.consume(name))).map(() => undefined);
   }
 
-  private waitForConnectionReady(): Future<Result<void, TechnicalError>> {
+  private waitForConnectionReady(): ResultAsync<void, TechnicalError> {
     return this.amqpClient.waitForConnect();
   }
 
@@ -377,7 +377,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
    * Start consuming messages for a specific handler — either a `consumers`
    * entry (regular event/command consumer) or an `rpcs` entry (RPC server).
    */
-  private consume(name: HandlerName<TContract>): Future<Result<void, TechnicalError>> {
+  private consume(name: HandlerName<TContract>): ResultAsync<void, TechnicalError> {
     const view = this.resolveConsumerView(name);
     // Non-null assertion safe: `WorkerInferHandlers<TContract>` requires every
     // consumers / rpcs key to have a handler, so by the time we reach this
@@ -396,24 +396,25 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
     schema: StandardSchemaV1,
     data: unknown,
     context: { consumerName: string; field: string },
-  ): Future<Result<unknown, TechnicalError>> {
+  ): ResultAsync<unknown, TechnicalError> {
     const rawValidation = schema["~standard"].validate(data);
     const validationPromise =
       rawValidation instanceof Promise ? rawValidation : Promise.resolve(rawValidation);
 
-    return Future.fromPromise(validationPromise)
-      .mapError((error) => new TechnicalError(`Error validating ${context.field}`, error))
-      .mapOkToResult((result) => {
-        if (result.issues) {
-          return Result.Error(
-            new TechnicalError(
-              `${context.field} validation failed`,
-              new MessageValidationError(context.consumerName, result.issues),
-            ),
-          );
-        }
-        return Result.Ok(result.value);
-      });
+    return ResultAsync.fromPromise(
+      validationPromise,
+      (error) => new TechnicalError(`Error validating ${context.field}`, error),
+    ).andThen((result) => {
+      if (result.issues) {
+        return err(
+          new TechnicalError(
+            `${context.field} validation failed`,
+            new MessageValidationError(context.consumerName, result.issues),
+          ),
+        );
+      }
+      return ok<unknown, TechnicalError>(result.value);
+    });
   }
 
   /**
@@ -427,26 +428,24 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
     msg: ConsumeMessage,
     consumer: ConsumerDefinition,
     consumerName: HandlerName<TContract>,
-  ): Future<Result<{ payload: unknown; headers: unknown }, TechnicalError>> {
+  ): ResultAsync<{ payload: unknown; headers: unknown }, TechnicalError> {
     const context = { consumerName: String(consumerName) };
 
     const parsePayload = decompressBuffer(msg.content, msg.properties.contentEncoding)
-      .mapErrorToResult((error) =>
-        Result.Error(new TechnicalError("Failed to decompress message", error)),
-      )
-      .mapOkToResult((buffer) =>
-        Result.fromExecution(() => JSON.parse(buffer.toString()) as unknown).mapError(
+      .andThen((buffer) =>
+        Result.fromThrowable(
+          () => JSON.parse(buffer.toString()) as unknown,
           (error) => new TechnicalError("Failed to parse JSON", error),
-        ),
+        )(),
       )
-      .flatMapOk((parsed) =>
+      .andThen((parsed) =>
         this.validateSchema(consumer.message.payload as StandardSchemaV1, parsed, {
           ...context,
           field: "payload",
         }),
       );
 
-    const parseHeaders = consumer.message.headers
+    const parseHeaders: ResultAsync<unknown, TechnicalError> = consumer.message.headers
       ? this.validateSchema(
           consumer.message.headers as StandardSchemaV1,
           msg.properties.headers ?? {},
@@ -455,11 +454,12 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
             field: "headers",
           },
         )
-      : Future.value(Result.Ok<unknown, TechnicalError>(undefined));
+      : okAsync(undefined);
 
-    return Future.allFromDict({ payload: parsePayload, headers: parseHeaders }).map(
-      Result.allFromDict,
-    ) as Future<Result<{ payload: unknown; headers: unknown }, TechnicalError>>;
+    return ResultAsync.combine([parsePayload, parseHeaders]).map(([payload, headers]) => ({
+      payload,
+      headers,
+    }));
   }
 
   /**
@@ -487,7 +487,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
     rpcName: HandlerName<TContract>,
     responseSchema: StandardSchemaV1,
     response: unknown,
-  ): Future<Result<void, HandlerError>> {
+  ): ResultAsync<void, HandlerError> {
     const replyTo = msg.properties.replyTo;
     const correlationId = msg.properties.correlationId;
     if (typeof replyTo !== "string" || replyTo.length === 0) {
@@ -495,11 +495,9 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
         "RPC handler returned a response but the incoming message has no replyTo",
         { rpcName: String(rpcName), queueName },
       );
-      return Future.value(
-        Result.Error<void, HandlerError>(
-          new NonRetryableError(
-            `RPC "${String(rpcName)}" received a message without replyTo; cannot deliver response`,
-          ),
+      return errAsync(
+        new NonRetryableError(
+          `RPC "${String(rpcName)}" received a message without replyTo; cannot deliver response`,
         ),
       );
     }
@@ -510,11 +508,9 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
         "RPC handler returned a response but the incoming message has no correlationId",
         { rpcName: String(rpcName), queueName, replyTo },
       );
-      return Future.value(
-        Result.Error<void, HandlerError>(
-          new NonRetryableError(
-            `RPC "${String(rpcName)}" received a message without correlationId; cannot deliver response`,
-          ),
+      return errAsync(
+        new NonRetryableError(
+          `RPC "${String(rpcName)}" received a message without correlationId; cannot deliver response`,
         ),
       );
     }
@@ -526,32 +522,28 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
     try {
       rawValidation = responseSchema["~standard"].validate(response);
     } catch (error: unknown) {
-      return Future.value(
-        Result.Error<void, HandlerError>(
-          new NonRetryableError("RPC response schema validation threw", error),
-        ),
-      );
+      return errAsync(new NonRetryableError("RPC response schema validation threw", error));
     }
     const validationPromise =
       rawValidation instanceof Promise ? rawValidation : Promise.resolve(rawValidation);
 
-    return Future.fromPromise(validationPromise)
-      .mapError(
-        (error: unknown) =>
-          new NonRetryableError("RPC response schema validation threw", error) as HandlerError,
-      )
-      .mapOkToResult((validation) => {
+    return ResultAsync.fromPromise(
+      validationPromise,
+      (error: unknown) =>
+        new NonRetryableError("RPC response schema validation threw", error) as HandlerError,
+    )
+      .andThen((validation) => {
         if (validation.issues) {
-          return Result.Error<unknown, HandlerError>(
+          return err<unknown, HandlerError>(
             new NonRetryableError(
               `RPC response for "${String(rpcName)}" failed schema validation`,
               new MessageValidationError(String(rpcName), validation.issues),
             ),
           );
         }
-        return Result.Ok<unknown, HandlerError>(validation.value);
+        return ok<unknown, HandlerError>(validation.value);
       })
-      .flatMapOk((validatedResponse) =>
+      .andThen((validatedResponse) =>
         this.amqpClient
           .publish("", replyTo, validatedResponse, {
             correlationId,
@@ -562,15 +554,14 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
           // already (or will soon) time out. Retrying the original message
           // re-runs the handler against a stale caller. Send to DLQ instead so
           // the failure is visible without churning the queue.
-          .mapErrorToResult((error: TechnicalError) =>
-            Result.Error<void, HandlerError>(
+          .mapErr(
+            (error: TechnicalError): HandlerError =>
               new NonRetryableError("Failed to publish RPC response", error),
-            ),
           )
-          .mapOkToResult((published) =>
+          .andThen((published) =>
             published
-              ? Result.Ok<void, HandlerError>(undefined)
-              : Result.Error<void, HandlerError>(
+              ? ok<void, HandlerError>(undefined)
+              : err<void, HandlerError>(
                   new NonRetryableError("Failed to publish RPC response: channel buffer full"),
                 ),
           ),
@@ -586,7 +577,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
     view: { consumer: ConsumerDefinition; isRpc: boolean; responseSchema?: StandardSchemaV1 },
     name: HandlerName<TContract>,
     handler: StoredHandler,
-  ): Future<Result<void, TechnicalError>> {
+  ): ResultAsync<void, TechnicalError> {
     const { consumer, isRpc, responseSchema } = view;
     const queueName = extractQueue(consumer.queue).name;
     const startTime = Date.now();
@@ -597,86 +588,83 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
     let messageHandled = false;
     let firstError: Error | undefined;
 
-    return this.parseAndValidateMessage(msg, consumer, name)
-      .flatMap((parseResult) =>
-        parseResult.match({
-          Ok: (validatedMessage) =>
-            handler(validatedMessage, msg)
-              .flatMapOk((handlerResponse) => {
-                if (isRpc && responseSchema) {
-                  return this.publishRpcResponse(
-                    msg,
-                    queueName,
-                    name,
-                    responseSchema,
-                    handlerResponse,
-                  ).flatMapOk(() => {
-                    this.logger?.info("Message consumed successfully", {
-                      consumerName: String(name),
-                      queueName,
-                    });
-                    this.amqpClient.ack(msg);
-                    messageHandled = true;
-                    return Future.value(Result.Ok<void, HandlerError>(undefined));
-                  });
-                }
+    // Parse / validation failure path: nack once with requeue=false so the
+    // queue's DLX (if configured) receives the poison message. We bypass
+    // handleError() because a malformed payload is deterministic — retrying
+    // it would burn the queue's retry budget on a guaranteed failure.
+    const parsedOrNack = this.parseAndValidateMessage(msg, consumer, name).orElse((parseError) => {
+      firstError = parseError;
+      this.logger?.error("Failed to parse/validate message; sending to DLQ", {
+        consumerName: String(name),
+        queueName,
+        error: parseError,
+      });
+      this.amqpClient.nack(msg, false, false);
+      return errAsync(parseError);
+    });
 
-                this.logger?.info("Message consumed successfully", {
-                  consumerName: String(name),
-                  queueName,
-                });
-                this.amqpClient.ack(msg);
-                messageHandled = true;
-
-                return Future.value(Result.Ok<void, HandlerError>(undefined));
-              })
-              .flatMapError((handlerError: HandlerError) => {
-                this.logger?.error("Error processing message", {
-                  consumerName: String(name),
-                  queueName,
-                  errorType: handlerError.name,
-                  error: handlerError.message,
-                });
-                firstError = handlerError;
-
-                return handleError(
-                  { amqpClient: this.amqpClient, logger: this.logger },
-                  handlerError,
-                  msg,
-                  String(name),
-                  consumer,
-                );
-              }),
-          // Parse / validation failure path: nack once with requeue=false so the
-          // queue's DLX (if configured) receives the poison message. We bypass
-          // handleError() because a malformed payload is deterministic — retrying
-          // it would burn the queue's retry budget on a guaranteed failure.
-          Error: (parseError) => {
-            firstError = parseError;
-            this.logger?.error("Failed to parse/validate message; sending to DLQ", {
-              consumerName: String(name),
+    const inner: ResultAsync<void, TechnicalError> = parsedOrNack.andThen((validatedMessage) =>
+      handler(validatedMessage, msg)
+        .andThen<void, HandlerError>((handlerResponse) => {
+          if (isRpc && responseSchema) {
+            return this.publishRpcResponse(
+              msg,
               queueName,
-              error: parseError,
+              name,
+              responseSchema,
+              handlerResponse,
+            ).map(() => {
+              this.logger?.info("Message consumed successfully", {
+                consumerName: String(name),
+                queueName,
+              });
+              this.amqpClient.ack(msg);
+              messageHandled = true;
             });
-            this.amqpClient.nack(msg, false, false);
-            return Future.value(Result.Error<void, TechnicalError>(parseError));
-          },
+          }
+
+          this.logger?.info("Message consumed successfully", {
+            consumerName: String(name),
+            queueName,
+          });
+          this.amqpClient.ack(msg);
+          messageHandled = true;
+          return okAsync<void, HandlerError>(undefined);
+        })
+        .orElse((handlerError: HandlerError) => {
+          this.logger?.error("Error processing message", {
+            consumerName: String(name),
+            queueName,
+            errorType: handlerError.name,
+            error: handlerError.message,
+          });
+          firstError = handlerError;
+
+          return handleError(
+            { amqpClient: this.amqpClient, logger: this.logger },
+            handlerError,
+            msg,
+            String(name),
+            consumer,
+          );
         }),
-      )
-      .map((result) => {
+    );
+
+    return new ResultAsync<void, TechnicalError>(
+      (async () => {
+        const result = await inner;
         const durationMs = Date.now() - startTime;
         if (messageHandled) {
           endSpanSuccess(span);
           recordConsumeMetric(this.telemetry, queueName, String(name), true, durationMs);
         } else {
-          const error = result.isError()
-            ? result.error
-            : (firstError ?? new Error("Unknown error"));
+          const error = result.isErr() ? result.error : (firstError ?? new Error("Unknown error"));
           endSpanError(span, error);
           recordConsumeMetric(this.telemetry, queueName, String(name), false, durationMs);
         }
         return result;
-      });
+      })(),
+    );
   }
 
   /**
@@ -686,7 +674,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
     name: HandlerName<TContract>,
     view: { consumer: ConsumerDefinition; isRpc: boolean; responseSchema?: StandardSchemaV1 },
     handler: StoredHandler,
-  ): Future<Result<void, TechnicalError>> {
+  ): ResultAsync<void, TechnicalError> {
     const queueName = extractQueue(view.consumer.queue).name;
 
     return this.amqpClient
@@ -700,15 +688,15 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
             });
             return;
           }
-          // The dispatch path is built on `Future<Result<…>>` so handler
-          // failures are values, not exceptions. Defensively guard the
-          // boundary anyway: a handler that violates the contract by throwing
-          // synchronously (or any unexpected fault inside processMessage)
-          // would otherwise leave the message neither acked nor nacked, and
-          // amqp-connection-manager would not redeliver it until the channel
-          // closes. nack(requeue=false) routes it via DLX if configured.
+          // The dispatch path is built on `ResultAsync` so handler failures
+          // are values, not exceptions. Defensively guard the boundary anyway:
+          // a handler that violates the contract by throwing synchronously (or
+          // any unexpected fault inside processMessage) would otherwise leave
+          // the message neither acked nor nacked, and amqp-connection-manager
+          // would not redeliver it until the channel closes. nack(requeue=false)
+          // routes it via DLX if configured.
           try {
-            await this.processMessage(msg, view, name, handler).toPromise();
+            await this.processMessage(msg, view, name, handler);
           } catch (error: unknown) {
             this.logger?.error("Uncaught error in consume callback; nacking message", {
               consumerName: String(name),
@@ -720,12 +708,12 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
         },
         this.consumerOptions[name],
       )
-      .tapOk((consumerTag) => {
+      .andTee((consumerTag) => {
         this.consumerTags.add(consumerTag);
       })
-      .mapError(
+      .map(() => undefined)
+      .mapErr(
         (error) => new TechnicalError(`Failed to start consuming for "${String(name)}"`, error),
-      )
-      .mapOk(() => undefined);
+      );
   }
 }

--- a/packages/worker/tsdown.config.ts
+++ b/packages/worker/tsdown.config.ts
@@ -1,9 +1,9 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  // Prevent @swan-io/boxed types from being inlined into the declaration files
-  // This ensures type compatibility across packages that use boxed types
-  external: ["@swan-io/boxed"],
+  // Prevent neverthrow types from being inlined into the declaration files.
+  // This ensures type compatibility across packages that re-export them.
+  external: ["neverthrow"],
   // Suppress warnings about bundled dependencies in declaration files
   inlineOnly: false,
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,9 +36,6 @@ catalogs:
     '@standard-schema/spec':
       specifier: 1.1.0
       version: 1.1.0
-    '@swan-io/boxed':
-      specifier: 3.2.1
-      version: 3.2.1
     '@types/amqplib':
       specifier: 0.10.8
       version: 0.10.8
@@ -66,6 +63,9 @@ catalogs:
     mermaid:
       specifier: 11.14.0
       version: 11.14.0
+    neverthrow:
+      specifier: 8.2.0
+      version: 8.2.0
     oxfmt:
       specifier: 0.47.0
       version: 0.47.0
@@ -225,12 +225,12 @@ importers:
       '@amqp-contract/tsconfig':
         specifier: workspace:*
         version: link:../../tools/tsconfig
-      '@swan-io/boxed':
-        specifier: 'catalog:'
-        version: 3.2.1(typescript@6.0.3)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.5(vitest@4.1.5)
+      neverthrow:
+        specifier: 'catalog:'
+        version: 8.2.0
       tsx:
         specifier: 'catalog:'
         version: 4.21.0
@@ -283,9 +283,9 @@ importers:
       '@amqp-contract/worker':
         specifier: workspace:*
         version: link:../../packages/worker
-      '@swan-io/boxed':
+      neverthrow:
         specifier: 'catalog:'
-        version: 3.2.1(typescript@6.0.3)
+        version: 8.2.0
       pino:
         specifier: 'catalog:'
         version: 10.3.1
@@ -387,9 +387,9 @@ importers:
       '@standard-schema/spec':
         specifier: 'catalog:'
         version: 1.1.0
-      '@swan-io/boxed':
+      neverthrow:
         specifier: 'catalog:'
-        version: 3.2.1(typescript@6.0.3)
+        version: 8.2.0
       ts-pattern:
         specifier: 'catalog:'
         version: 5.9.0
@@ -476,15 +476,15 @@ importers:
       '@amqp-contract/contract':
         specifier: workspace:*
         version: link:../contract
-      '@swan-io/boxed':
-        specifier: 'catalog:'
-        version: 3.2.1(typescript@6.0.3)
       amqp-connection-manager:
         specifier: 'catalog:'
         version: 5.0.0(amqplib@0.10.9)
       amqplib:
         specifier: 'catalog:'
         version: 0.10.9
+      neverthrow:
+        specifier: 'catalog:'
+        version: 8.2.0
     devDependencies:
       '@amqp-contract/testing':
         specifier: workspace:*
@@ -565,9 +565,9 @@ importers:
       '@standard-schema/spec':
         specifier: 'catalog:'
         version: 1.1.0
-      '@swan-io/boxed':
+      neverthrow:
         specifier: 'catalog:'
-        version: 3.2.1(typescript@6.0.3)
+        version: 8.2.0
     devDependencies:
       '@amqp-contract/testing':
         specifier: workspace:*
@@ -629,9 +629,9 @@ importers:
       '@amqp-contract/worker':
         specifier: workspace:*
         version: link:../packages/worker
-      '@swan-io/boxed':
+      neverthrow:
         specifier: 'catalog:'
-        version: 3.2.1(typescript@6.0.3)
+        version: 8.2.0
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -2068,6 +2068,12 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@shikijs/core@2.5.0':
     resolution: {integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==}
 
@@ -2183,15 +2189,6 @@ packages:
   '@stoplight/yaml@4.3.0':
     resolution: {integrity: sha512-JZlVFE6/dYpP9tQmV0/ADfn32L9uFarHWxfcRhReKUnljz1ZiUM5zpX+PH8h5CJs6lao3TuFqnPm9IJJCEkE2w==}
     engines: {node: '>=10.8'}
-
-  '@swan-io/boxed@3.2.1':
-    resolution: {integrity: sha512-MQqSpe09PdjDjTR4HCPpUxO9XsacNguCkce1C2wm1eIb6ycWXQoV+biYvLEuI/LiMqB31KySdgY2YFwrVucLCw==}
-    deprecated: This package has been transferred to @bloodyowl/boxed
-    peerDependencies:
-      typescript: '>=5.0.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   '@turbo/darwin-64@2.9.8':
     resolution: {integrity: sha512-zU1P95ygDpsQ+2QHh7CVTqvYwi9UBlhKWzoIyUnP3vUoge7H9SQEzrd8dj+XcTrslAp9Db3vIBcXtMVoTEYDnA==}
@@ -4052,6 +4049,10 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  neverthrow@8.2.0:
+    resolution: {integrity: sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ==}
+    engines: {node: '>=18'}
 
   nimma@0.2.3:
     resolution: {integrity: sha512-1ZOI8J+1PKKGceo/5CT5GfQOG6H8I2BencSK06YarZ2wXwH37BSSUWldqJmMJYA5JfqDqffxDXynt6f11AyKcA==}
@@ -6404,6 +6405,9 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
 
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
   '@shikijs/core@2.5.0':
     dependencies:
       '@shikijs/engine-javascript': 2.5.0
@@ -6612,10 +6616,6 @@ snapshots:
       '@stoplight/types': 14.1.1
       '@stoplight/yaml-ast-parser': 0.0.50
       tslib: 2.8.1
-
-  '@swan-io/boxed@3.2.1(typescript@6.0.3)':
-    optionalDependencies:
-      typescript: 6.0.3
 
   '@turbo/darwin-64@2.9.8':
     optional: true
@@ -8608,6 +8608,10 @@ snapshots:
     optional: true
 
   nanoid@3.3.11: {}
+
+  neverthrow@8.2.0:
+    optionalDependencies:
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
 
   nimma@0.2.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,7 +30,6 @@ catalog:
   "@orpc/valibot": 1.14.1
   "@orpc/zod": 1.14.1
   "@standard-schema/spec": 1.1.0
-  "@swan-io/boxed": 3.2.1
   "@types/amqplib": 0.10.8
   "@types/node": 24.12.2
   "@vitest/coverage-v8": 4.1.5
@@ -40,6 +39,7 @@ catalog:
   knip: 6.11.0
   lefthook: 2.1.6
   mermaid: 11.14.0
+  neverthrow: 8.2.0
   oxfmt: 0.47.0
   oxlint: 1.62.0
   pino: 10.3.1

--- a/tests/package.json
+++ b/tests/package.json
@@ -13,7 +13,7 @@
     "@amqp-contract/core": "workspace:*",
     "@amqp-contract/testing": "workspace:*",
     "@amqp-contract/worker": "workspace:*",
-    "@swan-io/boxed": "catalog:"
+    "neverthrow": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/tests/src/client-worker.spec.ts
+++ b/tests/src/client-worker.spec.ts
@@ -14,7 +14,7 @@ import {
   type WorkerInferConsumerHandlers,
   defineHandlers,
 } from "@amqp-contract/worker";
-import { Future, Result } from "@swan-io/boxed";
+import { ok, okAsync } from "neverthrow";
 import { describe, expect, vi } from "vitest";
 import { z } from "zod";
 
@@ -32,10 +32,12 @@ const it = baseIt.extend<{
 
     try {
       await use(async <TContract extends ContractDefinition>(contract: TContract) => {
-        const client = await TypedAmqpClient.create({
-          contract,
-          urls: [amqpConnectionUrl],
-        }).resultToPromise();
+        const client = (
+          await TypedAmqpClient.create({
+            contract,
+            urls: [amqpConnectionUrl],
+          })
+        )._unsafeUnwrap();
 
         clients.push(client);
         return client;
@@ -45,7 +47,7 @@ const it = baseIt.extend<{
       await Promise.all(
         clients.map(async (client) => {
           try {
-            await client.close().resultToPromise();
+            (await client.close())._unsafeUnwrap();
           } catch (error) {
             // Swallow errors during cleanup to avoid unhandled rejections
             // eslint-disable-next-line no-console
@@ -63,11 +65,13 @@ const it = baseIt.extend<{
           contract: TContract,
           handlers: WorkerInferConsumerHandlers<TContract>,
         ) => {
-          const worker = await TypedAmqpWorker.create({
-            contract,
-            handlers: defineHandlers(contract, handlers),
-            urls: [amqpConnectionUrl],
-          }).resultToPromise();
+          const worker = (
+            await TypedAmqpWorker.create({
+              contract,
+              handlers: defineHandlers(contract, handlers),
+              urls: [amqpConnectionUrl],
+            })
+          )._unsafeUnwrap();
 
           workers.push(worker);
           return worker;
@@ -78,7 +82,7 @@ const it = baseIt.extend<{
       await Promise.all(
         workers.map(async (worker) => {
           try {
-            await worker.close().resultToPromise();
+            (await worker.close())._unsafeUnwrap();
           } catch (error) {
             // Swallow errors during cleanup to avoid unhandled rejections
             // eslint-disable-next-line no-console
@@ -139,7 +143,7 @@ describe("Client and Worker Integration", () => {
       });
 
       // GIVEN
-      const mockHandler = vi.fn().mockReturnValue(Future.value(Result.Ok(undefined)));
+      const mockHandler = vi.fn().mockReturnValue(okAsync(undefined));
       await workerFactory(contract, {
         processOrder: mockHandler,
       });
@@ -166,7 +170,7 @@ describe("Client and Worker Integration", () => {
       );
 
       // THEN
-      expect(publishResult).toEqual(Result.Ok(undefined));
+      expect(publishResult).toEqual(ok(undefined));
 
       await vi.waitFor(
         () => {
@@ -223,7 +227,7 @@ describe("Client and Worker Integration", () => {
       const receivedMessages: unknown[] = [];
       const mockHandler = vi.fn().mockImplementation((message: unknown) => {
         receivedMessages.push(message);
-        return Future.value(Result.Ok(undefined));
+        return okAsync(undefined);
       });
       await workerFactory(contract, {
         processEvent: mockHandler,
@@ -242,7 +246,7 @@ describe("Client and Worker Integration", () => {
 
       for (const message of messages) {
         const result = await client.publish("eventPublisher", message);
-        expect(result).toEqual(Result.Ok(undefined));
+        expect(result).toEqual(ok(undefined));
       }
 
       // THEN
@@ -289,7 +293,7 @@ describe("Client and Worker Integration", () => {
         },
       });
 
-      const mockHandler = vi.fn().mockReturnValue(Future.value(Result.Ok(undefined)));
+      const mockHandler = vi.fn().mockReturnValue(okAsync(undefined));
       await workerFactory(contract, {
         processStrict: mockHandler,
       });
@@ -305,7 +309,7 @@ describe("Client and Worker Integration", () => {
       } as never);
 
       // THEN
-      expect(invalidResult.isError()).toBe(true);
+      expect(invalidResult.isErr()).toBe(true);
 
       // WHEN
       const validResult = await client.publish("strictPublisher", {
@@ -314,7 +318,7 @@ describe("Client and Worker Integration", () => {
       });
 
       // THEN
-      expect(validResult).toEqual(Result.Ok(undefined));
+      expect(validResult).toEqual(ok(undefined));
 
       await vi.waitFor(
         () => {
@@ -365,8 +369,8 @@ describe("Client and Worker Integration", () => {
       });
 
       // GIVEN
-      const emailHandler = vi.fn().mockReturnValue(Future.value(Result.Ok(undefined)));
-      const smsHandler = vi.fn().mockReturnValue(Future.value(Result.Ok(undefined)));
+      const emailHandler = vi.fn().mockReturnValue(okAsync(undefined));
+      const smsHandler = vi.fn().mockReturnValue(okAsync(undefined));
 
       await workerFactory(contract, {
         processEmail: emailHandler,
@@ -382,14 +386,14 @@ describe("Client and Worker Integration", () => {
         recipient: "user@example.com",
         message: "Test email",
       });
-      expect(emailResult).toEqual(Result.Ok(undefined));
+      expect(emailResult).toEqual(ok(undefined));
 
       // WHEN
       const smsResult = await client.publish("smsNotification", {
         recipient: "+1234567890",
         message: "Test SMS",
       });
-      expect(smsResult).toEqual(Result.Ok(undefined));
+      expect(smsResult).toEqual(ok(undefined));
 
       // THEN
       await vi.waitFor(

--- a/tests/src/rpc.spec.ts
+++ b/tests/src/rpc.spec.ts
@@ -14,7 +14,7 @@ import {
 import { TechnicalError } from "@amqp-contract/core";
 import { it as baseIt } from "@amqp-contract/testing/extension";
 import { TypedAmqpWorker } from "@amqp-contract/worker";
-import { Future, Result } from "@swan-io/boxed";
+import { okAsync, ResultAsync } from "neverthrow";
 import { describe, expect } from "vitest";
 import { z } from "zod";
 
@@ -31,11 +31,13 @@ const it = baseIt.extend<{
     const workers: Array<TypedAmqpWorker<ContractDefinition>> = [];
     try {
       await use(async (contract, handlers) => {
-        const worker = await TypedAmqpWorker.create({
-          contract,
-          handlers,
-          urls: [amqpConnectionUrl],
-        }).resultToPromise();
+        const worker = (
+          await TypedAmqpWorker.create({
+            contract,
+            handlers,
+            urls: [amqpConnectionUrl],
+          })
+        )._unsafeUnwrap();
         workers.push(worker as TypedAmqpWorker<ContractDefinition>);
         return worker;
       });
@@ -44,7 +46,7 @@ const it = baseIt.extend<{
         workers.map((w) =>
           w
             .close()
-            .resultToPromise()
+            .then((r) => r._unsafeUnwrap())
             .catch(() => undefined),
         ),
       );
@@ -54,10 +56,12 @@ const it = baseIt.extend<{
     const clients: Array<TypedAmqpClient<ContractDefinition>> = [];
     try {
       await use(async (contract) => {
-        const client = await TypedAmqpClient.create({
-          contract,
-          urls: [amqpConnectionUrl],
-        }).resultToPromise();
+        const client = (
+          await TypedAmqpClient.create({
+            contract,
+            urls: [amqpConnectionUrl],
+          })
+        )._unsafeUnwrap();
         clients.push(client as TypedAmqpClient<ContractDefinition>);
         return client;
       });
@@ -66,7 +70,7 @@ const it = baseIt.extend<{
         clients.map((c) =>
           c
             .close()
-            .resultToPromise()
+            .then((r) => r._unsafeUnwrap())
             .catch(() => undefined),
         ),
       );
@@ -87,11 +91,11 @@ describe("TypedAmqpClient RPC", () => {
     const contract = buildContract("rpc.calculate.success");
 
     await workerFactory(contract, {
-      calculate: ({ payload }) => Future.value(Result.Ok({ sum: payload.a + payload.b })),
+      calculate: ({ payload }) => okAsync({ sum: payload.a + payload.b }),
     });
     const client = await clientFactory(contract);
 
-    const result = await client.call("calculate", { a: 2, b: 3 }, { timeoutMs: 5_000 }).toPromise();
+    const result = await client.call("calculate", { a: 2, b: 3 }, { timeoutMs: 5_000 });
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
@@ -103,10 +107,10 @@ describe("TypedAmqpClient RPC", () => {
     const contract = buildContract("rpc.calculate.timeout");
     const client = await clientFactory(contract);
 
-    const result = await client.call("calculate", { a: 1, b: 1 }, { timeoutMs: 200 }).toPromise();
+    const result = await client.call("calculate", { a: 1, b: 1 }, { timeoutMs: 200 });
 
-    expect(result.isError()).toBe(true);
-    if (result.isError()) {
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
       expect(result.error).toBeInstanceOf(RpcTimeoutError);
     }
   });
@@ -120,14 +124,14 @@ describe("TypedAmqpClient RPC", () => {
     await workerFactory(contract, {
       // Cast through unknown to deliberately return a wrong shape — the worker's
       // response-schema validation drops the reply, so the client times out.
-      calculate: () => Future.value(Result.Ok({ wrong: "shape" } as unknown as { sum: number })),
+      calculate: () => okAsync({ wrong: "shape" } as unknown as { sum: number }),
     });
     const client = await clientFactory(contract);
 
-    const result = await client.call("calculate", { a: 1, b: 1 }, { timeoutMs: 500 }).toPromise();
+    const result = await client.call("calculate", { a: 1, b: 1 }, { timeoutMs: 500 });
 
-    expect(result.isError()).toBe(true);
-    if (result.isError()) {
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
       expect(result.error).toBeInstanceOf(RpcTimeoutError);
     }
   });
@@ -148,9 +152,9 @@ describe("TypedAmqpClient RPC", () => {
     await workerFactory(contract, {
       calculate: () => {
         handlerStarted();
-        // Future that never resolves — the worker holds the message until the
-        // channel is torn down by the test fixture cleanup.
-        return Future.make<Result<{ sum: number }, never>>(() => undefined);
+        // ResultAsync wrapping a never-resolving promise — the worker holds
+        // the message until the channel is torn down by the test fixture cleanup.
+        return new ResultAsync<{ sum: number }, never>(new Promise(() => undefined));
       },
     });
 
@@ -162,11 +166,11 @@ describe("TypedAmqpClient RPC", () => {
     // the publish has completed and the pending-call entry is registered.
     await handlerStartedPromise;
 
-    await client.close().resultToPromise();
+    (await client.close())._unsafeUnwrap();
 
-    const result = await callFuture.toPromise();
-    expect(result.isError()).toBe(true);
-    if (result.isError()) {
+    const result = await callFuture;
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
       expect(result.error).toBeInstanceOf(RpcCancelledError);
     }
   });
@@ -179,11 +183,10 @@ describe("TypedAmqpClient RPC", () => {
       // Intentional shape violation cast through unknown.
       .call("calculate", { a: "nope" } as unknown as { a: number; b: number }, {
         timeoutMs: 5_000,
-      })
-      .toPromise();
+      });
 
-    expect(result.isError()).toBe(true);
-    if (result.isError()) {
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
       expect(result.error).toBeInstanceOf(MessageValidationError);
     }
   });
@@ -198,10 +201,10 @@ describe("TypedAmqpClient RPC", () => {
     const contract = buildContract(`rpc.calculate.invalid-timeout-${value}`);
     const client = await clientFactory(contract);
 
-    const result = await client.call("calculate", { a: 1, b: 1 }, { timeoutMs: value }).toPromise();
+    const result = await client.call("calculate", { a: 1, b: 1 }, { timeoutMs: value });
 
-    expect(result.isError()).toBe(true);
-    if (result.isError()) {
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
       expect(result.error).toBeInstanceOf(TechnicalError);
     }
   });


### PR DESCRIPTION
## Summary

Public APIs across the workspace move from `Future<Result<T, E>>` (`@swan-io/boxed`) to `ResultAsync<T, E>` (`neverthrow`).

- **Handler signature change** (breaking): regular consumers return `ResultAsync<void, HandlerError>`, RPCs return `ResultAsync<TResponse, HandlerError>`.
- **All ~public methods** on `AmqpClient`, `TypedAmqpClient`, `TypedAmqpWorker` now return `ResultAsync` instead of `Future`.
- **Internal call sites, tests, docs, examples** updated to match.
- **Catalog** swaps `@swan-io/boxed` for `neverthrow@8.2.x`.

## Why

- neverthrow is the more widely-adopted Result library in the TS ecosystem (~10× the weekly downloads of boxed) — friendlier dependency for consumers of these packages.
- API surface maps almost 1:1 onto the existing Result-style code in this repo, so handler ergonomics don't change much for users.
- boxed has open issues that aren't getting addressed; neverthrow is actively maintained.

## What's not preserved

- **`Future` laziness and cancellation.** `ResultAsync` is eager and Promise-backed. AMQP work doesn't use per-handler cancellation, so this was a free trade — but if any consumer relied on it, it's now gone.

## Migration cheat-sheet for consumers

| Before                                | After                                 |
| ------------------------------------- | ------------------------------------- |
| `Future.value(Result.Ok(x))`          | `okAsync(x)`                          |
| `Future.value(Result.Error(e))`       | `errAsync(e)`                         |
| `Result.Ok(x)` / `Result.Error(e)`    | `ok(x)` / `err(e)`                    |
| `Future.fromPromise(p).mapError(fn)`  | `ResultAsync.fromPromise(p, fn)`      |
| `f.mapOk(fn)` / `f.mapError(fn)`      | `f.map(fn)` / `f.mapErr(fn)`          |
| `f.flatMapOk(fn)` / `f.flatMapError`  | `f.andThen(fn)` / `f.orElse(fn)`      |
| `f.tapOk(fn)` / `f.tapError(fn)`      | `f.andTee(fn)` / `f.orTee(fn)`        |
| `r.match({ Ok, Error })`              | `r.match(okFn, errFn)` (positional)   |
| `Future.all([...])` over Result-Futures | `ResultAsync.combine([...])`        |
| `await x.resultToPromise()` (unwrap)  | `(await x)._unsafeUnwrap()`           |
| `await x.toPromise()` (Result wrap)   | `await x` (`ResultAsync` is thenable) |
| `result.isError()`                    | `result.isErr()`                      |

The same table lives in `.changeset/replace-boxed-with-neverthrow.md` so it ships in the published changelog.

## Validation

- `pnpm typecheck` — clean across all 14 workspace projects
- `pnpm test` (unit) — 67 tests passing across worker / client / contract / asyncapi
- `pnpm lint` — 0 warnings / 0 errors
- Integration tests not run locally (require RabbitMQ); CI will exercise them

## Test plan

- [ ] CI integration tests pass against a real RabbitMQ
- [ ] Spot-check a published `0.24.0` package locally to confirm `ResultAsync` is exported (not inlined) in the `.d.ts`
- [ ] Verify the changelog rendered from the changeset surfaces the migration table for end users

🤖 Generated with [Claude Code](https://claude.com/claude-code)