### PR TITLE
docs: refresh root README — drop boxed import, bump TypeScript badge

### DIFF
--- a/.agents/rules/dependencies.md
+++ b/.agents/rules/dependencies.md
@@ -40,7 +40,7 @@ This project uses pnpm's catalog feature for dependency management. All shared d
 // Bad — hardcoded version in package.json
 "devDependencies": {
   "vitest": "^4.0.0",
-  "typescript": "^5.9.0"
+  "typescript": "^6.0.0"
 }
 ```
 

--- a/.agents/rules/dependencies.md
+++ b/.agents/rules/dependencies.md
@@ -7,12 +7,12 @@
 | `neverthrow`              | 8.2.0   | ResultAsync/Result functional types    |
 | `amqplib`                 | 0.10.9  | AMQP 0.9.1 client                      |
 | `amqp-connection-manager` | 5.0.0   | Connection management                  |
-| `zod`                     | 4.3.6   | Schema validation (Standard Schema v1) |
-| `valibot`                 | 1.2.0   | Schema validation alternative          |
-| `arktype`                 | 2.1.29  | Schema validation alternative          |
+| `zod`                     | 4.4.3   | Schema validation (Standard Schema v1) |
+| `valibot`                 | 1.3.1   | Schema validation alternative          |
+| `arktype`                 | 2.2.0   | Schema validation alternative          |
 | `@standard-schema/spec`   | 1.1.0   | Universal schema interface             |
-| `vitest`                  | 4.0.18  | Test framework                         |
-| `testcontainers`          | 11.11.0 | Docker containers for tests            |
+| `vitest`                  | 4.1.5   | Test framework                         |
+| `testcontainers`          | 11.14.0 | Docker containers for tests            |
 
 ## Monorepo Tooling
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/btravers/amqp-contract/actions/workflows/ci.yml/badge.svg)](https://github.com/btravers/amqp-contract/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/@amqp-contract/contract.svg?logo=npm)](https://www.npmjs.com/package/@amqp-contract/contract)
 [![npm downloads](https://img.shields.io/npm/dm/@amqp-contract/contract.svg)](https://www.npmjs.com/package/@amqp-contract/contract)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue?logo=typescript)](https://www.typescriptlang.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue?logo=typescript)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 [**Documentation**](https://btravers.github.io/amqp-contract) · [**Get Started**](https://btravers.github.io/amqp-contract/guide/getting-started) · [**Examples**](https://btravers.github.io/amqp-contract/examples/)
@@ -35,7 +35,7 @@ import {
 } from "@amqp-contract/contract";
 import { TypedAmqpClient } from "@amqp-contract/client";
 import { TypedAmqpWorker } from "@amqp-contract/worker";
-import { Future, Result } from "@swan-io/boxed";
+import { okAsync } from "neverthrow";
 import { z } from "zod";
 
 // 1. Define resources with Dead Letter Exchange and retry configuration
@@ -71,10 +71,12 @@ const contract = defineContract({
 });
 
 // 6. Type-safe publishing with validation
-const client = await TypedAmqpClient.create({
-  contract,
-  urls: ["amqp://localhost"],
-}).resultToPromise();
+const client = (
+  await TypedAmqpClient.create({
+    contract,
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 
 await client.publish("orderCreated", {
   orderId: "ORD-123", // ✅ TypeScript knows!
@@ -82,16 +84,18 @@ await client.publish("orderCreated", {
 });
 
 // 7. Type-safe consuming with automatic retry (configured at queue level)
-const worker = await TypedAmqpWorker.create({
-  contract,
-  handlers: {
-    processOrder: ({ payload }) => {
-      console.log(payload.orderId); // ✅ TypeScript knows!
-      return Future.value(Result.Ok(undefined));
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processOrder: ({ payload }) => {
+        console.log(payload.orderId); // ✅ TypeScript knows!
+        return okAsync(undefined);
+      },
     },
-  },
-  urls: ["amqp://localhost"],
-}).resultToPromise();
+    urls: ["amqp://localhost"],
+  })
+)._unsafeUnwrap();
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -101,8 +101,10 @@ const worker = (
 ## Installation
 
 ```bash
