### PR TITLE
chore: bump root engines.node to >=22.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "turbo": "catalog:"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22.19"
   },
   "packageManager": "pnpm@11.7.0"
 }


### PR DESCRIPTION
## Summary

- `undici@8.4.1`, pulled in transitively via `testcontainers@12.0.2` → `@amqp-contract/testing`, declares `engines.node >=22.19.0`.
- Root `engines.node = ">=20"` was inconsistent with what `pnpm install` can actually satisfy under `engineStrict: true`.
- Bumps root to `>=22.19` to match the floor enforced by the dependency graph. CI / local already run Node 24.16 (`.node-version`), so no infrastructure change.

Scoped to the root package only per discussion — publishable packages stay silent on `engines` (current behavior).

## Test plan

- [x] `pnpm install` clean on Node 24.16
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)