### PR TITLE
fix(ci): use changeset publish so tags and GitHub releases are created

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "knip": "knip",
     "lint": "oxlint .",
     "prepare": "lefthook install",
-    "release": "pnpm build && pnpm publish -r --access public --no-git-checks",
+    "release": "pnpm build && changeset publish",
     "test": "turbo run test",
     "test:integration": "turbo run test:integration",
     "typecheck": "turbo run typecheck",


### PR DESCRIPTION
## Summary

- Reverts the root `release` script from `pnpm publish -r --access public --no-git-checks` back to `changeset publish`.
- Restores git tag + GitHub release creation, which `changesets/action@v1` performs by parsing `changeset publish`'s stdout for `🦋  New tag:` lines.

## Why this broke

5cf3662 swapped to `pnpm publish -r` to dodge an ENEEDAUTH from the runner's preinstalled npm being older than 11.5.1 (where the npm CLI started honoring the Trusted Publishing OIDC env vars). That kept npm publishing working but silently broke the tag/release path — no lines matched the regex, so no tags were pushed and no GitHub releases were created. Latest GH release is `0.23.0` (May 3); every release since has gone to npm only.

The original ENEEDAUTH driver is fixed by the *other* half of that same commit: the setup composite now pins Node 24 via `.node-version`, and Node 24.16 ships with npm 11.13.0 — well above the 11.5.1 threshold. `changeset publish` shells out to `npm publish`, so OIDC now works through that path.

## Merge order

Land this **before** merging the open release PR #487, so the next release run uses the corrected script.

## Test plan

- [ ] After merge, watch the next release run: confirm `changeset publish` prints `🦋  New tag:` lines, the action pushes tags, and a GitHub release is created per published package.
- [ ] Confirm npm publishing still succeeds (Trusted Publishing OIDC, no `NPM_TOKEN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)