### PR TITLE
docs(agents): full audit + expansion of AGENTS.md and rule files

### DIFF
--- a/.agents/rules/build-and-release.md
+++ b/.agents/rules/build-and-release.md
@@ -1,0 +1,58 @@
+# Build and Release
+
+## Build (per package)
+
+Each publishable package has a `tsdown.config.ts` and emits both ESM and CJS plus matching declaration files (`.d.mts` / `.d.cts`). The conventions:
+
+- **Entry**: `src/index.ts` only — internal modules are imported via relative `.js` paths and tsdown bundles them.
+- **Externals**: anything whose types appear in the public declaration files must be marked `external` so tsdown does not inline them. Today that's just `neverthrow` (since `ResultAsync<T, E>` shows up in nearly every public signature). When adding a new dep that surfaces in types, add it to the `external` array — otherwise its types get duplicated into our `.d.ts` and break cross-package type compatibility.
+- **`inlineOnly: false`** is set so tsdown doesn't warn about externalised deps.
+- Build via `pnpm build` (root, runs `turbo run build`) or `pnpm --filter <pkg> build` (single package).
+
+When typechecking package B that depends on workspace package A, package A must be **built** first — `tsc` resolves workspace deps against their `dist/` output, not source. After editing a public type in A, run `pnpm --filter @amqp-contract/<a> build` before `pnpm --filter @amqp-contract/<b> typecheck` or you'll see stale errors.
+
+## Versioning and changesets
+
+Versioning runs through [changesets](https://github.com/changesets/changesets). Configuration lives in [`.changeset/config.json`](../../.changeset/config.json).
+
+- All six publishable packages (`asyncapi`, `client`, `contract`, `core`, `testing`, `worker`) are in a `fixed` group — they always bump together. A single changeset entry covering one of them bumps all six to the same version.
+- For `0.x` versions, breaking changes ship as **minor** bumps. (Pre-1.0, that's normal — the changelog should be loud about the break.)
+- Run `pnpm changeset` to interactively add an entry; commit the resulting `.changeset/<slug>.md` alongside the code change.
+- Internal-only changes (test infrastructure, examples, docs) don't need a changeset. CI does not enforce — use judgement.
+
+The root `version` script is wired to `changeset version` (the script that consumes pending entries and updates `package.json` files). Do not call `pnpm version` expecting npm's built-in — pnpm intercepts and runs the script. We've previously had bugs where this collision left package.jsons untouched; it's now wired correctly via `pnpm run version`.
+
+## Release flow (CI-driven)
+
+Releases are not run from a developer's machine. The flow:
+
+1. PR with code change + changeset → reviewed → merged to `main`.
+2. The "Release" workflow on `main` (triggered after CI passes) runs `changesets/action`. It either:
+   - Opens / updates a "Version Packages" PR that bumps versions and generates changelogs from pending entries; or
+   - If versions in `package.json` aren't yet on npm, runs `pnpm run release` which calls `pnpm publish -r` to publish all six packages.
+3. Publishing uses **npm Trusted Publishing via OIDC** — there is no `NPM_TOKEN` secret. The release workflow has `id-token: write` and the npmjs Trusted Publisher config points at `.github/workflows/release.yml`.
+
+Implications when changing CI:
+
+- The release job and the integration tests run on the runner's preinstalled Node + npm. **Node 24** is required for Trusted Publishing (older runner-default npm doesn't recognise OIDC env vars). The setup composite installs Node from `.node-version`; do not bypass it.
+- Every publishable package must have these `package.json` fields filled with the canonical GitHub URL — `repository.url`, `homepage`, `bugs`, `author`, `license`. Provenance attestations include the GitHub repo URL, and npm rejects mismatches with a 422. `packages/testing/package.json` was the package that bit us last time.
+- When adding a new publishable package: add it to the `fixed` group in `.changeset/config.json`, mirror the `package.json` metadata fields from `packages/contract/package.json`, and add it to the `tsdown.config.ts` external list if it re-exports public types.
+
+Workflows to be careful around — see [Safety in `AGENTS.md`](../../AGENTS.md#safety--blast-radius) before editing:
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/release.yml`
+- `.github/workflows/deploy-docs.yml`
+- `.github/actions/setup/action.yml`
+
+## What to do for common changes
+
+| Change you're making                  | Add a changeset? | Build before typecheck of consumers? |
+| ------------------------------------- | ---------------- | ------------------------------------ |
+| New public export from a package      | Yes              | Yes                                  |
+| Bug fix in public method              | Yes              | If types changed                     |
+| Internal refactor, types unchanged    | No               | No                                   |
+| New private function / file           | No               | No                                   |
+| Rename or remove a public symbol      | Yes (breaking)   | Yes                                  |
+| Doc / README / `.agents/rules/*` only | No               | No                                   |
+| Test-only change                      | No               | No                                   |

--- a/.agents/rules/build-and-release.md
+++ b/.agents/rules/build-and-release.md
@@ -2,12 +2,14 @@
 
 ## Build (per package)
 
-Each publishable package has a `tsdown.config.ts` and emits both ESM and CJS plus matching declaration files (`.d.mts` / `.d.cts`). The conventions:
+Builds use `tsdown`, but the wiring varies — always confirm with the package's `package.json` and (if present) `tsdown.config.ts`:
 
-- **Entry**: `src/index.ts` only — internal modules are imported via relative `.js` paths and tsdown bundles them.
-- **Externals**: anything whose types appear in the public declaration files must be marked `external` so tsdown does not inline them. Today that's just `neverthrow` (since `ResultAsync<T, E>` shows up in nearly every public signature). When adding a new dep that surfaces in types, add it to the `external` array — otherwise its types get duplicated into our `.d.ts` and break cross-package type compatibility.
-- **`inlineOnly: false`** is set so tsdown doesn't warn about externalised deps.
-- Build via `pnpm build` (root, runs `turbo run build`) or `pnpm --filter <pkg> build` (single package).
+- **Entry points.** Most packages bundle from `src/index.ts` only; `@amqp-contract/testing` bundles three (`index`, `global-setup`, `extension`) because it advertises sub-path exports.
+- **Output formats.** `core`, `client`, `worker`, `contract`, `asyncapi` emit dual ESM + CJS with matching `.d.mts` / `.d.cts`. `@amqp-contract/testing` is ESM-only.
+- **Config style.** `core`, `client`, `worker`, `asyncapi` keep their config in a `tsdown.config.ts`. `contract` and `testing` configure tsdown via CLI flags directly in `package.json`'s `build` script.
+- **Externals.** Anything whose types appear in the public declaration files must be marked `external` so tsdown does not inline them. The packages that do this today (`core`, `client`, `worker`) externalise `neverthrow` because `ResultAsync<T, E>` shows up in their public signatures — without that, neverthrow's types get duplicated into our `.d.ts` files and break cross-package type compatibility. When adding a new dep that surfaces in types, add it to the `external` array (or the equivalent CLI flag).
+- **`inlineOnly: false`** is set in the `tsdown.config.ts` files so tsdown doesn't warn about externalised deps.
+- Build via `pnpm build` (root, runs `turbo run build`) or `pnpm --filter <pkg> build`.
 
 When typechecking package B that depends on workspace package A, package A must be **built** first — `tsc` resolves workspace deps against their `dist/` output, not source. After editing a public type in A, run `pnpm --filter @amqp-contract/<a> build` before `pnpm --filter @amqp-contract/<b> typecheck` or you'll see stale errors.
 
@@ -34,9 +36,9 @@ Releases are not run from a developer's machine. The flow:
 
 Implications when changing CI:
 
-- The release job and the integration tests run on the runner's preinstalled Node + npm. **Node 24** is required for Trusted Publishing (older runner-default npm doesn't recognise OIDC env vars). The setup composite installs Node from `.node-version`; do not bypass it.
+- Both CI and release run via the `./.github/actions/setup` composite, which installs Node from [`.node-version`](../../.node-version) using `actions/setup-node@v4`. **Node 24** is required for Trusted Publishing (older npm doesn't recognise OIDC env vars), so don't bypass the composite or pin Node lower in a workflow.
 - Every publishable package must have these `package.json` fields filled with the canonical GitHub URL — `repository.url`, `homepage`, `bugs`, `author`, `license`. Provenance attestations include the GitHub repo URL, and npm rejects mismatches with a 422. `packages/testing/package.json` was the package that bit us last time.
-- When adding a new publishable package: add it to the `fixed` group in `.changeset/config.json`, mirror the `package.json` metadata fields from `packages/contract/package.json`, and add it to the `tsdown.config.ts` external list if it re-exports public types.
+- When adding a new publishable package: add it to the `fixed` group in `.changeset/config.json`, mirror the `package.json` metadata fields from `packages/contract/package.json`, and decide on a build shape — `tsdown.config.ts` (most packages, with `external: ["neverthrow", …]` for any deps surfaced in public types) or CLI-flag tsdown like `contract` / `testing`. Multi-entry / ESM-only is fine if it matches the package's exports map (see `testing` for the canonical example).
 
 Workflows to be careful around — see [Safety in `AGENTS.md`](../../AGENTS.md#safety--blast-radius) before editing:
 

--- a/.agents/rules/code-style.md
+++ b/.agents/rules/code-style.md
@@ -1,18 +1,6 @@
 # Code Style
 
-## TypeScript Rules
-
-- **No `any` types** — enforced by oxlint. Use `unknown` for dynamic data, then narrow.
-- **Type aliases over interfaces** — use `type Foo = {}` not `interface Foo {}`
-- **`.js` extensions required** — all imports must include `.js` extension (ESM requirement)
-- **Standard Schema v1** — for runtime validation (Zod, Valibot, ArkType supported)
-- **Catalog dependencies** — use `pnpm-workspace.yaml` catalog, not hardcoded versions
-- **ResultAsync/Result handlers** — always use `ResultAsync<void, HandlerError>`, not `async`
-- **Conventional commits** — required; use conventional commit types (for example: feat, fix, docs, chore, test, refactor)
-- **Strict mode** — enabled in tsconfig.json
-- Prefer `readonly` arrays and properties where appropriate
-- Prefer `const` over `let`
-- Use nullish coalescing (`?? {}`) for optional object parameters, not `||`
+The cross-cutting language and tooling rules ("no `any`", "ResultAsync handlers", catalog dependencies, etc.) live in [`AGENTS.md` → Key Constraints](../../AGENTS.md). This file covers the patterns that aren't enforced by the linter or commit hooks.
 
 ## Composition Pattern
 
@@ -53,11 +41,14 @@ processOrder: async ({ payload }) => {
   await process(payload);
 };
 
-// Good — use ResultAsync/Result pattern
+// Good — use the ResultAsync pattern from neverthrow.
+// fromPromise REQUIRES the error mapper as the second argument; chaining
+// .mapErr afterwards is a type error since fromPromise has no `unknown` overload.
 processOrder: ({ payload }) =>
-  ResultAsync.fromPromise(process(payload))
-    .map(() => undefined)
-    .mapErr((e) => new RetryableError("Failed", e));
+  ResultAsync.fromPromise(
+    process(payload),
+    (e) => new RetryableError("Failed", e),
+  ).map(() => undefined);
 
 // Bad — accessing message directly
 processOrder: (message) => {
@@ -78,7 +69,7 @@ defineQueue("orders", {
   retry: { mode: "immediate-requeue", maxRetries: 3 },
 });
 
-// Bad — accessing .name directly on TTL-backoff queue
+// Bad — accessing .name directly on a TTL-backoff queue
 const queue = defineQueue("orders", {
   deadLetter: { exchange: dlx },
   retry: { mode: "ttl-backoff" },
@@ -137,11 +128,13 @@ function process(options) {
 }
 ```
 
-## Additional Rules
+## Additional Guidance
 
-- Never use `@ts-ignore` or `@ts-expect-error` without explanation — fix the root cause
-- Public APIs should have JSDoc comments
-- Explain "why" not "what" in inline comments
-- Use Standard Schema v1 for validation — don't create custom validation logic
-- Choose the right exchange type for the use case — don't use topic when direct suffices
-- Quorum queues are the default — only use classic queues with good reason
+- Avoid `@ts-ignore` and `@ts-expect-error`. Fix the root cause when you can; if you genuinely can't, leave a comment explaining why and link the upstream issue.
+- Public APIs need JSDoc.
+- Comments explain _why_, not _what_ — well-named identifiers already say what.
+- Use Standard Schema v1 for validation; don't roll your own.
+- Pick the narrowest exchange type that fits — don't reach for `topic` when `direct` would do.
+- `quorum` queues are the default. Reach for `classic` only when you need a feature quorum doesn't support (`exclusive`, `autoDelete`, `maxPriority`).
+- Prefer `readonly` arrays and properties where it doesn't hurt ergonomics.
+- Prefer `const` over `let`.

--- a/.agents/rules/commands.md
+++ b/.agents/rules/commands.md
@@ -24,10 +24,10 @@ pnpm format --check       # Check formatting only
 pnpm test                 # Run unit tests (no Docker required)
 pnpm test:integration     # Run integration tests (requires Docker)
 
-# Run specific package tests
-pnpm test:integration --filter @amqp-contract/core
-pnpm test:integration --filter @amqp-contract/client
-pnpm test:integration --filter @amqp-contract/worker
+# Run a single package's tests via pnpm's filter
+pnpm --filter @amqp-contract/core test:integration
+pnpm --filter @amqp-contract/client test:integration
+pnpm --filter @amqp-contract/worker test:integration
 ```
 
 ## Versioning
@@ -40,10 +40,7 @@ pnpm release              # Publish packages
 
 ## Pre-Commit Checklist
 
-Before submitting code, ensure:
+Lefthook runs `oxfmt` and `oxlint` on every `git commit`, and commitlint on `commit-msg`, so format / lint / message-format breakage is caught automatically. Before pushing, also run:
 
-- TypeScript compiles without errors (`pnpm typecheck`)
-- All tests pass (`pnpm test`)
-- Code is properly formatted (`pnpm format`)
-- No linting errors (`pnpm lint`)
-- Commit message follows conventional commits format
+- `pnpm typecheck` — type errors are not in the pre-commit hook
+- `pnpm test` — unit tests (integration tests run in CI)

--- a/.agents/rules/contract-patterns.md
+++ b/.agents/rules/contract-patterns.md
@@ -104,7 +104,7 @@ const priorityQueue = defineQueue("priority-tasks", {
 
 - Queue-to-exchange bindings are **auto-generated** by `defineEventConsumer` and `defineCommandConsumer`
 - Exchange-to-exchange bindings are **auto-generated** when using `bridgeExchange` (see Bridge Exchange below)
-- For other exchange-to-exchange routing, set up manually via `AmqpClient` channel setup
+- For other exchange-to-exchange routing, declare them explicitly with `defineExchangeBinding` and add the result to `bindings`
 - For fanout exchanges, routing keys are optional
 
 ```typescript
@@ -262,9 +262,13 @@ const queueName = extractQueue(queue).name;
 
 ## Type Inference Helpers
 
-The `Infer*` naming pattern indicates type inference helpers that extract types from a contract at compile time:
+The `Infer*` naming pattern indicates type inference helpers that extract types from a contract at compile time. The full set lives in the package `index.ts` files; the most common ones:
 
-- `ClientInferPublisherInput<Contract, "publisherName">` — Publisher input type
-- `WorkerInferConsumerInput<Contract, "consumerName">` — Consumer input type
-- `WorkerInferConsumerHandler<Contract, "consumerName">` — Handler type
-- `WorkerInferConsumedMessage<Contract, "consumerName">` — Full message type (payload + headers)
+- `ClientInferPublisherInput<Contract, "publisherName">` — input shape for `client.publish(...)`
+- `ClientInferRpcRequestInput<Contract, "rpcName">` — input shape for `client.call(...)`
+- `ClientInferRpcResponseOutput<Contract, "rpcName">` — typed response from `client.call(...)`
+- `WorkerInferConsumedMessage<Contract, "consumerName">` — `{ payload, headers }` envelope for a regular consumer
+- `WorkerInferRpcConsumedMessage<Contract, "rpcName">` — `{ payload, headers }` envelope for an RPC handler
+- `WorkerInferConsumerHandler<Contract, "consumerName">` — handler signature for a regular consumer
+- `WorkerInferRpcHandler<Contract, "rpcName">` — handler signature for an RPC
+- `WorkerInferHandlers<Contract>` — full handlers object expected by `TypedAmqpWorker.create`

--- a/.agents/rules/contract-patterns.md
+++ b/.agents/rules/contract-patterns.md
@@ -262,13 +262,19 @@ const queueName = extractQueue(queue).name;
 
 ## Type Inference Helpers
 
-The `Infer*` naming pattern indicates type inference helpers that extract types from a contract at compile time. The full set lives in the package `index.ts` files; the most common ones:
+The `Infer*` naming pattern indicates type inference helpers that extract types from a contract at compile time.
+
+**Re-exported from `@amqp-contract/client`:**
 
 - `ClientInferPublisherInput<Contract, "publisherName">` — input shape for `client.publish(...)`
 - `ClientInferRpcRequestInput<Contract, "rpcName">` — input shape for `client.call(...)`
 - `ClientInferRpcResponseOutput<Contract, "rpcName">` — typed response from `client.call(...)`
-- `WorkerInferConsumedMessage<Contract, "consumerName">` — `{ payload, headers }` envelope for a regular consumer
-- `WorkerInferRpcConsumedMessage<Contract, "rpcName">` — `{ payload, headers }` envelope for an RPC handler
+
+**Re-exported from `@amqp-contract/worker`:**
+
 - `WorkerInferConsumerHandler<Contract, "consumerName">` — handler signature for a regular consumer
-- `WorkerInferRpcHandler<Contract, "rpcName">` — handler signature for an RPC
-- `WorkerInferHandlers<Contract>` — full handlers object expected by `TypedAmqpWorker.create`
+- `WorkerInferConsumedMessage<Contract, "consumerName">` — `{ payload, headers }` envelope for a regular consumer
+- `WorkerInferConsumerHeaders<Contract, "consumerName">` — just the headers slice
+- `WorkerInferConsumerHandlerEntry<Contract, "consumerName">` — handler-or-`[handler, opts]` tuple shape
+
+The RPC equivalents (`WorkerInferRpcHandler`, `WorkerInferRpcConsumedMessage`, `WorkerInferRpcRequest`, `WorkerInferRpcResponse`, `WorkerInferRpcHeaders`) and the unified `WorkerInferHandlers<Contract>` exist in `packages/worker/src/types.ts` but are **not** currently re-exported from the package root. Inline RPC handlers don't need them — the `handlers` parameter on `TypedAmqpWorker.create` infers each name's signature automatically.

--- a/.agents/rules/dependencies.md
+++ b/.agents/rules/dependencies.md
@@ -2,17 +2,19 @@
 
 ## Key Dependencies
 
-| Package                   | Version | Purpose                                |
-| ------------------------- | ------- | -------------------------------------- |
-| `neverthrow`              | 8.2.0   | ResultAsync/Result functional types    |
-| `amqplib`                 | 0.10.9  | AMQP 0.9.1 client                      |
-| `amqp-connection-manager` | 5.0.0   | Connection management                  |
-| `zod`                     | 4.4.3   | Schema validation (Standard Schema v1) |
-| `valibot`                 | 1.3.1   | Schema validation alternative          |
-| `arktype`                 | 2.2.0   | Schema validation alternative          |
-| `@standard-schema/spec`   | 1.1.0   | Universal schema interface             |
-| `vitest`                  | 4.1.5   | Test framework                         |
-| `testcontainers`          | 11.14.0 | Docker containers for tests            |
+Versions live in [`pnpm-workspace.yaml`](../../pnpm-workspace.yaml) — that file is the single source of truth, so this doc only describes purpose:
+
+| Package                   | Purpose                                  |
+| ------------------------- | ---------------------------------------- |
+| `neverthrow`              | `ResultAsync` / `Result` types           |
+| `amqplib`                 | AMQP 0.9.1 client                        |
+| `amqp-connection-manager` | Connection management + reconnect        |
+| `zod`                     | Schema validation (Standard Schema v1)   |
+| `valibot`                 | Schema validation alternative            |
+| `arktype`                 | Schema validation alternative            |
+| `@standard-schema/spec`   | Universal schema interface               |
+| `vitest`                  | Test framework                           |
+| `testcontainers`          | RabbitMQ container for integration tests |
 
 ## Monorepo Tooling
 

--- a/.agents/rules/handlers.md
+++ b/.agents/rules/handlers.md
@@ -1,20 +1,22 @@
 # Handler Patterns
 
-## Handler Signature
+This project uses [neverthrow](https://github.com/supermacro/neverthrow) for explicit, value-based error handling. Handlers return a `ResultAsync<T, E>` rather than throwing or using `async/await`.
 
-Handlers receive `({ payload, headers }, rawMessage)` and return `ResultAsync<void, HandlerError>`:
+## Regular consumer handler
+
+A consumer handler receives `({ payload, headers }, rawMessage)` and returns `ResultAsync<void, HandlerError>`:
 
 ```typescript
 import { okAsync, ResultAsync } from "neverthrow";
 import { RetryableError, NonRetryableError } from "@amqp-contract/worker";
 
-// Handler signature: (message, rawMessage) => ResultAsync<void, HandlerError>
+// Sync OK case
 const handler = ({ payload }, rawMessage) => {
   console.log(payload.orderId);
   return okAsync(undefined);
 };
 
-// For async operations, use ResultAsync.fromPromise(promise, errorMapper)
+// Async case — fromPromise REQUIRES the error mapper as the second arg
 const asyncHandler = ({ payload }) =>
   ResultAsync.fromPromise(
     processPayment(payload),
@@ -22,19 +24,52 @@ const asyncHandler = ({ payload }) =>
   ).map(() => undefined);
 ```
 
-## Handler Parameters
+### Parameters
 
-1. **`message`**: Object containing `{ payload, headers }`
-   - `payload`: Validated message data (typed from schema)
-   - `headers`: Validated headers (if schema defines them)
+1. **`message`** — `{ payload, headers }`
+   - `payload`: validated against the message's payload schema
+   - `headers`: validated against the message's optional headers schema (otherwise `undefined`)
+2. **`rawMessage`** — the raw amqplib `ConsumeMessage` (e.g. `msg.fields.deliveryTag`, `msg.properties.messageId`)
 
-2. **`rawMessage`**: Raw AMQP `ConsumeMessage` with full metadata
-   - `fields.deliveryTag`, `fields.routingKey`, `fields.exchange`
-   - `properties.messageId`, `properties.timestamp`, etc.
+## RPC handler
 
-## Using defineHandler
+`defineRpc` creates a request-reply slot. Handlers return `ResultAsync<TResponse, HandlerError>` — the worker validates the response against the RPC's response schema and publishes it back to the caller's `replyTo` with the same `correlationId`.
 
-Use `defineHandler` for all new code to get full type inference from the contract:
+```typescript
+import { okAsync, ResultAsync } from "neverthrow";
+import { defineHandler, RetryableError } from "@amqp-contract/worker";
+
+const calculateHandler = defineHandler(contract, "calculate", ({ payload }) =>
+  okAsync({ sum: payload.a + payload.b }),
+);
+
+const lookupUserHandler = defineHandler(contract, "lookupUser", ({ payload }) =>
+  ResultAsync.fromPromise(
+    db.users.findById(payload.userId),
+    (error) => new RetryableError("DB unavailable", error),
+  ).map((user) => ({ id: user.id, name: user.name })),
+);
+```
+
+The matching client-side call:
+
+```typescript
+const result = await client.call("calculate", { a: 2, b: 3 }, { timeoutMs: 5_000 });
+if (result.isOk()) {
+  console.log(result.value.sum); // 5
+}
+```
+
+RPC error semantics worth knowing:
+
+- **Missing `replyTo` / `correlationId`** on the inbound message → `NonRetryableError` (request goes to DLQ — retrying can't recover the lost reply path).
+- **Response fails the response schema** → `NonRetryableError` (handler returned the wrong shape; retrying won't help).
+- **Client-side timeout** → call resolves to `err(RpcTimeoutError)`; pending state is cleared so a late reply is dropped silently.
+- **Client closed mid-call** → call resolves to `err(RpcCancelledError)`.
+
+## Using `defineHandler` / `defineHandlers`
+
+Use `defineHandler` (single) or `defineHandlers` (object) for full type inference from the contract. Both also validate at construction time that the name exists in `contract.consumers` ∪ `contract.rpcs`:
 
 ```typescript
 import { defineHandler, RetryableError, NonRetryableError } from "@amqp-contract/worker";
@@ -47,7 +82,7 @@ const processOrderHandler = defineHandler(contract, "processOrder", ({ payload }
   ).map(() => undefined),
 );
 
-// For permanent failures
+// Permanent failures use NonRetryableError → DLQ, never retried
 const validateOrderHandler = defineHandler(contract, "validateOrder", ({ payload }) => {
   if (payload.amount < 1) {
     return errAsync(new NonRetryableError("Invalid amount"));
@@ -56,110 +91,62 @@ const validateOrderHandler = defineHandler(contract, "validateOrder", ({ payload
 });
 ```
 
-## Error Types
+## Error types
 
-- **`RetryableError`**: Transient failures — message retried
-- **`NonRetryableError`**: Permanent failures — message sent to DLQ (if configured) or dropped
-- Both extend `HandlerError` base class
-- Factory functions: `retryable()`, `nonRetryable()` (shorthand)
-- Type guards: `isRetryableError()`, `isNonRetryableError()`, `isHandlerError()`
+| Error                    | Behaviour                                                                        |
+| ------------------------ | -------------------------------------------------------------------------------- |
+| `RetryableError`         | Transient. Worker requeues per the queue's `retry` mode (immediate or backoff).  |
+| `NonRetryableError`      | Permanent. Worker `nack`s without requeue, sending to DLQ if configured.         |
+| `MessageValidationError` | Inbound payload/headers failed schema validation. Routes to DLQ — never retried. |
+| `TechnicalError`         | Transport-level failure (connection, channel, broker). Returned by core helpers. |
+
+Helpers and type guards: `retryable()`, `nonRetryable()` factory functions; `isRetryableError`, `isNonRetryableError`, `isHandlerError` for narrowing. Both `RetryableError` and `NonRetryableError` extend the `HandlerError` union type.
 
 ```typescript
-// Conditional error handling
+// Conditional error mapping inside fromPromise
 ({ payload }) =>
   ResultAsync.fromPromise(process(payload), (error) => {
-    if (error instanceof ValidationError) {
-      return new NonRetryableError("Invalid data");
-    }
+    if (error instanceof ValidationError) return new NonRetryableError("Invalid data");
     return new RetryableError("Temporary failure", error);
   }).map(() => undefined);
 ```
 
-## Handler Options
+## Per-handler options
+
+Handler entries accept an `[handler, options]` tuple to override `defaultConsumerOptions` for a single consumer:
 
 ```typescript
 const handlers = {
-  processOrder: [
-    processOrderHandler,
-    { prefetch: 10 }, // Process up to 10 messages concurrently
-  ],
+  processOrder: [processOrderHandler, { prefetch: 10 }],
 };
 ```
 
-## neverthrow API Reference
+## neverthrow API quick reference
 
-This project uses [neverthrow](https://github.com/supermacro/neverthrow) for functional error handling.
+`ResultAsync<T, E>`:
 
-### ResultAsync<A, E> Key Methods
+| Method                                 | Description                                                           |
+| -------------------------------------- | --------------------------------------------------------------------- |
+| `okAsync(value)` / `errAsync(error)`   | Construct a resolved `ResultAsync`                                    |
+| `ResultAsync.fromPromise(promise, fn)` | Wrap a `Promise`; `fn` maps the rejection reason. Mapper is required. |
+| `.map(f)`                              | Transform the OK value                                                |
+| `.mapErr(f)`                           | Transform the error                                                   |
+| `.andThen(f)`                          | Chain another `Result` / `ResultAsync`                                |
+| `.orElse(f)`                           | Recover from an error with another `Result` / `ResultAsync`           |
+| `.andTee(f)` / `.orTee(f)`             | Side effect on OK / error without changing the value                  |
+| `await resultAsync`                    | Resolves to a `Result<T, E>` — no exception, even on `Err`            |
 
-| Method                                 | Description                                                    | Example                                                      |
-| -------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------ |
-| `okAsync(value)` / `errAsync(error)`   | Create a resolved ResultAsync                                  | `okAsync(undefined)` / `errAsync(new Error("x"))`            |
-| `ResultAsync.fromPromise(promise, fn)` | Convert Promise to ResultAsync; `fn` maps the rejection reason | `ResultAsync.fromPromise(fetch(url), (e) => new TechErr(e))` |
-| `.map(f)`                              | Transform Ok value                                             | `.map(() => undefined)`                                      |
-| `.mapErr(f)`                           | Transform Error value                                          | `.mapErr((e) => new RetryableError(e))`                      |
-| `.andThen(f)`                          | Chain with another Result/ResultAsync                          | `.andThen((v) => okAsync(v))`                                |
-| `await resultAsync`                    | Resolves to a `Result<T, E>` (does not throw on `Err`)         | `const r = await future; if (r.isErr()) { ... }`             |
+`Result<T, E>` (sync):
 
-### Result<Ok, Error> Key Methods
+| Method                 | Description                                                                 |
+| ---------------------- | --------------------------------------------------------------------------- |
+| `ok(value)`            | Construct a successful `Result`                                             |
+| `err(error)`           | Construct a failed `Result`                                                 |
+| `.isOk()` / `.isErr()` | Narrowing type guards (read `.value` / `.error` after)                      |
+| `.match(okFn, errFn)`  | Positional pattern match (boxed-style `{ Ok, Error }` is **not** supported) |
+| `.unwrapOr(default)`   | Extract the value or fall back                                              |
+| `._unsafeUnwrap()`     | Throw on `Err`. Use sparingly — prefer matching.                            |
 
-| Method                 | Description                          | Example                             |
-| ---------------------- | ------------------------------------ | ----------------------------------- |
-| `ok(value)`            | Create success                       | `ok(undefined)`                     |
-| `err(error)`           | Create failure                       | `err(new RetryableError("failed"))` |
-| `.isOk()` / `.isErr()` | Type guards                          | `if (result.isOk()) { ... }`        |
-| `.map(f)`              | Transform Ok                         | `result.map(x => x * 2)`            |
-| `.mapErr(f)`           | Transform Error                      | `result.mapErr(e => new Error(e))`  |
-| `.getOr(default)`      | Extract with fallback                | `result.getOr(0)`                   |
-| `.match(okFn, errFn)`  | Pattern match (positional callbacks) | `result.match(v => v, () => 0)`     |
+## Public exports
 
-### Common Patterns
-
-```typescript
-// Simple sync handler
-({ payload }) => okAsync(undefined);
-
-// Async with error mapping
-({ payload }) =>
-  ResultAsync.fromPromise(
-    asyncOperation(payload),
-    (error) => new RetryableError("Failed", error),
-  ).map(() => undefined);
-```
-
-## Worker Package Exports
-
-```typescript
-// Worker class
-export { TypedAmqpWorker } from "@amqp-contract/worker";
-
-// Handler definition
-export { defineHandler, defineHandlers } from "@amqp-contract/worker";
-
-// Error classes and factory functions
-export {
-  RetryableError,
-  NonRetryableError,
-  TechnicalError,
-  MessageValidationError,
-  // Factory functions (shorthand)
-  retryable,
-  nonRetryable,
-  // Type guards
-  isRetryableError,
-  isNonRetryableError,
-  isHandlerError,
-} from "@amqp-contract/worker";
-
-// Types
-export type {
-  HandlerError,
-  WorkerInferConsumerHandler,
-  WorkerInferConsumerHandlers,
-  WorkerInferConsumedMessage,
-} from "@amqp-contract/worker";
-
-// Retry types and helpers (from contract package)
-export type { TtlBackoffRetryOptions, ImmediateRequeueRetryOptions } from "@amqp-contract/contract";
-export { extractQueue } from "@amqp-contract/contract";
-```
+For the authoritative list of what's exported from `@amqp-contract/worker`, read [`packages/worker/src/index.ts`](../../packages/worker/src/index.ts). Notable types: `WorkerInferHandlers<TContract>` (full handlers object — covers `consumers` ∪ `rpcs`), `WorkerInferConsumerHandler`, `WorkerInferRpcHandler`, `WorkerInferConsumedMessage`, `WorkerInferRpcConsumedMessage`. The legacy `WorkerInferConsumerHandlers` alias is `@deprecated` and still re-exported for one cycle — new code should use `WorkerInferHandlers`.

--- a/.agents/rules/handlers.md
+++ b/.agents/rules/handlers.md
@@ -93,6 +93,8 @@ const validateOrderHandler = defineHandler(contract, "validateOrder", ({ payload
 
 ## Error types
 
+### Worker-side (returned from handlers)
+
 | Error                    | Behaviour                                                                        |
 | ------------------------ | -------------------------------------------------------------------------------- |
 | `RetryableError`         | Transient. Worker requeues per the queue's `retry` mode (immediate or backoff).  |
@@ -101,6 +103,18 @@ const validateOrderHandler = defineHandler(contract, "validateOrder", ({ payload
 | `TechnicalError`         | Transport-level failure (connection, channel, broker). Returned by core helpers. |
 
 Helpers and type guards: `retryable()`, `nonRetryable()` factory functions; `isRetryableError`, `isNonRetryableError`, `isHandlerError` for narrowing. Both `RetryableError` and `NonRetryableError` extend the `HandlerError` union type.
+
+### Client-side (returned from `client.publish` / `client.call`)
+
+| Error                    | When you get it                                                                                                 |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `MessageValidationError` | Outbound payload failed the request/publisher schema before the message hit the broker.                         |
+| `TechnicalError`         | Publish failed at the broker (channel buffer full, connection lost, etc.).                                      |
+| `RpcTimeoutError`        | RPC call's `timeoutMs` elapsed before a reply arrived. Pending state cleared; a late reply is dropped silently. |
+| `RpcCancelledError`      | RPC was in flight when `client.close()` was called. All pending calls fail with this so callers don't hang.     |
+
+`publish()` returns `ResultAsync<void, TechnicalError | MessageValidationError>`.
+`call()` returns `ResultAsync<TResponse, TechnicalError | MessageValidationError | RpcTimeoutError | RpcCancelledError>`.
 
 ```typescript
 // Conditional error mapping inside fromPromise

--- a/.agents/rules/handlers.md
+++ b/.agents/rules/handlers.md
@@ -33,22 +33,32 @@ const asyncHandler = ({ payload }) =>
 
 ## RPC handler
 
-`defineRpc` creates a request-reply slot. Handlers return `ResultAsync<TResponse, HandlerError>` — the worker validates the response against the RPC's response schema and publishes it back to the caller's `replyTo` with the same `correlationId`.
+`defineRpc` creates a request-reply slot. RPC handlers return `ResultAsync<TResponse, HandlerError>` — the worker validates the response against the RPC's response schema and publishes it back to the caller's `replyTo` with the same `correlationId`.
+
+> **Important:** `defineHandler` / `defineHandlers` are not RPC-aware today. Both helpers are typed against `InferConsumerNames<TContract>` and the runtime `validateConsumerExists` only inspects `contract.consumers`. Passing an RPC name throws _"Consumer X not found in contract"_ and won't type-check. For RPC handlers, write them inline inside `TypedAmqpWorker.create({ handlers: { … } })` — the `handlers` parameter is typed against `WorkerInferHandlers<TContract>` internally, so each name (consumer or RPC) gets the correct signature inferred:
 
 ```typescript
 import { okAsync, ResultAsync } from "neverthrow";
-import { defineHandler, RetryableError } from "@amqp-contract/worker";
+import { TypedAmqpWorker, RetryableError } from "@amqp-contract/worker";
 
-const calculateHandler = defineHandler(contract, "calculate", ({ payload }) =>
-  okAsync({ sum: payload.a + payload.b }),
-);
+const result = await TypedAmqpWorker.create({
+  contract,
+  handlers: {
+    // Regular consumer — `payload` typed from the consumer's message schema
+    processOrder: ({ payload }) => okAsync(undefined),
 
-const lookupUserHandler = defineHandler(contract, "lookupUser", ({ payload }) =>
-  ResultAsync.fromPromise(
-    db.users.findById(payload.userId),
-    (error) => new RetryableError("DB unavailable", error),
-  ).map((user) => ({ id: user.id, name: user.name })),
-);
+    // RPC handler — must return the typed response payload
+    calculate: ({ payload }) => okAsync({ sum: payload.a + payload.b }),
+
+    // RPC with async work
+    lookupUser: ({ payload }) =>
+      ResultAsync.fromPromise(
+        db.users.findById(payload.userId),
+        (error) => new RetryableError("DB unavailable", error),
+      ).map((user) => ({ id: user.id, name: user.name })),
+  },
+  urls: ["amqp://localhost"],
+});
 ```
 
 The matching client-side call:
@@ -62,14 +72,14 @@ if (result.isOk()) {
 
 RPC error semantics worth knowing:
 
-- **Missing `replyTo` / `correlationId`** on the inbound message → `NonRetryableError` (request goes to DLQ — retrying can't recover the lost reply path).
+- **Missing `replyTo` / `correlationId`** on the inbound message → `NonRetryableError`. The request is `nack`ed without requeue, so it routes to the queue's DLQ if configured (poison messages stay visible for inspection rather than being silently ack'd).
 - **Response fails the response schema** → `NonRetryableError` (handler returned the wrong shape; retrying won't help).
-- **Client-side timeout** → call resolves to `err(RpcTimeoutError)`; pending state is cleared so a late reply is dropped silently.
+- **Client-side timeout** → call resolves to `err(RpcTimeoutError)`; pending state is cleared. If a reply still arrives, it's logged at `warn` and counted via `recordLateRpcReply` (telemetry hook for tuning) — it's not retried.
 - **Client closed mid-call** → call resolves to `err(RpcCancelledError)`.
 
-## Using `defineHandler` / `defineHandlers`
+## Using `defineHandler` / `defineHandlers` (regular consumers only)
 
-Use `defineHandler` (single) or `defineHandlers` (object) for full type inference from the contract. Both also validate at construction time that the name exists in `contract.consumers` ∪ `contract.rpcs`:
+Use `defineHandler` (single) or `defineHandlers` (object) for full type inference and a runtime check that the name exists in `contract.consumers`. Neither helper handles RPC names today (see the warning above).
 
 ```typescript
 import { defineHandler, RetryableError, NonRetryableError } from "@amqp-contract/worker";
@@ -93,25 +103,32 @@ const validateOrderHandler = defineHandler(contract, "validateOrder", ({ payload
 
 ## Error types
 
-### Worker-side (returned from handlers)
+`HandlerError` is the **union type alias** `RetryableError | NonRetryableError` (not a base class — `instanceof HandlerError` does not work). Handlers can only legally return one of those two error types. The other errors below are produced by the framework around handlers.
 
-| Error                    | Behaviour                                                                        |
-| ------------------------ | -------------------------------------------------------------------------------- |
-| `RetryableError`         | Transient. Worker requeues per the queue's `retry` mode (immediate or backoff).  |
-| `NonRetryableError`      | Permanent. Worker `nack`s without requeue, sending to DLQ if configured.         |
-| `MessageValidationError` | Inbound payload/headers failed schema validation. Routes to DLQ — never retried. |
-| `TechnicalError`         | Transport-level failure (connection, channel, broker). Returned by core helpers. |
+### Returned from handlers
 
-Helpers and type guards: `retryable()`, `nonRetryable()` factory functions; `isRetryableError`, `isNonRetryableError`, `isHandlerError` for narrowing. Both `RetryableError` and `NonRetryableError` extend the `HandlerError` union type.
+| Error               | Behaviour                                                                       |
+| ------------------- | ------------------------------------------------------------------------------- |
+| `RetryableError`    | Transient. Worker requeues per the queue's `retry` mode (immediate or backoff). |
+| `NonRetryableError` | Permanent. Worker `nack`s without requeue, sending to DLQ if configured.        |
+
+Helpers and type guards: `retryable()`, `nonRetryable()` factory functions; `isRetryableError`, `isNonRetryableError`, `isHandlerError` for narrowing.
+
+### Raised by the framework around handlers
+
+| Error                    | When                                                                                                                                       |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `MessageValidationError` | Inbound payload/headers failed schema validation **before** the handler ran. Routes to DLQ — never retried.                                |
+| `TechnicalError`         | Transport-level failure (connection, channel, broker). Returned by `@amqp-contract/core` and surfaced via the client / worker public APIs. |
 
 ### Client-side (returned from `client.publish` / `client.call`)
 
-| Error                    | When you get it                                                                                                 |
-| ------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| `MessageValidationError` | Outbound payload failed the request/publisher schema before the message hit the broker.                         |
-| `TechnicalError`         | Publish failed at the broker (channel buffer full, connection lost, etc.).                                      |
-| `RpcTimeoutError`        | RPC call's `timeoutMs` elapsed before a reply arrived. Pending state cleared; a late reply is dropped silently. |
-| `RpcCancelledError`      | RPC was in flight when `client.close()` was called. All pending calls fail with this so callers don't hang.     |
+| Error                    | When                                                                                                                                                                                     |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MessageValidationError` | Outbound payload failed the request/publisher schema before the message hit the broker.                                                                                                  |
+| `TechnicalError`         | Publish failed at the broker (channel buffer full, connection lost, etc.).                                                                                                               |
+| `RpcTimeoutError`        | RPC call's `timeoutMs` elapsed before a reply arrived. Pending state is cleared. A reply that arrives later is logged at `warn` and counted via `recordLateRpcReply` (it isn't retried). |
+| `RpcCancelledError`      | RPC was in flight when `client.close()` was called. All pending calls fail with this so callers don't hang.                                                                              |
 
 `publish()` returns `ResultAsync<void, TechnicalError | MessageValidationError>`.
 `call()` returns `ResultAsync<TResponse, TechnicalError | MessageValidationError | RpcTimeoutError | RpcCancelledError>`.
@@ -163,4 +180,11 @@ const handlers = {
 
 ## Public exports
 
-For the authoritative list of what's exported from `@amqp-contract/worker`, read [`packages/worker/src/index.ts`](../../packages/worker/src/index.ts). Notable types: `WorkerInferHandlers<TContract>` (full handlers object — covers `consumers` ∪ `rpcs`), `WorkerInferConsumerHandler`, `WorkerInferRpcHandler`, `WorkerInferConsumedMessage`, `WorkerInferRpcConsumedMessage`. The legacy `WorkerInferConsumerHandlers` alias is `@deprecated` and still re-exported for one cycle — new code should use `WorkerInferHandlers`.
+For the authoritative list, read [`packages/worker/src/index.ts`](../../packages/worker/src/index.ts). What's currently re-exported:
+
+- Classes: `TypedAmqpWorker`, `RetryableError`, `NonRetryableError`, `MessageValidationError`
+- Factories / guards: `retryable`, `nonRetryable`, `isRetryableError`, `isNonRetryableError`, `isHandlerError`
+- Helpers: `defineHandler`, `defineHandlers`
+- Types: `CreateWorkerOptions`, `ConsumerOptions`, `HandlerError`, `WorkerInferConsumerHandler`, `WorkerInferConsumerHandlerEntry`, `WorkerInferConsumerHandlers` (deprecated alias for the consumer-handlers shape), `WorkerConsumedMessage`, `WorkerInferConsumedMessage`, `WorkerInferConsumerHeaders`
+
+What is **not** currently re-exported (RPC-side types live in `packages/worker/src/types.ts` but aren't surfaced at the package root): `WorkerInferHandlers`, `WorkerInferRpcHandler`, `WorkerInferRpcHandlerEntry`, `WorkerInferRpcConsumedMessage`, `WorkerInferRpcRequest`, `WorkerInferRpcResponse`, `WorkerInferRpcHeaders`. RPC handlers don't need them at the call site — `TypedAmqpWorker.create`'s parameter type infers each handler's signature from the contract automatically.

--- a/.agents/rules/project-overview.md
+++ b/.agents/rules/project-overview.md
@@ -4,14 +4,16 @@
 
 ## Key Technologies
 
-- **TypeScript 5.9+** — strict type safety
+- **TypeScript** — strict type safety
 - **Standard Schema v1** — universal schema validation interface (Zod, Valibot, ArkType)
 - **amqplib** — AMQP 0.9.1 client for Node.js
-- **neverthrow** — ResultAsync/Result functional error handling
+- **neverthrow** — `ResultAsync` / `Result` functional error handling
 - **Vitest** — test framework
-- **Turbo** — monorepo build system
-- **pnpm** — package manager
+- **Turbo** — monorepo build orchestrator
+- **pnpm** — package manager (catalog-based dependency management)
 - **oxlint / oxfmt** — linter and formatter
+
+Pinned versions live in [`pnpm-workspace.yaml`](../../pnpm-workspace.yaml) — that file is the source of truth, do not duplicate versions in docs.
 
 ## Packages
 
@@ -19,38 +21,42 @@
 | ------------------------- | ------------------------------------------------------------ |
 | `@amqp-contract/contract` | Contract definition builder and types (foundation)           |
 | `@amqp-contract/core`     | AMQP connection management, topology setup, telemetry        |
-| `@amqp-contract/client`   | Type-safe publishing via `TypedAmqpClient`                   |
+| `@amqp-contract/client`   | Type-safe publishing and RPC via `TypedAmqpClient`           |
 | `@amqp-contract/worker`   | Type-safe consumption via `TypedAmqpWorker` with retry logic |
 | `@amqp-contract/asyncapi` | AsyncAPI 3.0 specification generator                         |
-| `@amqp-contract/testing`  | Testcontainers setup and vitest fixtures                     |
+| `@amqp-contract/testing`  | Testcontainers setup and Vitest fixtures                     |
 
 ## Monorepo Structure
 
 ```
 amqp-contract/
-├── docs/                  # Documentation site
+├── docs/                  # VitePress documentation site
 ├── packages/
-│   ├── contract/          # Core contract builder
-│   ├── core/              # Core utilities for AMQP setup and management
-│   ├── client/            # Type-safe AMQP client
-│   ├── worker/            # Type-safe AMQP worker
+│   ├── contract/          # Contract builder (foundation)
+│   ├── core/              # AMQP connection / topology / telemetry
+│   ├── client/            # TypedAmqpClient (publish + RPC)
+│   ├── worker/            # TypedAmqpWorker (consume + retry)
 │   ├── asyncapi/          # AsyncAPI 3.0 generator
-│   └── testing/           # Testing utilities
-├── samples/               # Example implementations
-└── tools/                 # Development tools
+│   └── testing/           # Vitest fixtures + testcontainers setup
+├── examples/              # Runnable example apps
+├── tests/                 # Cross-package integration tests
+└── tools/                 # Shared tsconfig / typedoc presets
 ```
 
-## Package Structure
-
-Each package follows this layout:
+## Package Source Layout
 
 ```
-packages/[package-name]/
+packages/<name>/
 ├── src/
-│   ├── index.ts           # Public API exports
-│   ├── [feature].ts       # Implementation
-│   └── [feature].spec.ts  # Tests alongside code
+│   ├── index.ts             # Public API surface
+│   ├── <feature>.ts         # Implementation
+│   ├── <feature>.spec.ts    # Unit tests (no broker required)
+│   └── __tests__/
+│       └── <feature>.spec.ts  # Integration tests (require RabbitMQ)
 ├── package.json
 ├── tsconfig.json
-└── vitest.config.ts
+├── tsdown.config.ts         # Build config
+└── vitest.config.ts         # Splits unit / integration projects
 ```
+
+Unit specs live next to the source they cover. Integration specs go under `src/__tests__/` so the `vitest.config.ts` `unit` and `integration` projects can target them by glob.

--- a/.agents/rules/project-overview.md
+++ b/.agents/rules/project-overview.md
@@ -26,6 +26,8 @@ Pinned versions live in [`pnpm-workspace.yaml`](../../pnpm-workspace.yaml) — t
 | `@amqp-contract/asyncapi` | AsyncAPI 3.0 specification generator                         |
 | `@amqp-contract/testing`  | Testcontainers setup and Vitest fixtures                     |
 
+`@amqp-contract/asyncapi` is purely a code-generation aid: feed it a contract and it emits an AsyncAPI 3.0 document for catalogues, doc sites, or other tooling. Entry point is the `AsyncAPIGenerator` class exported from the package — instantiate, call `.generate(contract, { info, ... })`, get a JSON spec back. It has no runtime dependency on the broker.
+
 ## Monorepo Structure
 
 ```

--- a/.agents/rules/project-overview.md
+++ b/.agents/rules/project-overview.md
@@ -47,18 +47,17 @@ amqp-contract/
 
 ## Package Source Layout
 
-```
-packages/<name>/
-├── src/
-│   ├── index.ts             # Public API surface
-│   ├── <feature>.ts         # Implementation
-│   ├── <feature>.spec.ts    # Unit tests (no broker required)
-│   └── __tests__/
-│       └── <feature>.spec.ts  # Integration tests (require RabbitMQ)
-├── package.json
-├── tsconfig.json
-├── tsdown.config.ts         # Build config
-└── vitest.config.ts         # Splits unit / integration projects
-```
+The shape varies by package — there's no single template. The pieces that _do_ recur:
 
-Unit specs live next to the source they cover. Integration specs go under `src/__tests__/` so the `vitest.config.ts` `unit` and `integration` projects can target them by glob.
+- `src/index.ts` — public API surface (always).
+- `src/<feature>.ts` — implementation modules, `.js` extensions in imports.
+- `package.json` — entry points, `exports` map, build script, deps; metadata fields (`repository`, `homepage`, `bugs`, `author`, `license`) required on every publishable package, see [Build & Release](./build-and-release.md).
+- `tsconfig.json` — extends from `tools/tsconfig`.
+
+Where the packages **diverge**:
+
+- **Build config.** `core`, `client`, `worker`, `asyncapi` use a `tsdown.config.ts` (mostly to mark `neverthrow` external). `contract` and `testing` configure tsdown via CLI flags in `package.json`. `testing` is multi-entry (`index`, `global-setup`, `extension`) and ESM-only; the others are dual ESM + CJS.
+- **Test layout.** `core`, `client`, `worker` have a unit / integration split: unit specs sit next to source (`feature.spec.ts`), integration specs under `src/__tests__/`, and `vitest.config.ts` runs them as two named projects. `contract` and `asyncapi` only have unit specs and keep them next to source. `testing` has no tests (it _is_ the testing package — see [Testing](./testing.md)).
+- **Build/test scripts.** Confirm via `package.json` rather than assuming.
+
+Look at `packages/contract` for the simplest case, `packages/worker` for a package with an integration suite, `packages/testing` for the multi-entry/ESM-only shape.

--- a/.agents/rules/recipes.md
+++ b/.agents/rules/recipes.md
@@ -1,0 +1,72 @@
+# Recipes
+
+End-to-end how-tos for the changes that come up most. Each recipe lists the exact files to touch.
+
+## Add a new event consumer
+
+1. **Schema** — define (or reuse) a `defineMessage(...)` for the payload, in the contract that owns the publisher.
+2. **Queue** — `defineQueue(...)` with a `deadLetter` and a `retry` mode (immediate-requeue or ttl-backoff). Quorum by default; classic only if you need priority/exclusive/auto-delete.
+3. **Consumer entry** — `defineEventConsumer(eventPublisher, queue, { routingKey: ... })`. The queue↔exchange binding is auto-generated.
+4. **Add to `defineContract`** under `consumers: { ... }`. Don't add the queue or binding yourself — they're auto-extracted.
+5. **Handler** — implement with `defineHandler(contract, "yourConsumerName", ({ payload, headers }) => …)` returning `ResultAsync<void, HandlerError>`. See [handlers.md](./handlers.md).
+6. **Tests** — integration test in `src/__tests__/<consumer>.spec.ts` using `it` from `@amqp-contract/testing/extension`. Mock the handler with `vi.fn().mockReturnValue(okAsync(undefined))`.
+7. **Changeset** — `pnpm changeset` with a minor bump. Public API surface grew.
+
+## Add a new RPC
+
+1. **Schemas** — request and response, both via `defineMessage`.
+2. **Queue** — `defineQueue(...)` for the RPC. Almost always quorum, no DLQ for the RPC queue itself (the reply path handles the failure modes; see [handlers.md → RPC error semantics](./handlers.md#rpc-handler)).
+3. **RPC entry** — `defineRpc(queue, { request, response })`.
+4. **Add to `defineContract`** under `rpcs: { ... }`.
+5. **Server-side handler** — `defineHandler(contract, "yourRpcName", ({ payload }) => okAsync({ /* response */ }))`. The worker validates the response and replies automatically.
+6. **Client call** — `client.call("yourRpcName", request, { timeoutMs: 5_000 })`. `timeoutMs` is required.
+7. **Tests** — round-trip integration test (worker + client both wired up). For "no server" scenarios, just create the client without a worker; for "request validation fails", pass a deliberately wrong payload through `as unknown as ...`.
+8. **Changeset** — minor bump.
+
+## Add a new publisher (event or command)
+
+1. **Event publisher**: `defineEventPublisher(exchange, message, { routingKey })`. One publisher, many consumers.
+2. **Command publisher**: derived from `defineCommandConsumer(...)` via `defineCommandPublisher(consumer)`. Many publishers, one consumer.
+3. **Add to `defineContract`** under `publishers: { ... }`.
+4. **Use** `client.publish("yourPublisherName", payload, options?)`. Returns `ResultAsync<void, TechnicalError | MessageValidationError>`.
+5. **Changeset** — minor bump if it's part of the public contract surface.
+
+## Add a new publishable package
+
+If you're spinning up a new `@amqp-contract/*` package:
+
+1. Create `packages/<name>/` with `package.json`, `tsconfig.json`, `tsdown.config.ts`, `vitest.config.ts`, `src/index.ts`.
+2. Mirror the metadata fields from `packages/contract/package.json`: `homepage`, `bugs`, `license`, `author`, `repository` (with the correct `directory`), `files`, `type: "module"`, `exports`, `main`/`module`/`types`. **All six fields are required** — npm Trusted Publishing rejects on missing/empty `repository.url` (we hit this in the migration).
+3. In `tsdown.config.ts`, mark `neverthrow` external if the package re-exports `ResultAsync` types. Add any other dep whose types surface publicly.
+4. Add the package to the `fixed` group in [`.changeset/config.json`](../../.changeset/config.json) so it versions with the rest.
+5. Configure the npmjs Trusted Publisher for the new package (npm UI → package settings → trusted publishing → point at `.github/workflows/release.yml` in `btravers/amqp-contract`). Until this is done, the publish will fail with `ENEEDAUTH`.
+6. `pnpm install` to update the lockfile and turbo's package graph.
+7. Initial release — add a changeset documenting the package, merge through the normal flow.
+
+## Migrate a handler from `async` to `ResultAsync`
+
+Old shape (now banned):
+
+```typescript
+processOrder: async ({ payload }) => {
+  await processPayment(payload);
+};
+```
+
+New shape:
+
+```typescript
+processOrder: ({ payload }) =>
+  ResultAsync.fromPromise(
+    processPayment(payload),
+    (error) => new RetryableError("Payment failed", error),
+  ).map(() => undefined);
+```
+
+Three things to remember:
+
+- `fromPromise` requires the error mapper as the second arg — chaining `.mapErr` afterwards is a type error.
+- For permanent failures, return `errAsync(new NonRetryableError(...))`.
+- For success with no value, `okAsync(undefined)`.
+
+See [handlers.md](./handlers.md) for the full neverthrow API and the common-mistakes list in [`AGENTS.md`](../../AGENTS.md#common-mistakes).

--- a/.agents/rules/recipes.md
+++ b/.agents/rules/recipes.md
@@ -15,10 +15,10 @@ End-to-end how-tos for the changes that come up most. Each recipe lists the exac
 ## Add a new RPC
 
 1. **Schemas** — request and response, both via `defineMessage`.
-2. **Queue** — `defineQueue(...)` for the RPC. Almost always quorum, no DLQ for the RPC queue itself (the reply path handles the failure modes; see [handlers.md → RPC error semantics](./handlers.md#rpc-handler)).
+2. **Queue** — `defineQueue(...)` for the RPC. Quorum by default. **Configure a `deadLetter`** even though replies, not the queue, drive most failure modes: missing `replyTo` / `correlationId` and response-schema mismatches are surfaced as `NonRetryableError` and the worker `nack`s them without requeue, so without a DLX they're dropped silently.
 3. **RPC entry** — `defineRpc(queue, { request, response })`.
 4. **Add to `defineContract`** under `rpcs: { ... }`.
-5. **Server-side handler** — `defineHandler(contract, "yourRpcName", ({ payload }) => okAsync({ /* response */ }))`. The worker validates the response and replies automatically.
+5. **Server-side handler** — define it **inline** in the `handlers` object passed to `TypedAmqpWorker.create({ handlers: { yourRpcName: ({ payload }) => okAsync({ /* response */ }) } })`. `defineHandler` / `defineHandlers` are not RPC-aware (they're typed against `InferConsumerNames` and only validate `contract.consumers`); calling them with an RPC name throws _"Consumer X not found in contract"_. The worker validates the response against the response schema and publishes back automatically.
 6. **Client call** — `client.call("yourRpcName", request, { timeoutMs: 5_000 })`. `timeoutMs` is required.
 7. **Tests** — round-trip integration test (worker + client both wired up). For "no server" scenarios, just create the client without a worker; for "request validation fails", pass a deliberately wrong payload through `as unknown as ...`.
 8. **Changeset** — minor bump.
@@ -35,9 +35,12 @@ End-to-end how-tos for the changes that come up most. Each recipe lists the exac
 
 If you're spinning up a new `@amqp-contract/*` package:
 
-1. Create `packages/<name>/` with `package.json`, `tsconfig.json`, `tsdown.config.ts`, `vitest.config.ts`, `src/index.ts`.
-2. Mirror the metadata fields from `packages/contract/package.json`: `homepage`, `bugs`, `license`, `author`, `repository` (with the correct `directory`), `files`, `type: "module"`, `exports`, `main`/`module`/`types`. **All six fields are required** — npm Trusted Publishing rejects on missing/empty `repository.url` (we hit this in the migration).
-3. In `tsdown.config.ts`, mark `neverthrow` external if the package re-exports `ResultAsync` types. Add any other dep whose types surface publicly.
+1. Create `packages/<name>/` with at minimum: `package.json`, `tsconfig.json` (extends `@amqp-contract/tsconfig`), and `src/index.ts`. Add `vitest.config.ts` only if the package has tests; add `tsdown.config.ts` only if you need config beyond what the CLI flags can express (see existing packages — `contract` and `testing` skip the config file, the others use one).
+2. Mirror the metadata fields from `packages/contract/package.json`: `homepage`, `bugs`, `license`, `author`, `repository` (with the correct `directory`), `files`, `type: "module"`, plus the appropriate `exports` map (single entry like `contract` or multi-entry like `testing`). **All of these are required** — npm Trusted Publishing rejects on missing or empty `repository.url` (we hit that during the migration).
+3. Pick the build shape that matches your package's exports:
+   - **Single-entry, dual ESM+CJS** (most packages): `tsdown src/index.ts --format cjs,esm --dts --clean`, with a `tsdown.config.ts` if you need to mark deps external (see [Build & Release](./build-and-release.md)).
+   - **Multi-entry, ESM-only** (like `testing`): pass each entry as a positional and use `--format esm`.
+     If `ResultAsync` (or any other dep) appears in your public types, mark that dep `external` to prevent its types being inlined.
 4. Add the package to the `fixed` group in [`.changeset/config.json`](../../.changeset/config.json) so it versions with the rest.
 5. Configure the npmjs Trusted Publisher for the new package (npm UI → package settings → trusted publishing → point at `.github/workflows/release.yml` in `btravers/amqp-contract`). Until this is done, the publish will fail with `ENEEDAUTH`.
 6. `pnpm install` to update the lockfile and turbo's package graph.

--- a/.agents/rules/runtime.md
+++ b/.agents/rules/runtime.md
@@ -1,0 +1,51 @@
+# Runtime
+
+Cross-cutting concerns for code that touches the live AMQP layer: telemetry, connection pooling, and compression. Most of this lives in `@amqp-contract/core`.
+
+## Connection management
+
+`@amqp-contract/core` keeps a process-wide `ConnectionManagerSingleton` keyed on the URL set + connection options. `TypedAmqpClient` and `TypedAmqpWorker` share connections automatically when they're constructed with the same URLs — you don't need to (and shouldn't) wire connections manually.
+
+Two invariants matter when touching this layer:
+
+- **Ref-counted lifecycle.** `getConnection(...)` increments the count; `releaseConnection(...)` decrements and closes the underlying connection when the count hits zero. Every `getConnection` must be paired with a `releaseConnection` — otherwise the connection lives forever.
+- **Failure-path cleanup.** If `waitForConnect()` (or any setup step before the worker/client returns to the user) errors, you must call `close()` to release the ref-count _before_ returning the error. `TypedAmqpClient.create` and `TypedAmqpWorker.create` already do this; if you write a new factory, mirror the pattern.
+
+`AmqpClient.waitForConnect()` accepts a `connectTimeoutMs` (default 30s). `null` disables it; `Infinity`/`NaN`/`<= 0` are coerced to `null` because Node's `setTimeout` clamps and silently mis-fires on those. See `DEFAULT_CONNECT_TIMEOUT_MS` in [`packages/core/src/amqp-client.ts`](../../packages/core/src/amqp-client.ts).
+
+## Telemetry (OpenTelemetry, optional)
+
+`@opentelemetry/api` is an **optional peer dependency** of `@amqp-contract/core`. If a consumer installs it, telemetry flows automatically; if not, the default provider is a no-op.
+
+Public surface from `@amqp-contract/core`:
+
+| Export                                        | Use                                                                                                                  |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `TelemetryProvider`                           | Type. Pass a custom one via `CreateClientOptions.telemetry` etc.                                                     |
+| `defaultTelemetryProvider`                    | Auto-detects `@opentelemetry/api`; no-op if absent.                                                                  |
+| `startPublishSpan` / `startConsumeSpan`       | Open a span around a publish or consume operation.                                                                   |
+| `endSpanSuccess` / `endSpanError`             | Close it; `endSpanError(span, error)` records the exception too.                                                     |
+| `recordPublishMetric` / `recordConsumeMetric` | Counter for success/failure + duration histogram.                                                                    |
+| `recordLateRpcReply`                          | Counter for replies that arrived after the caller gave up.                                                           |
+| `MessagingSemanticConventions`                | Pre-defined attribute keys (`messaging.rabbitmq.message.delivery_tag`, etc.) — use these rather than ad-hoc strings. |
+
+When adding a new public method to `TypedAmqpClient` / `TypedAmqpWorker`, wrap it in spans and metrics consistent with the surrounding code. See `client.ts:publish` for the canonical pattern (start span → run → `andTee` records success metric, `orTee` records failure metric).
+
+## Compression
+
+Both ends support gzip and deflate, controlled by the publisher:
+
+- **Client** opts in per-publish via `options.compression: 'gzip' | 'deflate'`. The body is compressed and `contentEncoding` is set automatically — don't set `contentEncoding` yourself when using `compression`.
+- **Worker** decompresses transparently before validation, based on `properties.contentEncoding`. Unknown encodings produce a `TechnicalError` (parse failure → DLQ via single `nack`, never enters retry).
+- **RPC requests do not support compression.** The reply path doesn't decompress, so a compressed request would round-trip incorrectly. The client drops `compression` from RPC publish options on purpose (see `client.ts:call`).
+
+The `CompressionAlgorithm` type is exported from `@amqp-contract/contract`.
+
+## Logging
+
+`Logger` is a structured-logging interface (compatible with `pino`'s shape). It's optional everywhere — `TypedAmqpClient` and `TypedAmqpWorker` accept a `logger?: Logger` option. When writing a new code path:
+
+- Log at `info` for routine successes (one per published message is fine).
+- Log at `warn` for recoverable issues (consumer cancelled by server, retry attempts).
+- Log at `error` for handler failures and DLQ routing — include `consumerName`, `queueName`, and the error.
+- Never log payload contents at info/warn — they may contain PII. Log identifiers (orderId, etc.) instead, and only at error if needed for triage.

--- a/.agents/rules/runtime.md
+++ b/.agents/rules/runtime.md
@@ -37,7 +37,7 @@ Both ends support gzip and deflate, controlled by the publisher:
 
 - **Client** opts in per-publish via `options.compression: 'gzip' | 'deflate'`. The body is compressed and `contentEncoding` is set automatically — don't set `contentEncoding` yourself when using `compression`.
 - **Worker** decompresses transparently before validation, based on `properties.contentEncoding`. Unknown encodings produce a `TechnicalError` (parse failure → DLQ via single `nack`, never enters retry).
-- **RPC requests do not support compression.** The reply path doesn't decompress, so a compressed request would round-trip incorrectly. The client drops `compression` from RPC publish options on purpose (see `client.ts:call`).
+- **RPC requests don't carry compression.** The worker's parse/validate path _does_ decompress an RPC request fine if it sees `contentEncoding`, and replies are always uncompressed — so a compressed RPC request would round-trip mechanically. Even so, `client.call()` deliberately strips any inherited `compression` from `defaultPublishOptions` before publishing, so the on-wire convention stays consistent (no compression in either direction of an RPC). If you're wiring a new code path involving RPCs, mirror that — don't compress RPC requests.
 
 The `CompressionAlgorithm` type is exported from `@amqp-contract/contract`.
 

--- a/.agents/rules/testing.md
+++ b/.agents/rules/testing.md
@@ -29,7 +29,13 @@ export default defineConfig({
 
 ## Test Fixtures
 
-Import `it` from `@amqp-contract/testing/extension` for fixtures. Available fixtures: `vhost`, `amqpConnectionUrl`, `amqpConnection`, `amqpChannel`.
+Import `it` from `@amqp-contract/testing/extension` for fixtures. Available fixtures:
+
+- `vhost` — isolated RabbitMQ vhost (one per test)
+- `amqpConnectionUrl` — connection URL pointing at that vhost
+- `amqpConnection` / `amqpChannel` — opened connection + channel for direct broker calls
+- `publishMessage(exchange, routingKey, content, options?)` — publish a JSON-serialised message
+- `initConsumer(exchange, routingKey)` — returns a `(opts?) => Promise<ConsumeMessage[]>` waiter that you call to await N messages
 
 ```typescript
 import { describe, expect } from "vitest";

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,19 +10,21 @@ Type-safe contracts for AMQP/RabbitMQ messaging with automatic runtime validatio
 | [Commands](.agents/rules/commands.md)                   | Dev, quality, test, versioning commands                                      |
 | [Contract Patterns](.agents/rules/contract-patterns.md) | Contract composition, event/command, retry, type inference                   |
 | [Handlers](.agents/rules/handlers.md)                   | Handler signatures, ResultAsync, neverthrow API, error types, worker exports |
-| [Code Style](.agents/rules/code-style.md)               | TypeScript rules, imports, anti-patterns, best practices                     |
+| [Code Style](.agents/rules/code-style.md)               | Composition pattern, anti-patterns, advisory style guidance                  |
 | [Testing](.agents/rules/testing.md)                     | Testing strategy, integration tests, fixtures, assertions                    |
 | [Dependencies](.agents/rules/dependencies.md)           | Key deps, catalog management, monorepo tooling                               |
 
 ## Key Constraints
 
-- No `any` types — use `unknown` and narrow
+This is the canonical list — sub-files refer back to it rather than restating these.
+
+- No `any` types — use `unknown` and narrow (enforced by oxlint)
 - Type aliases over interfaces — `type Foo = {}` not `interface Foo {}`
 - `.js` extensions required in all imports (ESM)
-- Handlers return `ResultAsync<void, HandlerError>` (neverthrow) — not async/await
+- Handlers return `ResultAsync<void, HandlerError>` (neverthrow) — not `async`/`await`
 - Standard Schema v1 for validation (Zod, Valibot, ArkType)
-- Catalog dependencies via `pnpm-workspace.yaml` — not hardcoded versions
-- Conventional commits required (e.g. feat, fix, docs, chore, test, refactor — full set per Conventional Commits spec)
-- Quorum queues by default — classic queues only for special cases
-- Composition pattern — define resources first, then reference
-- Git hooks: lefthook runs format, lint on `pre-commit`, and commitlint on `commit-msg`
+- Catalog dependencies via `pnpm-workspace.yaml` — never hardcode versions in `package.json`
+- Conventional commits required (feat, fix, docs, chore, test, refactor, ci, build, perf, refactor, revert, style — Conventional Commits spec, enforced by commitlint on `commit-msg`)
+- Quorum queues by default — classic queues only when you need a feature quorum doesn't support (`exclusive`, `autoDelete`, `maxPriority`)
+- Composition pattern — define resources first, then reference; never inline
+- Git hooks: lefthook runs `oxfmt` and `oxlint` on `pre-commit`, commitlint on `commit-msg`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,30 +1,83 @@
 # amqp-contract
 
-Type-safe contracts for AMQP/RabbitMQ messaging with automatic runtime validation.
+Type-safe contracts for AMQP/RabbitMQ messaging with automatic runtime validation. TypeScript ESM monorepo using pnpm catalogs and Turbo.
 
 ## Rules
 
-| Rule                                                    | Description                                                                  |
-| ------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| [Project Overview](.agents/rules/project-overview.md)   | Architecture, packages, monorepo structure                                   |
-| [Commands](.agents/rules/commands.md)                   | Dev, quality, test, versioning commands                                      |
-| [Contract Patterns](.agents/rules/contract-patterns.md) | Contract composition, event/command, retry, type inference                   |
-| [Handlers](.agents/rules/handlers.md)                   | Handler signatures, ResultAsync, neverthrow API, error types, worker exports |
-| [Code Style](.agents/rules/code-style.md)               | Composition pattern, anti-patterns, advisory style guidance                  |
-| [Testing](.agents/rules/testing.md)                     | Testing strategy, integration tests, fixtures, assertions                    |
-| [Dependencies](.agents/rules/dependencies.md)           | Key deps, catalog management, monorepo tooling                               |
+| Rule                                                    | Read this when…                                                  |
+| ------------------------------------------------------- | ---------------------------------------------------------------- |
+| [Project Overview](.agents/rules/project-overview.md)   | Orienting yourself in the repo, looking up which package owns X  |
+| [Commands](.agents/rules/commands.md)                   | Running anything (`pnpm`, turbo filters, integration tests)      |
+| [Contract Patterns](.agents/rules/contract-patterns.md) | Defining or modifying a contract (publishers/consumers/RPCs)     |
+| [Handlers](.agents/rules/handlers.md)                   | Writing worker handlers, dealing with `ResultAsync` / neverthrow |
+| [Runtime](.agents/rules/runtime.md)                     | Touching connections, telemetry, compression                     |
+| [Code Style](.agents/rules/code-style.md)               | Reviewing or writing TS — composition, anti-patterns             |
+| [Testing](.agents/rules/testing.md)                     | Adding unit or integration tests, using the testing fixtures     |
+| [Build & Release](.agents/rules/build-and-release.md)   | Adding a package, modifying tsdown config, shipping a release    |
+| [Dependencies](.agents/rules/dependencies.md)           | Adding a dep, picking a schema lib, catalog questions            |
+| [Recipes](.agents/rules/recipes.md)                     | "How do I add a new consumer / RPC / publishable package?"       |
 
 ## Key Constraints
 
-This is the canonical list — sub-files refer back to it rather than restating these.
+This is the canonical list — sub-files reference these rather than restating them.
 
-- No `any` types — use `unknown` and narrow (enforced by oxlint)
-- Type aliases over interfaces — `type Foo = {}` not `interface Foo {}`
-- `.js` extensions required in all imports (ESM)
-- Handlers return `ResultAsync<void, HandlerError>` (neverthrow) — not `async`/`await`
-- Standard Schema v1 for validation (Zod, Valibot, ArkType)
-- Catalog dependencies via `pnpm-workspace.yaml` — never hardcode versions in `package.json`
-- Conventional commits required (feat, fix, docs, chore, test, refactor, ci, build, perf, refactor, revert, style — Conventional Commits spec, enforced by commitlint on `commit-msg`)
-- Quorum queues by default — classic queues only when you need a feature quorum doesn't support (`exclusive`, `autoDelete`, `maxPriority`)
-- Composition pattern — define resources first, then reference; never inline
-- Git hooks: lefthook runs `oxfmt` and `oxlint` on `pre-commit`, commitlint on `commit-msg`
+### Language and types
+
+- No `any` — use `unknown` and narrow (enforced by oxlint).
+- Type aliases over interfaces — `type Foo = {}`, not `interface Foo {}`.
+- `.js` extensions required in all imports (ESM).
+- Standard Schema v1 for validation (Zod, Valibot, ArkType — anything that implements the spec).
+
+### Handlers and error handling
+
+- Handlers return `ResultAsync<void, HandlerError>` (regular consumer) or `ResultAsync<TResponse, HandlerError>` (RPC). No `async`/`await` in handler signatures.
+- `await resultAsync` resolves to a `Result<T, E>` — it does **not** throw on `Err`.
+- `result.match(okFn, errFn)` is **positional**. Boxed-style `match({ Ok, Error })` is not supported.
+- `ResultAsync.fromPromise(promise, errorMapper)` requires the error mapper as the second argument. Chaining `.mapErr(fn)` afterwards instead is a type error.
+
+### Topology and contract authoring
+
+- Quorum queues by default. Classic queues only for features quorum doesn't support (`exclusive`, `autoDelete`, `maxPriority`).
+- Composition pattern — define resources first, then reference; never inline inside `defineContract`.
+
+### Tooling and process
+
+- Catalog dependencies via `pnpm-workspace.yaml` — never hardcode versions in `package.json`.
+- Conventional commits required (feat, fix, docs, chore, test, refactor, ci, build, perf, revert, style). Enforced by commitlint on `commit-msg`.
+- Git hooks: lefthook runs `oxfmt` and `oxlint` on `pre-commit`; commitlint on `commit-msg`. `pnpm typecheck` is **not** in the hook, so run it before pushing if you changed types.
+
+## Safety / blast radius
+
+Before doing any of the following, confirm with the user:
+
+- Pushing to `main`, force-pushing, or rewriting history (main is protected, but local mistakes happen — see [Build & Release](.agents/rules/build-and-release.md) for the release flow).
+- Running `git reset --hard`, `git clean -fdx`, or any destructive `git` operation when the working tree contains uncommitted state.
+- Closing or merging a PR.
+- Anything that publishes to npm or pushes to GitHub Releases (the changeset/release pipeline owns publishing — never run `pnpm release` or `npm publish` manually).
+- Skipping commit hooks (`--no-verify`) or signing flags. If a hook fails, fix the underlying issue.
+- Editing `.github/workflows/*.yml` — release uses Trusted Publishing OIDC; small changes can break npm auth. Read [Build & Release](.agents/rules/build-and-release.md) first.
+
+These do **not** need confirmation:
+
+- Local commits, branches, file edits, running `pnpm build`/`test`/`lint`.
+- Pushing a feature branch to origin.
+- Creating a PR (always go via PR — never push directly to `main`).
+
+## Common mistakes
+
+These have been re-introduced more than once across recent migrations / reviews — flag them in self-review:
+
+- **Treating `await TypedAmqp(Client|Worker).create(...)` as a client/worker.** It returns `ResultAsync<Client, TechnicalError>`; `await` gives you a `Result`. Unwrap with `_unsafeUnwrap()` (or pattern-match) before calling instance methods.
+- **Wrapping `client.publish(...)` in `ResultAsync.fromPromise(...)`.** `publish` already returns a `ResultAsync` — wrap it again and you get `ResultAsync<ResultAsync<...>>`. Chain `.map` / `.mapErr` directly.
+- **Calling `ResultAsync.fromPromise(p)` without the error mapper.** The mapper is a required second argument. The TS error is sometimes opaque ("expected 2 arguments, got 1"), but the fix is always: pass the mapper.
+- **Using `result.match({ Ok, Error })`.** That's the boxed shape. neverthrow's `match` is positional: `result.match(okFn, errFn)`.
+- **Adding a publishable package without `repository`, `homepage`, `bugs`, `author`, `license`** — npm will reject with a 422 on provenance validation under Trusted Publishing.
+- **Hardcoding a dep version in a `package.json`.** Use `"catalog:"` and add the actual version once in `pnpm-workspace.yaml`.
+- **Forgetting to add a changeset** when changing public API. The release will silently skip your change.
+
+## Workflow rules for agents
+
+- **Before claiming a refactor is done**, run `pnpm typecheck` (it isn't in the pre-commit hook). If you changed a public type in package A, also rebuild it (`pnpm --filter @amqp-contract/<a> build`) before typechecking package B that depends on it — workspace packages are typed against their `dist/` output.
+- **Public API changes need a changeset** (`pnpm changeset`). The six publishable packages are in a `fixed` group — they all bump together; you only add one entry.
+- **Don't claim integration tests "pass" if they didn't run.** They require Docker; if you can't run them locally, say so explicitly rather than implying coverage.
+- **When deferring to a doc**, link to a specific `path/to/file.ts` line rather than restating it. Stale duplication is the dominant failure mode of these rule files.


### PR DESCRIPTION
## Summary

Two-part docs pass on `AGENTS.md` and `.agents/rules/*`. First commit fixed accuracy; second commit fills the coverage and agent-UX gaps. Both commits are docs-only.

### Commit 1 — accuracy fixes

Stale or wrong claims corrected across `project-overview.md`, `contract-patterns.md`, `code-style.md`, `handlers.md`, `testing.md`, `commands.md`. Highlights:

- TS "5.9+" → drop pinned version (catalog is the source of truth).
- Fake `samples/` → real `examples/` + `tests/` + `tools/`.
- Fabricated `WorkerInferConsumerInput` → real Client/Worker `Infer*` exports including the RPC ones.
- Broken `ResultAsync.fromPromise(p).mapErr(fn)` "Good" example fixed (won't compile under neverthrow).
- Deprecated `WorkerInferConsumerHandlers` removed; **RPC section added** (was completely missing).
- Test fixtures list completed (`publishMessage`, `initConsumer` were used in the example but missing from the list above).
- Pre-commit checklist trimmed to what isn't already enforced by lefthook.

Best-practice cleanups in commit 1:

- Constraints duplication between AGENTS.md and code-style.md → AGENTS.md is now canonical.
- handlers.md "Worker Package Exports" hand-maintained copy of `index.ts` → linked to source.
- dependencies.md hardcoded version table → drops versions, points at `pnpm-workspace.yaml`.

### Commit 2 — coverage and agent-UX

**New rule files:**

- **`runtime.md`** — connection ref-counting + failure-path cleanup invariant, optional OpenTelemetry surface, gzip/deflate rules (worker decompresses transparently; RPC drops compression on purpose), structured logging conventions.
- **`build-and-release.md`** — tsdown externals (`neverthrow` stays external so public types don't get inlined), build-before-typecheck-consumers rule, changesets `fixed` group, `pnpm version` collision we hit, Trusted Publishing flow with Node 24 + `repository.url` requirements.
- **`recipes.md`** — end-to-end how-tos: add a consumer, add an RPC, add a publisher, add a publishable package, migrate a handler from `async/await` to `ResultAsync`.

**AGENTS.md restructured** so agents that don't chase links still have the high-leverage info:

- Index table reads "Read this when…" so it doubles as a routing decision.
- Key Constraints split into Language / Handlers / Topology / Tooling groups; promoted the four neverthrow gotchas (`await` returns `Result`, positional `match`, `fromPromise` mapper required, etc.) — Copilot re-flagged each across multiple PRs.
- **Safety / blast-radius** section: what needs user confirmation (push to main, destructive git, manual publish, hook bypass, workflow edits) vs. what doesn't.
- **Common Mistakes** section: the migration's recurring traps, captured in one place.
- **Workflow rules for agents**: typecheck before claiming done, rebuild deps before typechecking consumers, don't claim integration tests passed if they didn't run.

**Existing files updated:**

- `handlers.md` — split Error Types into worker-side and client-side tables; added the `RpcTimeoutError` / `RpcCancelledError` / outbound `MessageValidationError` rows that were undocumented.
- `project-overview.md` — short note on `@amqp-contract/asyncapi`'s purpose and `AsyncAPIGenerator` entry point.

## Test plan

- [ ] Eyeball the rendered AGENTS.md and the three new rule files
- [ ] Confirm CI passes (docs-only)