### PR TITLE
chore: declare engines.node on publishable packages

### DIFF
--- a/.changeset/declare-node-engines.md
+++ b/.changeset/declare-node-engines.md
@@ -1,0 +1,5 @@
+---
+"@amqp-contract/asyncapi": minor
+---
+
+Declare `engines.node: ">=22.19"` on all publishable packages. `undici@8.4.1` (transitively required via `@amqp-contract/testing` → `testcontainers`) requires Node `>=22.19.0`; consumers now see this constraint at install time instead of silently inheriting it.

--- a/packages/asyncapi/package.json
+++ b/packages/asyncapi/package.json
@@ -77,5 +77,8 @@
     "valibot": "catalog:",
     "vitest": "catalog:",
     "zod": "catalog:"
+  },
+  "engines": {
+    "node": ">=22.19"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -78,5 +78,8 @@
     "typescript": "catalog:",
     "vitest": "catalog:",
     "zod": "catalog:"
+  },
+  "engines": {
+    "node": ">=22.19"
   }
 }

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -69,5 +69,8 @@
     "typescript": "catalog:",
     "vitest": "catalog:",
     "zod": "catalog:"
+  },
+  "engines": {
+    "node": ">=22.19"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -83,5 +83,8 @@
     "@opentelemetry/api": {
       "optional": true
     }
+  },
+  "engines": {
+    "node": ">=22.19"
   }
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -64,5 +64,8 @@
   },
   "peerDependencies": {
     "vitest": "^4"
+  },
+  "engines": {
+    "node": ">=22.19"
   }
 }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -77,5 +77,8 @@
     "typescript": "catalog:",
     "vitest": "catalog:",
     "zod": "catalog:"
+  },
+  "engines": {
+    "node": ">=22.19"
   }
 }


### PR DESCRIPTION
## Summary

- Add `engines.node: ">=22.19"` to all 6 publishable packages (`@amqp-contract/{asyncapi,client,contract,core,testing,worker}`).
- `undici@8.4.1`, pulled in transitively via `@amqp-contract/testing` → `testcontainers@12.0.2`, declares `engines.node >=22.19.0`. Consumers were silently inheriting this constraint with no install-time signal — declaring it on the published packages surfaces it explicitly.
- Includes a changeset (minor bump for the fixed group).

Follow-up to #485 which fixed the workspace root.

## Test plan

- [x] `pnpm install` clean
- [x] `pnpm typecheck` → 16/16
- [x] `pnpm lint` / `pnpm format` green
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)