-pnpm add @amqp-contract/contract @amqp-contract/client @amqp-contract/worker
+pnpm add @amqp-contract/contract @amqp-contract/client @amqp-contract/worker neverthrow
 ```
+
+`neverthrow` is exposed in the public types (`ResultAsync<void, HandlerError>`), so consumers need it directly to construct handler results.
 
 ## Documentation
 

--- a/packages/asyncapi/README.md
+++ b/packages/asyncapi/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/btravers/amqp-contract/actions/workflows/ci.yml/badge.svg)](https://github.com/btravers/amqp-contract/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/@amqp-contract/asyncapi.svg?logo=npm)](https://www.npmjs.com/package/@amqp-contract/asyncapi)
 [![npm downloads](https://img.shields.io/npm/dm/@amqp-contract/asyncapi.svg)](https://www.npmjs.com/package/@amqp-contract/asyncapi)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue?logo=typescript)](https://www.typescriptlang.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue?logo=typescript)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 📖 **[Full documentation →](https://btravers.github.io/amqp-contract/api/asyncapi)**

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/btravers/amqp-contract/actions/workflows/ci.yml/badge.svg)](https://github.com/btravers/amqp-contract/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/@amqp-contract/client.svg?logo=npm)](https://www.npmjs.com/package/@amqp-contract/client)
 [![npm downloads](https://img.shields.io/npm/dm/@amqp-contract/client.svg)](https://www.npmjs.com/package/@amqp-contract/client)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue?logo=typescript)](https://www.typescriptlang.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue?logo=typescript)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 📖 **[Full documentation →](https://btravers.github.io/amqp-contract/api/client)**

--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/btravers/amqp-contract/actions/workflows/ci.yml/badge.svg)](https://github.com/btravers/amqp-contract/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/@amqp-contract/contract.svg?logo=npm)](https://www.npmjs.com/package/@amqp-contract/contract)
 [![npm downloads](https://img.shields.io/npm/dm/@amqp-contract/contract.svg)](https://www.npmjs.com/package/@amqp-contract/contract)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue?logo=typescript)](https://www.typescriptlang.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue?logo=typescript)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 📖 **[Full documentation →](https://btravers.github.io/amqp-contract/api/contract)**

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/btravers/amqp-contract/actions/workflows/ci.yml/badge.svg)](https://github.com/btravers/amqp-contract/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/@amqp-contract/core.svg?logo=npm)](https://www.npmjs.com/package/@amqp-contract/core)
 [![npm downloads](https://img.shields.io/npm/dm/@amqp-contract/core.svg)](https://www.npmjs.com/package/@amqp-contract/core)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue?logo=typescript)](https://www.typescriptlang.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue?logo=typescript)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 This package provides centralized functionality for establishing AMQP topology (exchanges, queues, and bindings) from contract definitions, and defines the `Logger` interface used across amqp-contract packages.

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/btravers/amqp-contract/actions/workflows/ci.yml/badge.svg)](https://github.com/btravers/amqp-contract/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/@amqp-contract/testing.svg?logo=npm)](https://www.npmjs.com/package/@amqp-contract/testing)
 [![npm downloads](https://img.shields.io/npm/dm/@amqp-contract/testing.svg)](https://www.npmjs.com/package/@amqp-contract/testing)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue?logo=typescript)](https://www.typescriptlang.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue?logo=typescript)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 📖 **[Full documentation →](https://btravers.github.io/amqp-contract/guide/getting-started)**

--- a/packages/worker/README.md
+++ b/packages/worker/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/btravers/amqp-contract/actions/workflows/ci.yml/badge.svg)](https://github.com/btravers/amqp-contract/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/@amqp-contract/worker.svg?logo=npm)](https://www.npmjs.com/package/@amqp-contract/worker)
 [![npm downloads](https://img.shields.io/npm/dm/@amqp-contract/worker.svg)](https://www.npmjs.com/package/@amqp-contract/worker)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue?logo=typescript)](https://www.typescriptlang.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue?logo=typescript)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 📖 **[Full documentation →](https://btravers.github.io/amqp-contract/api/worker)**


### PR DESCRIPTION
## Summary

Two follow-ups from the boxed→neverthrow migration that were missed in #457 because the sweep only walked `docs/`, `packages/`, and `examples/`:

- Root **`README.md`** quick-start example still imported `Future, Result` from `@swan-io/boxed` and called `.resultToPromise()`. Rewritten to use `okAsync` from `neverthrow` and unwrap the `create()` Result via `_unsafeUnwrap()`.
- TypeScript badge across all 7 READMEs (root + 6 packages) and the `.agents/rules/dependencies.md` reference table said **5.9** but the workspace catalog has been on **6.0** for some time. Bumped them.

## Test plan

- [ ] Confirm CI passes (docs-only)
- [ ] Eyeball the rendered README on GitHub for the updated code sample and badge