### PR TITLE
feat: RPC-aware handler helpers, exported RPC types, HandlerError class

### DIFF
--- a/.agents/rules/handlers.md
+++ b/.agents/rules/handlers.md
@@ -182,9 +182,7 @@ const handlers = {
 
 For the authoritative list, read [`packages/worker/src/index.ts`](../../packages/worker/src/index.ts). What's currently re-exported:
 
-- Classes: `TypedAmqpWorker`, `RetryableError`, `NonRetryableError`, `MessageValidationError`
+- Classes: `TypedAmqpWorker`, `HandlerError` (abstract base), `RetryableError`, `NonRetryableError`, `MessageValidationError`
 - Factories / guards: `retryable`, `nonRetryable`, `isRetryableError`, `isNonRetryableError`, `isHandlerError`
-- Helpers: `defineHandler`, `defineHandlers`
-- Types: `CreateWorkerOptions`, `ConsumerOptions`, `HandlerError`, `WorkerInferConsumerHandler`, `WorkerInferConsumerHandlerEntry`, `WorkerInferConsumerHandlers` (deprecated alias for the consumer-handlers shape), `WorkerConsumedMessage`, `WorkerInferConsumedMessage`, `WorkerInferConsumerHeaders`
-
-What is **not** currently re-exported (RPC-side types live in `packages/worker/src/types.ts` but aren't surfaced at the package root): `WorkerInferHandlers`, `WorkerInferRpcHandler`, `WorkerInferRpcHandlerEntry`, `WorkerInferRpcConsumedMessage`, `WorkerInferRpcRequest`, `WorkerInferRpcResponse`, `WorkerInferRpcHeaders`. RPC handlers don't need them at the call site — `TypedAmqpWorker.create`'s parameter type infers each handler's signature from the contract automatically.
+- Helpers: `defineHandler`, `defineHandlers` (both accept consumer **and** RPC names)
+- Types: `CreateWorkerOptions`, `ConsumerOptions`, `WorkerConsumedMessage`, `WorkerInferConsumedMessage`, `WorkerInferConsumerHandler`, `WorkerInferConsumerHandlerEntry`, `WorkerInferConsumerHeaders`, `WorkerInferHandlers` (consumers ∪ rpcs), `WorkerInferRpcConsumedMessage`, `WorkerInferRpcHandler`, `WorkerInferRpcHandlerEntry`, `WorkerInferRpcHeaders`, `WorkerInferRpcRequest`, `WorkerInferRpcResponse`

--- a/.changeset/audit-public-api-gaps.md
+++ b/.changeset/audit-public-api-gaps.md
@@ -1,0 +1,15 @@
+---
+"@amqp-contract/asyncapi": minor
+"@amqp-contract/client": minor
+"@amqp-contract/contract": minor
+"@amqp-contract/core": minor
+"@amqp-contract/testing": minor
+"@amqp-contract/worker": minor
+---
+
+Close public-API gaps surfaced by the audit:
+
+- `defineHandler` / `defineHandlers` now accept RPC names in addition to consumer names. The handler type for `defineHandler` is inferred from the contract — consumer names yield `WorkerInferConsumerHandler`, RPC names yield `WorkerInferRpcHandler`. `defineHandlers` is typed against `WorkerInferHandlers<TContract>`, which already spans `consumers ∪ rpcs`. Runtime validation walks both sets and the error message lists both.
+- The RPC-side `Infer*` helpers and the unified handlers type are now re-exported from `@amqp-contract/worker`: `WorkerInferHandlers`, `WorkerInferRpcHandler`, `WorkerInferRpcHandlerEntry`, `WorkerInferRpcConsumedMessage`, `WorkerInferRpcRequest`, `WorkerInferRpcResponse`, `WorkerInferRpcHeaders`. This makes the worker package symmetrical with the client package's RPC-side exports.
+- `HandlerError` is now an abstract base class (`error instanceof HandlerError` works). `RetryableError` and `NonRetryableError` extend it, and the `name` property still discriminates so exhaustive narrowing in user code keeps working. Public type signature is unchanged (a class can be used as a type).
+- **Removed** `WorkerInferConsumerHandlers` (was `@deprecated` for one cycle). Use `WorkerInferHandlers` instead — same shape, accurate name.

--- a/packages/worker/src/__tests__/fixture.ts
+++ b/packages/worker/src/__tests__/fixture.ts
@@ -1,12 +1,12 @@
 import type { ContractDefinition } from "@amqp-contract/contract";
 import { TypedAmqpWorker } from "../worker.js";
-import type { WorkerInferConsumerHandlers } from "../types.js";
+import type { WorkerInferHandlers } from "../types.js";
 import { it as baseIt } from "@amqp-contract/testing/extension";
 
 export const it = baseIt.extend<{
   workerFactory: <TContract extends ContractDefinition>(
     contract: TContract,
-    handlers: WorkerInferConsumerHandlers<TContract>,
+    handlers: WorkerInferHandlers<TContract>,
   ) => Promise<TypedAmqpWorker<TContract>>;
 }>({
   workerFactory: async ({ amqpConnectionUrl }, use) => {
@@ -16,7 +16,7 @@ export const it = baseIt.extend<{
       await use(
         async <TContract extends ContractDefinition>(
           contract: TContract,
-          handlers: WorkerInferConsumerHandlers<TContract>,
+          handlers: WorkerInferHandlers<TContract>,
         ) => {
           // Topology setup (exchanges, queues, bindings, wait queues) is done automatically
           // by AmqpClient in the channel setup callback

--- a/packages/worker/src/errors.spec.ts
+++ b/packages/worker/src/errors.spec.ts
@@ -1,4 +1,5 @@
 import {
+  HandlerError,
   NonRetryableError,
   RetryableError,
   isHandlerError,
@@ -83,6 +84,31 @@ describe("Type Guards", () => {
       expect(isHandlerError(123)).toBe(false);
       expect(isHandlerError({})).toBe(false);
     });
+  });
+});
+
+describe("HandlerError class hierarchy", () => {
+  it("RetryableError is an instance of HandlerError", () => {
+    const error = new RetryableError("test");
+    expect(error).toBeInstanceOf(HandlerError);
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it("NonRetryableError is an instance of HandlerError", () => {
+    const error = new NonRetryableError("test");
+    expect(error).toBeInstanceOf(HandlerError);
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it("HandlerError narrows by name discriminator", () => {
+    const errors: HandlerError[] = [new RetryableError("retry"), new NonRetryableError("dlq")];
+    for (const error of errors) {
+      if (error.name === "RetryableError") {
+        expect(error).toBeInstanceOf(RetryableError);
+      } else {
+        expect(error).toBeInstanceOf(NonRetryableError);
+      }
+    }
   });
 });
 

--- a/packages/worker/src/errors.ts
+++ b/packages/worker/src/errors.ts
@@ -1,19 +1,20 @@
 export { MessageValidationError } from "@amqp-contract/core";
 
 /**
- * Retryable errors - transient failures that may succeed on retry
- * Examples: network timeouts, rate limiting, temporary service unavailability
+ * Abstract base class for all handler-signalled errors.
  *
- * Use this error type when the operation might succeed if retried.
- * The worker will apply exponential backoff and retry the message.
+ * Concrete subclasses (`RetryableError`, `NonRetryableError`) discriminate on
+ * the `name` property so exhaustive narrowing in user code keeps working.
+ * `error instanceof HandlerError` is true for any handler error.
  */
-export class RetryableError extends Error {
+export abstract class HandlerError extends Error {
+  abstract override readonly name: "RetryableError" | "NonRetryableError";
+
   constructor(
     message: string,
     public override readonly cause?: unknown,
   ) {
     super(message);
-    this.name = "RetryableError";
     // Node.js specific stack trace capture
     const ErrorConstructor = Error as unknown as {
       captureStackTrace?: (target: object, constructor: Function) => void;
@@ -22,6 +23,17 @@ export class RetryableError extends Error {
       ErrorConstructor.captureStackTrace(this, this.constructor);
     }
   }
+}
+
+/**
+ * Retryable errors - transient failures that may succeed on retry
+ * Examples: network timeouts, rate limiting, temporary service unavailability
+ *
+ * Use this error type when the operation might succeed if retried.
+ * The worker will apply exponential backoff and retry the message.
+ */
+export class RetryableError extends HandlerError {
+  override readonly name = "RetryableError" as const;
 }
 
 /**
@@ -31,28 +43,9 @@ export class RetryableError extends Error {
  * Use this error type when retrying would not help - the message will be
  * immediately sent to the dead letter queue (DLQ) if configured.
  */
-export class NonRetryableError extends Error {
-  constructor(
-    message: string,
-    public override readonly cause?: unknown,
-  ) {
-    super(message);
-    this.name = "NonRetryableError";
-    // Node.js specific stack trace capture
-    const ErrorConstructor = Error as unknown as {
-      captureStackTrace?: (target: object, constructor: Function) => void;
-    };
-    if (typeof ErrorConstructor.captureStackTrace === "function") {
-      ErrorConstructor.captureStackTrace(this, this.constructor);
-    }
-  }
+export class NonRetryableError extends HandlerError {
+  override readonly name = "NonRetryableError" as const;
 }
-
-/**
- * Union type representing all handler errors.
- * Use this type when defining handlers that explicitly signal error outcomes.
- */
-export type HandlerError = RetryableError | NonRetryableError;
 
 // =============================================================================
 // Type Guards
@@ -129,7 +122,7 @@ export function isNonRetryableError(error: unknown): error is NonRetryableError 
  * ```
  */
 export function isHandlerError(error: unknown): error is HandlerError {
-  return isRetryableError(error) || isNonRetryableError(error);
+  return error instanceof HandlerError;
 }
 
 // =============================================================================

--- a/packages/worker/src/handlers.spec.ts
+++ b/packages/worker/src/handlers.spec.ts
@@ -5,6 +5,7 @@ import {
   defineContract,
   defineMessage,
   defineQueue,
+  defineRpc,
 } from "@amqp-contract/contract";
 import { defineHandler, defineHandlers } from "./handlers.js";
 import { describe, expect, it } from "vitest";
@@ -52,11 +53,17 @@ describe("handlers", () => {
       data: z.string(),
     }),
   );
+  const rpcQueue = defineQueue("rpc-queue");
+  const rpcRequest = defineMessage(z.object({ a: z.number(), b: z.number() }));
+  const rpcResponse = defineMessage(z.object({ sum: z.number() }));
 
   const testContract = defineContract({
     consumers: {
       testConsumer: defineConsumer(testQueue, testMessage),
       anotherConsumer: defineConsumer(testQueue, testMessage),
+    },
+    rpcs: {
+      calculate: defineRpc(rpcQueue, { request: rpcRequest, response: rpcResponse }),
     },
   });
 
@@ -89,7 +96,31 @@ describe("handlers", () => {
       expect(result).toEqual([handler, { prefetch: 10 }]);
     });
 
-    it("should throw error if consumer not found in contract", () => {
+    it("should create an RPC handler returning a typed response", () => {
+      // GIVEN
+      const handler = ({ payload }: { payload: { a: number; b: number } }) =>
+        okAsync({ sum: payload.a + payload.b });
+
+      // WHEN
+      const result = defineHandler(testContract, "calculate", handler);
+
+      // THEN
+      expect(result).toBe(handler);
+    });
+
+    it("should create an RPC handler with options", () => {
+      // GIVEN
+      const handler = ({ payload }: { payload: { a: number; b: number } }) =>
+        okAsync({ sum: payload.a + payload.b });
+
+      // WHEN
+      const result = defineHandler(testContract, "calculate", handler, { prefetch: 5 });
+
+      // THEN
+      expect(result).toEqual([handler, { prefetch: 5 }]);
+    });
+
+    it("should throw error if name is not in contract (mentioning both consumers and RPCs)", () => {
       // GIVEN
       const handler = ({ payload }: { payload: { id: string; data: string } }) => {
         console.log(payload.id);
@@ -98,16 +129,16 @@ describe("handlers", () => {
 
       // WHEN/THEN
       expect(() => {
-        // @ts-expect-error Testing runtime validation with invalid consumer name
-        defineHandler(testContract, "nonExistentConsumer", handler);
+        // @ts-expect-error Testing runtime validation with invalid name
+        defineHandler(testContract, "nonExistent", handler);
       }).toThrow(
-        'Consumer "nonExistentConsumer" not found in contract. Available consumers: testConsumer, anotherConsumer',
+        'Handler target "nonExistent" not found in contract. Available consumers and RPCs: testConsumer, anotherConsumer, calculate',
       );
     });
   });
 
   describe("defineHandlers (safe handlers)", () => {
-    it("should create multiple safe handlers", () => {
+    it("should create multiple safe handlers spanning consumers and RPCs", () => {
       // GIVEN
       const handlers = {
         testConsumer: ({ payload }: { payload: { id: string; data: string } }) => {
@@ -118,6 +149,8 @@ describe("handlers", () => {
           console.log(payload.data);
           return okAsync(undefined);
         },
+        calculate: ({ payload }: { payload: { a: number; b: number } }) =>
+          okAsync({ sum: payload.a + payload.b }),
       };
 
       // WHEN
@@ -127,25 +160,30 @@ describe("handlers", () => {
       expect(result).toBe(handlers);
     });
 
-    it("should throw error if handler references non-existent consumer", () => {
+    it("should throw error if a handler key is not in contract (consumers ∪ rpcs)", () => {
       // GIVEN
       const handlers = {
         testConsumer: ({ payload }: { payload: { id: string; data: string } }) => {
           console.log(payload.id);
           return okAsync(undefined);
         },
-        nonExistentConsumer: ({ payload }: { payload: { id: string; data: string } }) => {
+        anotherConsumer: ({ payload }: { payload: { id: string; data: string } }) => {
+          console.log(payload.data);
+          return okAsync(undefined);
+        },
+        calculate: ({ payload }: { payload: { a: number; b: number } }) =>
+          okAsync({ sum: payload.a + payload.b }),
+        nonExistent: ({ payload }: { payload: { id: string; data: string } }) => {
           console.log(payload.data);
           return okAsync(undefined);
         },
       };
 
-      // WHEN/THEN
+      // WHEN/THEN — cast to bypass type-system check; runtime guard is what's under test
       expect(() => {
-        // @ts-expect-error Testing runtime validation with non-existent consumer
-        defineHandlers(testContract, handlers);
+        defineHandlers(testContract, handlers as never);
       }).toThrow(
-        'Consumer "nonExistentConsumer" not found in contract. Available consumers: testConsumer, anotherConsumer',
+        'Handler target "nonExistent" not found in contract. Available consumers and RPCs: testConsumer, anotherConsumer, calculate',
       );
     });
   });

--- a/packages/worker/src/handlers.ts
+++ b/packages/worker/src/handlers.ts
@@ -1,8 +1,14 @@
-import type { ContractDefinition, InferConsumerNames } from "@amqp-contract/contract";
+import type {
+  ContractDefinition,
+  InferConsumerNames,
+  InferRpcNames,
+} from "@amqp-contract/contract";
 import type {
   WorkerInferConsumerHandler,
   WorkerInferConsumerHandlerEntry,
-  WorkerInferConsumerHandlers,
+  WorkerInferHandlers,
+  WorkerInferRpcHandler,
+  WorkerInferRpcHandlerEntry,
 } from "./types.js";
 import { ConsumerOptions } from "./worker.js";
 
@@ -11,41 +17,53 @@ import { ConsumerOptions } from "./worker.js";
 // =============================================================================
 
 /**
- * Validate that a consumer exists in the contract
+ * Build the list of available handler-target names — every key under
+ * `contract.consumers` plus every key under `contract.rpcs`.
  */
-function validateConsumerExists<TContract extends ContractDefinition>(
+function availableHandlerNames<TContract extends ContractDefinition>(
   contract: TContract,
-  consumerName: string,
+): readonly string[] {
+  const consumers = contract.consumers ? Object.keys(contract.consumers) : [];
+  const rpcs = contract.rpcs ? Object.keys(contract.rpcs) : [];
+  return [...consumers, ...rpcs];
+}
+
+function formatAvailable(names: readonly string[]): string {
+  return names.length > 0 ? names.join(", ") : "none";
+}
+
+/**
+ * Validate that a name maps to a contract entry — either a `consumers` key
+ * or an `rpcs` key. The two name spaces are disjoint by contract definition.
+ */
+function validateHandlerTargetExists<TContract extends ContractDefinition>(
+  contract: TContract,
+  name: string,
 ): void {
   const consumers = contract.consumers;
+  const rpcs = contract.rpcs;
 
-  if (!consumers || !(consumerName in consumers)) {
-    const availableConsumers = consumers ? Object.keys(consumers) : [];
-    const available = availableConsumers.length > 0 ? availableConsumers.join(", ") : "none";
+  const isConsumer = !!consumers && Object.hasOwn(consumers, name);
+  const isRpc = !!rpcs && Object.hasOwn(rpcs, name);
+
+  if (!isConsumer && !isRpc) {
+    const available = formatAvailable(availableHandlerNames(contract));
     throw new Error(
-      `Consumer "${consumerName}" not found in contract. Available consumers: ${available}`,
+      `Handler target "${name}" not found in contract. Available consumers and RPCs: ${available}`,
     );
   }
 }
 
 /**
- * Validate that all handlers reference valid consumers
+ * Validate that every key in `handlers` maps to a contract entry —
+ * either a `consumers` key or an `rpcs` key.
  */
 function validateHandlers<TContract extends ContractDefinition>(
   contract: TContract,
   handlers: object,
 ): void {
-  const consumers = contract.consumers;
-  const availableConsumers = Object.keys(consumers ?? {});
-  const availableConsumerNames =
-    availableConsumers.length > 0 ? availableConsumers.join(", ") : "none";
-
   for (const handlerName of Object.keys(handlers)) {
-    if (!consumers || !(handlerName in consumers)) {
-      throw new Error(
-        `Consumer "${handlerName}" not found in contract. Available consumers: ${availableConsumerNames}`,
-      );
-    }
+    validateHandlerTargetExists(contract, handlerName);
   }
 }
 
@@ -54,30 +72,32 @@ function validateHandlers<TContract extends ContractDefinition>(
 // =============================================================================
 
 /**
- * Define a type-safe handler for a specific consumer in a contract.
+ * Define a type-safe handler for a specific consumer or RPC in a contract.
  *
- * **Recommended:** This function creates handlers that return `ResultAsync<void, HandlerError>`,
- * providing explicit error handling and better control over retry behavior.
+ * **Recommended:** This function creates handlers that return
+ * `ResultAsync<void, HandlerError>` (consumers) or
+ * `ResultAsync<TResponse, HandlerError>` (RPCs), providing explicit error
+ * handling and better control over retry behavior.
  *
  * Supports two patterns:
  * 1. Simple handler: just the function
- * 2. Handler with options: [handler, { prefetch: 10 }]
+ * 2. Handler with options: `[handler, { prefetch: 10 }]`
  *
  * @template TContract - The contract definition type
- * @template TName - The consumer name from the contract
- * @param contract - The contract definition containing the consumer
- * @param consumerName - The name of the consumer from the contract
- * @param handler - The handler function that returns `ResultAsync<void, HandlerError>`
+ * @template TName - The consumer or RPC name from the contract
+ * @param contract - The contract definition containing the consumer or RPC
+ * @param name - The name of the consumer or RPC from the contract
+ * @param handler - The handler function — for consumers, returns
+ *   `ResultAsync<void, HandlerError>`; for RPCs, returns
+ *   `ResultAsync<TResponse, HandlerError>`.
  * @param options - Optional consumer options (prefetch)
  * @returns A type-safe handler that can be used with TypedAmqpWorker
  *
- * @example
+ * @example Consumer handler
  * ```typescript
  * import { defineHandler, RetryableError, NonRetryableError } from '@amqp-contract/worker';
  * import { errAsync, okAsync, ResultAsync } from 'neverthrow';
- * import { orderContract } from './contract';
  *
- * // Simple handler with explicit error handling
  * const processOrderHandler = defineHandler(
  *   orderContract,
  *   'processOrder',
@@ -87,18 +107,14 @@ function validateHandlers<TContract extends ContractDefinition>(
  *       (error) => new RetryableError('Payment failed', error),
  *     ).map(() => undefined),
  * );
+ * ```
  *
- * // Handler with validation (non-retryable error)
- * const validateOrderHandler = defineHandler(
- *   orderContract,
- *   'validateOrder',
- *   ({ payload }) => {
- *     if (payload.amount < 1) {
- *       // Won't be retried - goes directly to DLQ
- *       return errAsync(new NonRetryableError('Invalid order amount'));
- *     }
- *     return okAsync(undefined);
- *   },
+ * @example RPC handler
+ * ```typescript
+ * const calculateHandler = defineHandler(
+ *   rpcContract,
+ *   'calculate',
+ *   ({ payload }) => okAsync({ sum: payload.a + payload.b }),
  * );
  * ```
  */
@@ -107,7 +123,7 @@ export function defineHandler<
   TName extends InferConsumerNames<TContract>,
 >(
   contract: TContract,
-  consumerName: TName,
+  name: TName,
   handler: WorkerInferConsumerHandler<TContract, TName>,
 ): WorkerInferConsumerHandlerEntry<TContract, TName>;
 export function defineHandler<
@@ -115,20 +131,32 @@ export function defineHandler<
   TName extends InferConsumerNames<TContract>,
 >(
   contract: TContract,
-  consumerName: TName,
+  name: TName,
   handler: WorkerInferConsumerHandler<TContract, TName>,
   options: ConsumerOptions,
 ): WorkerInferConsumerHandlerEntry<TContract, TName>;
 export function defineHandler<
   TContract extends ContractDefinition,
-  TName extends InferConsumerNames<TContract>,
+  TName extends InferRpcNames<TContract>,
 >(
   contract: TContract,
-  consumerName: TName,
-  handler: WorkerInferConsumerHandler<TContract, TName>,
-  options?: ConsumerOptions,
-): WorkerInferConsumerHandlerEntry<TContract, TName> {
-  validateConsumerExists(contract, String(consumerName));
+  name: TName,
+  handler: WorkerInferRpcHandler<TContract, TName>,
+): WorkerInferRpcHandlerEntry<TContract, TName>;
+export function defineHandler<
+  TContract extends ContractDefinition,
+  TName extends InferRpcNames<TContract>,
+>(
+  contract: TContract,
+  name: TName,
+  handler: WorkerInferRpcHandler<TContract, TName>,
+  options: ConsumerOptions,
+): WorkerInferRpcHandlerEntry<TContract, TName>;
+export function defineHandler<
+  TContract extends ContractDefinition,
+  TName extends InferConsumerNames<TContract> | InferRpcNames<TContract>,
+>(contract: TContract, name: TName, handler: unknown, options?: ConsumerOptions): unknown {
+  validateHandlerTargetExists(contract, String(name));
 
   if (options) {
     return [handler, options];
@@ -137,21 +165,25 @@ export function defineHandler<
 }
 
 /**
- * Define multiple type-safe handlers for consumers in a contract.
+ * Define multiple type-safe handlers for consumers and RPCs in a contract.
  *
- * **Recommended:** This function creates handlers that return `ResultAsync<void, HandlerError>`,
- * providing explicit error handling and better control over retry behavior.
+ * **Recommended:** This function creates handlers that return
+ * `ResultAsync<void, HandlerError>` (consumers) or
+ * `ResultAsync<TResponse, HandlerError>` (RPCs), providing explicit error
+ * handling and better control over retry behavior.
+ *
+ * The handlers object must contain exactly one entry per `consumers` and
+ * `rpcs` key in the contract — see {@link WorkerInferHandlers}.
  *
  * @template TContract - The contract definition type
- * @param contract - The contract definition containing the consumers
- * @param handlers - An object with handler functions for each consumer
+ * @param contract - The contract definition containing the consumers and RPCs
+ * @param handlers - An object with handler functions for each consumer and RPC
  * @returns A type-safe handlers object that can be used with TypedAmqpWorker
  *
  * @example
  * ```typescript
  * import { defineHandlers, RetryableError } from '@amqp-contract/worker';
- * import { ResultAsync } from 'neverthrow';
- * import { orderContract } from './contract';
+ * import { okAsync, ResultAsync } from 'neverthrow';
  *
  * const handlers = defineHandlers(orderContract, {
  *   processOrder: ({ payload }) =>
@@ -159,18 +191,14 @@ export function defineHandler<
  *       processPayment(payload),
  *       (error) => new RetryableError('Payment failed', error),
  *     ).map(() => undefined),
- *   notifyOrder: ({ payload }) =>
- *     ResultAsync.fromPromise(
- *       sendNotification(payload),
- *       (error) => new RetryableError('Notification failed', error),
- *     ).map(() => undefined),
+ *   calculate: ({ payload }) => okAsync({ sum: payload.a + payload.b }),
  * });
  * ```
  */
 export function defineHandlers<TContract extends ContractDefinition>(
   contract: TContract,
-  handlers: WorkerInferConsumerHandlers<TContract>,
-): WorkerInferConsumerHandlers<TContract> {
+  handlers: WorkerInferHandlers<TContract>,
+): WorkerInferHandlers<TContract> {
   validateHandlers(contract, handlers);
   return handlers;
 }

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -1,8 +1,8 @@
 export { TypedAmqpWorker } from "./worker.js";
 export type { CreateWorkerOptions, ConsumerOptions } from "./worker.js";
-export type { HandlerError } from "./errors.js";
 export {
-  // Error classes
+  // Error classes (HandlerError is an abstract base class)
+  HandlerError,
   MessageValidationError,
   NonRetryableError,
   RetryableError,
@@ -16,10 +16,16 @@ export {
 } from "./errors.js";
 export { defineHandler, defineHandlers } from "./handlers.js";
 export type {
-  WorkerInferConsumerHandler,
-  WorkerInferConsumerHandlerEntry,
-  WorkerInferConsumerHandlers,
   WorkerConsumedMessage,
   WorkerInferConsumedMessage,
+  WorkerInferConsumerHandler,
+  WorkerInferConsumerHandlerEntry,
   WorkerInferConsumerHeaders,
+  WorkerInferHandlers,
+  WorkerInferRpcConsumedMessage,
+  WorkerInferRpcHandler,
+  WorkerInferRpcHandlerEntry,
+  WorkerInferRpcHeaders,
+  WorkerInferRpcRequest,
+  WorkerInferRpcResponse,
 } from "./types.js";

--- a/packages/worker/src/types.ts
+++ b/packages/worker/src/types.ts
@@ -262,9 +262,3 @@ export type WorkerInferHandlers<TContract extends ContractDefinition> = ([
   ([InferRpcNames<TContract>] extends [never]
     ? {}
     : { [K in InferRpcNames<TContract>]: WorkerInferRpcHandlerEntry<TContract, K> });
-
-/**
- * @deprecated Use `WorkerInferHandlers` — handlers now span consumers ∪ rpcs.
- */
-export type WorkerInferConsumerHandlers<TContract extends ContractDefinition> =
-  WorkerInferHandlers<TContract>;

--- a/tests/src/client-worker.spec.ts
+++ b/tests/src/client-worker.spec.ts
@@ -9,11 +9,7 @@ import {
   defineQueue,
 } from "@amqp-contract/contract";
 import { it as baseIt } from "@amqp-contract/testing/extension";
-import {
-  TypedAmqpWorker,
-  type WorkerInferConsumerHandlers,
-  defineHandlers,
-} from "@amqp-contract/worker";
+import { TypedAmqpWorker, type WorkerInferHandlers, defineHandlers } from "@amqp-contract/worker";
 import { ok, okAsync } from "neverthrow";
 import { describe, expect, vi } from "vitest";
 import { z } from "zod";
@@ -24,7 +20,7 @@ const it = baseIt.extend<{
   ) => Promise<TypedAmqpClient<TContract>>;
   workerFactory: <TContract extends ContractDefinition>(
     contract: TContract,
-    handlers: WorkerInferConsumerHandlers<TContract>,
+    handlers: WorkerInferHandlers<TContract>,
   ) => Promise<TypedAmqpWorker<TContract>>;
 }>({
   clientFactory: async ({ amqpConnectionUrl }, use) => {
@@ -63,7 +59,7 @@ const it = baseIt.extend<{
       await use(
         async <TContract extends ContractDefinition>(
           contract: TContract,
-          handlers: WorkerInferConsumerHandlers<TContract>,
+          handlers: WorkerInferHandlers<TContract>,
         ) => {
           const worker = (
             await TypedAmqpWorker.create({


### PR DESCRIPTION
## Summary

Closes a batch of public-API gaps surfaced by the audit. Scope is intentionally narrow (`packages/worker/src/{handlers,types,errors,index}.ts` plus the test files that consumed the deprecated alias) so the PR doesn't conflict with the worker dispatch refactor (PR C) or other in-flight work.

### `defineHandler` / `defineHandlers` are now RPC-aware

Both helpers previously typed against `InferConsumerNames<TContract>` only — calling either with an RPC name threw `Consumer X not found in contract`.

- `defineHandler` now has overloads for `TName extends InferConsumerNames<TContract>` (returning `WorkerInferConsumerHandlerEntry`) and `TName extends InferRpcNames<TContract>` (returning `WorkerInferRpcHandlerEntry`), each with and without `ConsumerOptions`.
- `defineHandlers` is typed against `WorkerInferHandlers<TContract>`, which already spans `consumers ∪ rpcs`.
- Runtime validation walks both sets; the error message reads `Handler target "X" not found in contract. Available consumers and RPCs: ...`.

### RPC-side `Infer*` helpers re-exported from `@amqp-contract/worker`

These already lived in `packages/worker/src/types.ts` but weren't surfaced at the package root: `WorkerInferHandlers`, `WorkerInferRpcHandler`, `WorkerInferRpcHandlerEntry`, `WorkerInferRpcConsumedMessage`, `WorkerInferRpcRequest`, `WorkerInferRpcResponse`, `WorkerInferRpcHeaders`. The client package exports its RPC-side equivalents — worker is now symmetrical.

### `HandlerError` is an abstract base class

`HandlerError` was a type alias union — `error instanceof HandlerError` did not work. It is now `abstract class HandlerError extends Error`, with `RetryableError extends HandlerError` and `NonRetryableError extends HandlerError`. The `name` property still discriminates (`"RetryableError" | "NonRetryableError"`) so exhaustive narrowing keeps working. `isHandlerError` now uses `instanceof HandlerError` directly. The public type signature is unchanged (a class can be used as a type).

### Removed deprecated `WorkerInferConsumerHandlers` alias

It was kept for one cycle; it's now removed in favour of `WorkerInferHandlers`. Migrated `packages/worker/src/__tests__/fixture.ts` and `tests/src/client-worker.spec.ts`. The changeset calls this out explicitly.

## Test plan

- [x] `pnpm install`
- [x] `pnpm build` (14/14 tasks)
- [x] `pnpm typecheck` (16/16 tasks, including downstream packages built against the new `dist/`)
- [x] `pnpm test` (12/12 unit-test packages, all green; integration tests in `tests/` require Docker and were not run locally)
- [x] `pnpm lint` (0 warnings / 0 errors across 87 files)
- [x] `pnpm format` (no further changes after first run)
- [x] New unit tests in `packages/worker/src/handlers.spec.ts` cover: defining an RPC handler, defining an RPC handler with options, defining a mixed consumer+RPC handlers object, and the runtime error for an unknown name (lists both consumers and RPCs).
- [x] New unit tests in `packages/worker/src/errors.spec.ts` cover: `RetryableError`/`NonRetryableError` are `instanceof HandlerError`, and `HandlerError` narrows by `name`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)