### PR TITLE
feat!: upgrade unthrown to v1.0.0

### DIFF
--- a/.agents/rules/handlers.md
+++ b/.agents/rules/handlers.md
@@ -7,13 +7,13 @@ This project uses [unthrown](https://github.com/btravstack/unthrown) for explici
 A consumer handler receives `({ payload, headers }, rawMessage)` and returns `AsyncResult<void, HandlerError>`:
 
 ```typescript
-import { fromPromise, ok } from "unthrown";
+import { fromPromise, Ok } from "unthrown";
 import { RetryableError, NonRetryableError } from "@amqp-contract/worker";
 
 // Sync OK case — lift a sync Result into an AsyncResult with .toAsync()
 const handler = ({ payload }, rawMessage) => {
   console.log(payload.orderId);
-  return ok(undefined).toAsync();
+  return Ok(undefined).toAsync();
 };
 
 // Async case — fromPromise REQUIRES the qualify mapper as the second arg
@@ -37,17 +37,17 @@ const asyncHandler = ({ payload }) =>
 You can define RPC handlers either with `defineHandler` / `defineHandlers` (overloaded against `InferRpcNames<TContract>`, and `validateHandlerTargetExists` checks both `contract.consumers` and `contract.rpcs`) or inline inside `TypedAmqpWorker.create({ handlers: { … } })`. The inline `handlers` parameter is typed against `WorkerInferHandlers<TContract>`, so each name (consumer or RPC) gets the correct signature inferred:
 
 ```typescript
-import { fromPromise, ok } from "unthrown";
+import { fromPromise, Ok } from "unthrown";
 import { TypedAmqpWorker, RetryableError } from "@amqp-contract/worker";
 
 const result = await TypedAmqpWorker.create({
   contract,
   handlers: {
     // Regular consumer — `payload` typed from the consumer's message schema
-    processOrder: ({ payload }) => ok(undefined).toAsync(),
+    processOrder: ({ payload }) => Ok(undefined).toAsync(),
 
     // RPC handler — must return the typed response payload
-    calculate: ({ payload }) => ok({ sum: payload.a + payload.b }).toAsync(),
+    calculate: ({ payload }) => Ok({ sum: payload.a + payload.b }).toAsync(),
 
     // RPC with async work
     lookupUser: ({ payload }) =>
@@ -75,8 +75,8 @@ RPC error semantics worth knowing:
 
 - **Missing `replyTo` / `correlationId`** on the inbound message → `NonRetryableError`. The request is `nack`ed without requeue, so it routes to the queue's DLQ if configured (poison messages stay visible for inspection rather than being silently ack'd).
 - **Response fails the response schema** → `NonRetryableError` (handler returned the wrong shape; retrying won't help).
-- **Client-side timeout** → call resolves to `err(RpcTimeoutError)`; pending state is cleared. If a reply still arrives, it's logged at `warn` and counted via `recordLateRpcReply` (telemetry hook for tuning) — it's not retried.
-- **Client closed mid-call** → call resolves to `err(RpcCancelledError)`.
+- **Client-side timeout** → call resolves to `Err(RpcTimeoutError)`; pending state is cleared. If a reply still arrives, it's logged at `warn` and counted via `recordLateRpcReply` (telemetry hook for tuning) — it's not retried.
+- **Client closed mid-call** → call resolves to `Err(RpcCancelledError)`.
 
 ## Using `defineHandler` / `defineHandlers`
 
@@ -84,7 +84,7 @@ Use `defineHandler` (single) or `defineHandlers` (object) for full type inferenc
 
 ```typescript
 import { defineHandler, RetryableError, NonRetryableError } from "@amqp-contract/worker";
-import { err, fromPromise, ok } from "unthrown";
+import { Err, fromPromise, Ok } from "unthrown";
 
 const processOrderHandler = defineHandler(contract, "processOrder", ({ payload }) =>
   fromPromise(
@@ -96,9 +96,9 @@ const processOrderHandler = defineHandler(contract, "processOrder", ({ payload }
 // Permanent failures use NonRetryableError → DLQ, never retried
 const validateOrderHandler = defineHandler(contract, "validateOrder", ({ payload }) => {
   if (payload.amount < 1) {
-    return err(new NonRetryableError("Invalid amount")).toAsync();
+    return Err(new NonRetryableError("Invalid amount")).toAsync();
   }
-  return ok(undefined).toAsync();
+  return Ok(undefined).toAsync();
 });
 ```
 
@@ -161,9 +161,9 @@ For the authoritative API read unthrown's type definitions; the subset this proj
 
 | Method                          | Description                                                                       |
 | ------------------------------- | --------------------------------------------------------------------------------- |
-| `ok(value).toAsync()`           | Lift a successful sync `Result` into an `AsyncResult`                             |
-| `err(error).toAsync()`          | Lift a failed sync `Result` into an `AsyncResult`                                 |
-| `fromPromise(promise, qualify)` | Wrap a `Promise`; `qualify` maps the rejection to `E \| defect(cause)`. Required. |
+| `Ok(value).toAsync()`           | Lift a successful sync `Result` into an `AsyncResult`                             |
+| `Err(error).toAsync()`          | Lift a failed sync `Result` into an `AsyncResult`                                 |
+| `fromPromise(promise, qualify)` | Wrap a `Promise`; `qualify` maps the rejection to `E \| Defect(cause)`. Required. |
 | `fromSafePromise(promise)`      | Wrap a `Promise` asserted not to fail in a modeled way (rejection → `Defect`).    |
 | `.map(f)` / `.mapErr(f)`        | Transform the OK value / the error                                                |
 | `.flatMap(f)`                   | Chain another `Result` / `AsyncResult` (was `.andThen` in neverthrow)             |
@@ -175,7 +175,7 @@ For the authoritative API read unthrown's type definitions; the subset this proj
 
 | Method / function                         | Description                                                                                                                                                                                                         |
 | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ok(value)` / `err(error)`                | Construct a successful / failed `Result`                                                                                                                                                                            |
+| `Ok(value)` / `Err(error)`                | Construct a successful / failed `Result`                                                                                                                                                                            |
 | `r.isOk()` / `r.isErr()` / `r.isDefect()` | **Preferred** narrowing form — the methods narrow `this` (unthrown 0.2.0+), so `if (r.isErr()) r.error` works. Standalone `isOk(r)` / `isErr(r)` / `isDefect(r)` functions narrow identically but aren't used here. |
 | `.match({ ok, err, defect })`             | Boxed pattern match with three branches (positional `match(okFn, errFn)` is **not** supported)                                                                                                                      |
 | `matchTags(r, { Ok, Defect, ...tags })`   | Exhaustive dispatch on a tagged-error union's `_tag`                                                                                                                                                                |

--- a/.agents/rules/recipes.md
+++ b/.agents/rules/recipes.md
@@ -9,7 +9,7 @@ End-to-end how-tos for the changes that come up most. Each recipe lists the exac
 3. **Consumer entry** — `defineEventConsumer(eventPublisher, queue, { routingKey: ... })`. The queue↔exchange binding is auto-generated.
 4. **Add to `defineContract`** under `consumers: { ... }`. Don't add the queue or binding yourself — they're auto-extracted.
 5. **Handler** — implement with `defineHandler(contract, "yourConsumerName", ({ payload, headers }) => …)` returning `AsyncResult<void, HandlerError>`. See [handlers.md](./handlers.md).
-6. **Tests** — integration test in `src/__tests__/<consumer>.spec.ts` using `it` from `@amqp-contract/testing/extension`. Mock the handler with `vi.fn().mockReturnValue(ok(undefined).toAsync())`.
+6. **Tests** — integration test in `src/__tests__/<consumer>.spec.ts` using `it` from `@amqp-contract/testing/extension`. Mock the handler with `vi.fn().mockReturnValue(Ok(undefined).toAsync())`.
 7. **Changeset** — `pnpm changeset` with a minor bump. Public API surface grew.
 
 ## Add a new RPC
@@ -18,7 +18,7 @@ End-to-end how-tos for the changes that come up most. Each recipe lists the exac
 2. **Queue** — `defineQueue(...)` for the RPC. Quorum by default. **Configure a `deadLetter`** even though replies, not the queue, drive most failure modes: missing `replyTo` / `correlationId` and response-schema mismatches are surfaced as `NonRetryableError` and the worker `nack`s them without requeue, so without a DLX they're dropped silently.
 3. **RPC entry** — `defineRpc(queue, { request, response })`.
 4. **Add to `defineContract`** under `rpcs: { ... }`.
-5. **Server-side handler** — define it with `defineHandler(contract, "yourRpcName", ({ payload }) => ok({ /* response */ }).toAsync())`, via `defineHandlers`, or inline in the `handlers` object passed to `TypedAmqpWorker.create({ handlers: { … } })`. All three are RPC-aware: `defineHandler` / `defineHandlers` are overloaded against `InferRpcNames` and validate the name against both `contract.consumers` and `contract.rpcs`. The worker validates the response against the response schema and publishes back automatically.
+5. **Server-side handler** — define it with `defineHandler(contract, "yourRpcName", ({ payload }) => Ok({ /* response */ }).toAsync())`, via `defineHandlers`, or inline in the `handlers` object passed to `TypedAmqpWorker.create({ handlers: { … } })`. All three are RPC-aware: `defineHandler` / `defineHandlers` are overloaded against `InferRpcNames` and validate the name against both `contract.consumers` and `contract.rpcs`. The worker validates the response against the response schema and publishes back automatically.
 6. **Client call** — `client.call("yourRpcName", request, { timeoutMs: 5_000 })`. `timeoutMs` is required.
 7. **Tests** — round-trip integration test (worker + client both wired up). For "no server" scenarios, just create the client without a worker; for "request validation fails", pass a deliberately wrong payload through `as unknown as ...`.
 8. **Changeset** — minor bump.
@@ -68,7 +68,7 @@ processOrder: ({ payload }) =>
 Three things to remember:
 
 - `fromPromise` requires the error mapper as the second arg — chaining `.mapErr` afterwards is a type error.
-- For permanent failures, return `err(new NonRetryableError(...)).toAsync()`.
-- For success with no value, `ok(undefined).toAsync()`.
+- For permanent failures, return `Err(new NonRetryableError(...)).toAsync()`.
+- For success with no value, `Ok(undefined).toAsync()`.
 
 See [handlers.md](./handlers.md) for the full unthrown API and the common-mistakes list in [`AGENTS.md`](../../AGENTS.md#common-mistakes).

--- a/.agents/rules/testing.md
+++ b/.agents/rules/testing.md
@@ -57,11 +57,11 @@ describe("Order Processing", () => {
 
 ## Handler Testing
 
-Handlers return `ok(undefined).toAsync()` in mocks:
+Handlers return `Ok(undefined).toAsync()` in mocks:
 
 ```typescript
 // Test handler mock
-const mockHandler = vi.fn().mockReturnValue(ok(undefined).toAsync());
+const mockHandler = vi.fn().mockReturnValue(Ok(undefined).toAsync());
 
 // Assertion pattern
 expect(mockHandler).toHaveBeenCalledWith(

--- a/.changeset/unthrown-v1.md
+++ b/.changeset/unthrown-v1.md
@@ -1,0 +1,18 @@
+---
+"@amqp-contract/contract": major
+---
+
+**BREAKING:** Upgrade [`unthrown`](https://github.com/btravstack/unthrown) to `1.0.0`.
+
+unthrown 1.0 renames the value constructors — **`ok` → `Ok`, `err` → `Err`, `defect` → `Defect`** (the lowercase forms are removed). All packages now depend on `unthrown@1.0.0`, so consumers that build `Result` / `AsyncResult` values directly must update their call sites:
+
+```diff
+- import { ok, err } from "unthrown";
+- return ok(undefined).toAsync();
+- return err(new RetryableError("...")).toAsync();
++ import { Ok, Err } from "unthrown";
++ return Ok(undefined).toAsync();
++ return Err(new RetryableError("...")).toAsync();
+```
+
+Everything else is unchanged: the `.match({ ok, err, defect })` handler keys stay lowercase (they're case branches, not constructors), and `fromPromise` / `fromSafePromise` / `fromThrowable` / `all` / `allAsync` / `TaggedError(tag, { name })` / `.isOk()` / `.toAsync()` / `.unwrap()` keep the same signatures.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ This is the canonical list — sub-files reference these rather than restating t
 - Handlers return `AsyncResult<void, HandlerError>` (regular consumer) or `AsyncResult<TResponse, HandlerError>` (RPC). No `async`/`await` in handler signatures.
 - `await asyncResult` resolves to a `Result<T, E>` — it does **not** throw on `Err`.
 - `result.match({ ok, err, defect })` is **boxed and has three branches**. Positional `match(okFn, errFn)` is the old neverthrow shape and is not supported.
-- Build async results with `ok(value).toAsync()` / `err(error).toAsync()` — there is no `okAsync` / `errAsync`.
-- Wrap promises with the free function `fromPromise(promise, qualify)` (not a static `ResultAsync.fromPromise`); `qualify` maps the rejection reason to `E | defect(cause)` and is required.
+- Build async results with `Ok(value).toAsync()` / `Err(error).toAsync()` — there is no `okAsync` / `errAsync`.
+- Wrap promises with the free function `fromPromise(promise, qualify)` (not a static `ResultAsync.fromPromise`); `qualify` maps the rejection reason to `E | Defect(cause)` and is required.
 - `.isOk()` / `.isErr()` / `.isDefect()` are type guards that **narrow `this`** (since unthrown 0.2.0), so `if (result.isErr()) result.error` works. **Prefer the method form** — the standalone `isOk(result)` / `isErr(result)` / `isDefect(result)` functions narrow identically but are not used in this codebase.
 
 ### Topology and contract authoring
@@ -72,9 +72,10 @@ These have been re-introduced more than once across recent migrations / reviews 
 
 - **Treating `await TypedAmqp(Client|Worker).create(...)` as a client/worker.** It returns `AsyncResult<Client, TechnicalError>`; `await` gives you a `Result`. Unwrap with `.unwrap()` (or pattern-match) before calling instance methods.
 - **Wrapping `client.publish(...)` in `fromPromise(...)`.** `publish` already returns an `AsyncResult` — wrap it again and you get `AsyncResult<AsyncResult<...>>`. Chain `.map` / `.mapErr` / `.flatMap` directly.
-- **Calling `fromPromise(p)` without the `qualify` mapper.** The mapper is a required second argument and must return `E | defect(cause)`. The fix to the opaque "expected 2 arguments, got 1" error is always: pass the mapper.
+- **Calling `fromPromise(p)` without the `qualify` mapper.** The mapper is a required second argument and must return `E | Defect(cause)`. The fix to the opaque "expected 2 arguments, got 1" error is always: pass the mapper.
 - **Using positional `result.match(okFn, errFn)`.** That's the old neverthrow shape. unthrown's `match` is boxed with three branches: `result.match({ ok, err, defect })`.
-- **Reaching for `okAsync` / `errAsync` or `ResultAsync` / `_unsafeUnwrap`.** Those are neverthrow. Use `ok(v).toAsync()` / `err(e).toAsync()`, the `AsyncResult` type, and `.unwrap()`.
+- **Reaching for `okAsync` / `errAsync` or `ResultAsync` / `_unsafeUnwrap`.** Those are neverthrow. Use `Ok(v).toAsync()` / `Err(e).toAsync()`, the `AsyncResult` type, and `.unwrap()`.
+- **Using lowercase `ok` / `err` / `defect` constructors.** unthrown 1.0 renamed them to **`Ok` / `Err` / `Defect`** (the lowercase forms are removed). The `.match({ ok, err, defect })` handler keys stay lowercase, though — those are case branches, not constructors.
 - **Adding a publishable package without `repository`, `homepage`, `bugs`, `author`, `license`** — npm will reject with a 422 on provenance validation under Trusted Publishing.
 - **Hardcoding a dep version in a `package.json`.** Use `"catalog:"` and add the actual version once in `pnpm-workspace.yaml`.
 - **Forgetting to add a changeset** when changing public API. The release will silently skip your change.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ import {
 } from "@amqp-contract/contract";
 import { TypedAmqpClient } from "@amqp-contract/client";
 import { TypedAmqpWorker } from "@amqp-contract/worker";
-import { ok } from "unthrown";
+import { Ok } from "unthrown";
 import { z } from "zod";
 
 // 1. Define resources with Dead Letter Exchange and retry configuration
@@ -90,7 +90,7 @@ const worker = (
     handlers: {
       processOrder: ({ payload }) => {
         console.log(payload.orderId); // ✅ TypeScript knows!
-        return ok(undefined).toAsync();
+        return Ok(undefined).toAsync();
       },
     },
     urls: ["amqp://localhost"],

--- a/docs/TERMINOLOGY.md
+++ b/docs/TERMINOLOGY.md
@@ -79,7 +79,7 @@ These terms (`publishers`, `consumers`) describe the **messaging patterns** in y
 When implementing the contract, we use our terms:
 
 ```typescript
-import { ok } from "unthrown";
+import { Ok } from "unthrown";
 
 // Client = runtime publisher
 const client = (await TypedAmqpClient.create({ contract, urls })).unwrap();
@@ -93,7 +93,7 @@ const worker = (
     handlers: {
       processOrder: ({ payload }) => {
         // Handle message
-        return ok(undefined).toAsync();
+        return Ok(undefined).toAsync();
       },
     },
     urls,

--- a/docs/examples/basic-order-processing.md
+++ b/docs/examples/basic-order-processing.md
@@ -368,22 +368,22 @@ const worker = (
         console.log(`[PROCESSING] Order ${payload.orderId}`);
         console.log(`  Customer: ${payload.customerId}`);
         console.log(`  Total: $${payload.totalAmount}`);
-        return ok(undefined).toAsync();
+        return Ok(undefined).toAsync();
       },
 
       notifyOrder: ({ payload }) => {
         console.log(`[NOTIFICATION] Order ${payload.orderId} event`);
-        return ok(undefined).toAsync();
+        return Ok(undefined).toAsync();
       },
 
       shipOrder: ({ payload }) => {
         console.log(`[SHIPPING] Order ${payload.orderId} - ${payload.status}`);
-        return ok(undefined).toAsync();
+        return Ok(undefined).toAsync();
       },
 
       handleUrgentOrder: ({ payload }) => {
         console.log(`[URGENT] Order ${payload.orderId} - ${payload.status}`);
-        return ok(undefined).toAsync();
+        return Ok(undefined).toAsync();
       },
     },
     connection,

--- a/docs/guide/comparison.md
+++ b/docs/guide/comparison.md
@@ -121,7 +121,7 @@ channel.consume("order-processing", (msg) => {
 
 ```typescript [✅ amqp-contract - Fully typed]
 import { TypedAmqpWorker } from "@amqp-contract/worker";
-import { fromPromise, ok, type AsyncResult, type Result } from "unthrown";
+import { fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 import { contract } from "./contract.js";
 
 const worker = (
@@ -133,7 +133,7 @@ const worker = (
         console.log(payload.orderId); // ✅ Full autocomplete!
         console.log(payload.amount); // ✅ Type-safe!
         // ✅ Automatic validation - invalid messages rejected!
-        return ok(undefined).toAsync();
+        return Ok(undefined).toAsync();
       }, // ✅ Auto-acknowledgment on success!
     },
     urls: ["amqp://localhost"],

--- a/docs/guide/defining-contracts.md
+++ b/docs/guide/defining-contracts.md
@@ -444,7 +444,7 @@ const handlers = defineHandlers(contract, {
       `Processing order ${message.payload.orderId} for tenant ${message.headers.tenantId}`,
     );
 
-    return ok(undefined).toAsync();
+    return Ok(undefined).toAsync();
   },
 });
 ```

--- a/docs/guide/error-model.md
+++ b/docs/guide/error-model.md
@@ -45,7 +45,7 @@ import { NonRetryableError } from "@amqp-contract/worker";
 
 ({ payload }) => {
   if (payload.amount < 0) {
-    return err(new NonRetryableError("Negative amount")).toAsync();
+    return Err(new NonRetryableError("Negative amount")).toAsync();
   }
   // ...
 };
@@ -107,13 +107,13 @@ A Standard Schema validation failed (incoming payload, incoming headers, or RPC 
 
 On the worker side, validation failures route directly to the DLQ via `nack(requeue=false)` — they never enter the retry pipeline because retrying a malformed payload cannot succeed. The message body is preserved exactly as the broker delivered it; the worker does not republish, so it does not stamp diagnostic headers like `x-last-error` on this path. The error details (consumer name, schema `issues`) live in the worker's logs. See [Retry Strategies → Inspecting retry state](./retry-strategies.md#inspecting-retry-state) for the full breakdown of which DLQ paths add headers.
 
-On the client side (publisher input or RPC response validation), `MessageValidationError` is returned via `err(...)` from `publish()` / `call()` so you can decide how to react before sending.
+On the client side (publisher input or RPC response validation), `MessageValidationError` is returned via `Err(...)` from `publish()` / `call()` so you can decide how to react before sending.
 
 ## Client-side RPC errors
 
 ### `RpcTimeoutError`
 
-The reply did not arrive within the configured `timeoutMs` (or the server-side default). The pending call is cleared and the future resolves to `err(RpcTimeoutError)`.
+The reply did not arrive within the configured `timeoutMs` (or the server-side default). The pending call is cleared and the future resolves to `Err(RpcTimeoutError)`.
 
 ### `RpcCancelledError`
 
@@ -141,13 +141,13 @@ result.match({
 
 Two reasons:
 
-1. **Async errors that don't reject Promises silently.** A handler that throws synchronously inside a AsyncResult chain would normally crash the consume loop. Returning `err(...)` makes failure a value the worker can route deterministically (DLQ, retry, ack).
+1. **Async errors that don't reject Promises silently.** A handler that throws synchronously inside a AsyncResult chain would normally crash the consume loop. Returning `Err(...)` makes failure a value the worker can route deterministically (DLQ, retry, ack).
 
 2. **Type-safe error union.** `AsyncResult<T, MyError | OtherError>` lets TypeScript force you to handle every variant via `.match({ ok, err, defect })`. A thrown `unknown` gives no such guarantees.
 
 ## Defensive guards
 
-The worker still wraps the consume callback in `try/catch` so a buggy handler that throws synchronously cannot leave a message neither acked nor nacked: the worker logs the error and nacks with `requeue=false` (DLQ if configured). Don't rely on it — return `err(...).toAsync()` instead.
+The worker still wraps the consume callback in `try/catch` so a buggy handler that throws synchronously cannot leave a message neither acked nor nacked: the worker logs the error and nacks with `requeue=false` (DLQ if configured). Don't rely on it — return `Err(...).toAsync()` instead.
 
 ## See also
 

--- a/docs/guide/error-model.md
+++ b/docs/guide/error-model.md
@@ -42,6 +42,7 @@ The failure is permanent. The message bypasses the retry mode entirely and goes 
 
 ```ts
 import { NonRetryableError } from "@amqp-contract/worker";
+import { Err } from "unthrown";
 
 ({ payload }) => {
   if (payload.amount < 0) {

--- a/docs/guide/message-compression.md
+++ b/docs/guide/message-compression.md
@@ -94,7 +94,7 @@ const worker = (
         // Message is automatically decompressed
         console.log("Processing order:", payload.orderId);
         console.log("Items:", payload.items); // Already decompressed
-        return ok(undefined).toAsync();
+        return Ok(undefined).toAsync();
       },
     },
     urls: ["amqp://localhost"],

--- a/docs/guide/retry-strategies.md
+++ b/docs/guide/retry-strategies.md
@@ -8,9 +8,9 @@ This page explains both, and how they compose.
 
 When a worker processes a message, three things can happen:
 
-1. The handler returns `ok(undefined)` — the message is **acked** and gone.
-2. The handler returns `err(NonRetryableError)` — the message is sent **straight to the DLQ**, no retries (the queue's retry mode is bypassed).
-3. The handler returns `err(RetryableError)` — the **queue's retry mode** decides what happens next.
+1. The handler returns `Ok(undefined)` — the message is **acked** and gone.
+2. The handler returns `Err(NonRetryableError)` — the message is sent **straight to the DLQ**, no retries (the queue's retry mode is bypassed).
+3. The handler returns `Err(RetryableError)` — the **queue's retry mode** decides what happens next.
 
 So `RetryableError` is the only path that consults the retry mode. `NonRetryableError` is your way of saying "this will never succeed, don't bother."
 
@@ -135,6 +135,6 @@ If you need the failure context to be visible on poison messages too, prefer a q
 ## Pitfalls
 
 - **No DLX configured.** `nack(requeue=false)` will drop the message. The worker logs a warning, but you'll lose the body. Always set `deadLetter` if you care about poison messages.
-- **Throwing instead of returning.** A handler that throws an exception bypasses the AsyncResult/Result framework. The worker has a defensive try/catch that nacks to DLQ, but you've lost the chance to classify the error. Always return `err(...).toAsync()`.
+- **Throwing instead of returning.** A handler that throws an exception bypasses the AsyncResult/Result framework. The worker has a defensive try/catch that nacks to DLQ, but you've lost the chance to classify the error. Always return `Err(...).toAsync()`.
 - **Mixing modes per handler.** Retry is a property of the queue, not the handler. If you want different policies for different work, give them different queues.
 - **Tuning `maxRetries` without DLQ inspection.** Pick a number that makes sense for your latency budget; the right answer almost always lives in the DLQ telemetry, not in your head.

--- a/docs/guide/schema-libraries.md
+++ b/docs/guide/schema-libraries.md
@@ -341,7 +341,7 @@ const handler: WorkerInferConsumerHandler<typeof contract, "processOrder"> = ({ 
   // payload is fully typed based on your schema
   console.log(payload.orderId); // string
   console.log(payload.amount); // number
-  return ok(undefined).toAsync();
+  return Ok(undefined).toAsync();
 };
 ```
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -111,7 +111,7 @@ import { describe, expect } from "vitest";
 import { it } from "@amqp-contract/testing/extension";
 import { TypedAmqpClient } from "@amqp-contract/client";
 import { TypedAmqpWorker } from "@amqp-contract/worker";
-import { fromPromise, ok, type AsyncResult, type Result } from "unthrown";
+import { fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 import { contract } from "./contract.js";
 
 describe("Order Processing Contract", () => {
@@ -135,7 +135,7 @@ describe("Order Processing Contract", () => {
         handlers: {
           processOrder: ({ payload }) => {
             receivedPayloads.push(payload);
-            return ok(undefined).toAsync();
+            return Ok(undefined).toAsync();
           },
         },
         urls: [amqpConnectionUrl],

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -219,13 +219,13 @@ Property 'orderId' does not exist on type 'never'.
 3. **Check consumer handler types:**
 
    ```typescript
-   import { ok } from "unthrown";
+   import { Ok } from "unthrown";
 
    // ✅ Payload is automatically typed
    handlers: {
      processEmail: ({ payload }) => {
        console.log(payload.to);  // Type-safe!
-       return ok(undefined).toAsync();
+       return Ok(undefined).toAsync();
      },
    }
    ```

--- a/docs/guide/why-amqp-contract.md
+++ b/docs/guide/why-amqp-contract.md
@@ -167,7 +167,7 @@ const worker = (
         console.log(payload.orderId); // ✅ Fully typed!
         console.log(payload.customerId); // ✅ Autocomplete!
         console.log(payload.amount); // ✅ Type safe!
-        return ok(undefined).toAsync();
+        return Ok(undefined).toAsync();
       },
     },
     urls: ["amqp://localhost"],

--- a/docs/guide/worker-usage.md
+++ b/docs/guide/worker-usage.md
@@ -13,7 +13,7 @@ import {
   RetryableError,
   NonRetryableError,
 } from "@amqp-contract/worker";
-import { fromPromise, ok, type AsyncResult, type Result } from "unthrown";
+import { fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 import { contract } from "./contract";
 
 const processOrder = defineHandler(contract, "processOrder", ({ payload }) =>
@@ -43,7 +43,7 @@ For one-file demos, you can inline the handler. The signature and types are iden
 
 ```typescript
 import { TypedAmqpWorker } from "@amqp-contract/worker";
-import { fromPromise, ok, type AsyncResult, type Result } from "unthrown";
+import { fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 import { contract } from "./contract";
 
 const worker = (
@@ -52,11 +52,11 @@ const worker = (
     handlers: {
       processOrder: ({ payload }) => {
         console.log("Processing:", payload.orderId);
-        return ok(undefined).toAsync();
+        return Ok(undefined).toAsync();
       },
       notifyOrder: ({ payload }) => {
         console.log("Notifying:", payload.orderId);
-        return ok(undefined).toAsync();
+        return Ok(undefined).toAsync();
       },
     },
     urls: ["amqp://localhost"],
@@ -71,7 +71,7 @@ In production code, prefer `defineHandler` so handler logic lives in its own mod
 Handlers receive validated, fully-typed messages with `{ payload, headers }`:
 
 ```typescript
-import { fromPromise, ok, type AsyncResult, type Result } from "unthrown";
+import { fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 
 const worker = (
   await TypedAmqpWorker.create({
@@ -86,7 +86,7 @@ const worker = (
         for (const item of payload.items) {
           console.log(`${item.productId}: ${item.quantity}`);
         }
-        return ok(undefined).toAsync();
+        return Ok(undefined).toAsync();
       },
     },
     connection,
@@ -136,7 +136,7 @@ Safe handlers return `AsyncResult<void, HandlerError>` for explicit error handli
 
 ```typescript
 import { defineHandler, RetryableError, NonRetryableError } from "@amqp-contract/worker";
-import { fromPromise, ok, type AsyncResult, type Result } from "unthrown";
+import { fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 import { contract } from "./contract";
 
 const processOrderHandler = defineHandler(contract, "processOrder", ({ payload }) =>
@@ -148,9 +148,9 @@ const processOrderHandler = defineHandler(contract, "processOrder", ({ payload }
 // Non-retryable errors go directly to DLQ
 const validateOrderHandler = defineHandler(contract, "validateOrder", ({ payload }) => {
   if (payload.amount <= 0) {
-    return err(new NonRetryableError("Invalid order amount")).toAsync();
+    return Err(new NonRetryableError("Invalid order amount")).toAsync();
   }
-  return ok(undefined).toAsync();
+  return Ok(undefined).toAsync();
 });
 ```
 
@@ -158,7 +158,7 @@ const validateOrderHandler = defineHandler(contract, "validateOrder", ({ payload
 
 ```typescript
 import { defineHandlers, RetryableError } from "@amqp-contract/worker";
-import { fromPromise, ok, type AsyncResult, type Result } from "unthrown";
+import { fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 import { contract } from "./contract";
 
 // Safe handlers (recommended) - for async operations use fromPromise
@@ -201,7 +201,7 @@ Create a dedicated module for handlers with explicit error handling:
 ```typescript
 // handlers/order-handlers.ts
 import { defineHandler, defineHandlers, RetryableError } from "@amqp-contract/worker";
-import { fromPromise, ok, type AsyncResult } from "unthrown";
+import { fromPromise, Ok, type AsyncResult } from "unthrown";
 import { orderContract } from "../contract";
 import { processPayment } from "../services/payment";
 import { sendEmail } from "../services/email";
@@ -266,7 +266,7 @@ console.log('Worker ready, waiting for messages...');
 By default, messages are automatically acknowledged after successful processing:
 
 ```typescript
-import { fromPromise, ok, type AsyncResult, type Result } from "unthrown";
+import { fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 
 const worker = (
   await TypedAmqpWorker.create({
@@ -275,7 +275,7 @@ const worker = (
       processOrder: ({ payload }) => {
         console.log("Processing:", payload.orderId);
         // Message is automatically acked after this handler completes
-        return ok(undefined).toAsync();
+        return Ok(undefined).toAsync();
       },
     },
     connection,
@@ -289,7 +289,7 @@ For more control over acknowledgment, use the raw message parameter and error ty
 
 ```typescript
 import { defineHandler, RetryableError, NonRetryableError } from "@amqp-contract/worker";
-import { fromPromise, ok, type AsyncResult, type Result } from "unthrown";
+import { fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 
 const worker = (
   await TypedAmqpWorker.create({
@@ -312,9 +312,9 @@ const worker = (
 
 **Acknowledgment behavior:**
 
-- Handler returns `ok(undefined)` → Message is acknowledged
-- Handler returns `err(RetryableError)` → Message is nacked and retried
-- Handler returns `err(NonRetryableError)` → Message is sent to DLQ (if configured) or dropped
+- Handler returns `Ok(undefined)` → Message is acknowledged
+- Handler returns `Err(RetryableError)` → Message is nacked and retried
+- Handler returns `Err(NonRetryableError)` → Message is sent to DLQ (if configured) or dropped
 
 ## Graceful Shutdown
 
@@ -335,7 +335,7 @@ process.on("SIGINT", shutdown);
 
 ```typescript
 import { TypedAmqpWorker, defineHandlers, RetryableError } from "@amqp-contract/worker";
-import { fromPromise, ok, type AsyncResult } from "unthrown";
+import { fromPromise, Ok, type AsyncResult } from "unthrown";
 import { contract } from "./contract";
 
 async function main() {
@@ -393,7 +393,7 @@ Control the number of unacknowledged messages a consumer can have at once. This 
 Use the tuple syntax `[handler, options]` to configure prefetch per-handler:
 
 ```typescript
-import { fromPromise, ok, type AsyncResult } from "unthrown";
+import { fromPromise, Ok, type AsyncResult } from "unthrown";
 import { RetryableError } from "@amqp-contract/worker";
 
 const worker = (
@@ -422,7 +422,7 @@ const worker = (
 If you want to apply a common consumer configuration across all handlers, use `defaultConsumerOptions` when creating the worker:
 
 ```typescript
-import { fromPromise, ok, type AsyncResult } from "unthrown";
+import { fromPromise, Ok, type AsyncResult } from "unthrown";
 import { RetryableError } from "@amqp-contract/worker";
 
 const worker = (
@@ -455,7 +455,7 @@ Three configuration patterns are supported:
 handlers: {
   processOrder: ({ payload }) => {
     // Single message processing
-    return ok(undefined).toAsync();
+    return Ok(undefined).toAsync();
   };
 }
 ```
@@ -467,7 +467,7 @@ handlers: {
   processOrder: [
     ({ payload }) => {
       // Single message processing with prefetch
-      return ok(undefined).toAsync();
+      return Ok(undefined).toAsync();
     },
     { prefetch: 10 },
   ];
@@ -498,7 +498,7 @@ A simpler mode that requeues failed messages immediately (no wait queues):
 ```typescript
 import { defineQueue, defineExchange, defineContract } from "@amqp-contract/contract";
 import { TypedAmqpWorker, RetryableError } from "@amqp-contract/worker";
-import { fromPromise, ok, type AsyncResult } from "unthrown";
+import { fromPromise, Ok, type AsyncResult } from "unthrown";
 
 // 1. Define queue with immediate-requeue retry
 const dlx = defineExchange("orders-dlx");
@@ -555,7 +555,7 @@ import {
   defineMessage,
 } from "@amqp-contract/contract";
 import { TypedAmqpWorker, RetryableError } from "@amqp-contract/worker";
-import { fromPromise, ok, type AsyncResult } from "unthrown";
+import { fromPromise, Ok, type AsyncResult } from "unthrown";
 import { z } from "zod";
 
 // 1. Define queue with TTL-backoff retry - infrastructure auto-generated
@@ -703,7 +703,7 @@ Use `RetryableError` for transient failures that may succeed on retry:
 
 ```typescript
 import { RetryableError, defineHandler } from "@amqp-contract/worker";
-import { fromPromise, ok, type AsyncResult } from "unthrown";
+import { fromPromise, Ok, type AsyncResult } from "unthrown";
 
 const worker = (
   await TypedAmqpWorker.create({
@@ -737,7 +737,7 @@ Use `NonRetryableError` for permanent failures that should NOT be retried:
 
 ```typescript
 import { NonRetryableError, RetryableError, defineHandler } from "@amqp-contract/worker";
-import { fromPromise, ok, type AsyncResult, type Result } from "unthrown";
+import { fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 
 const worker = (
   await TypedAmqpWorker.create({
@@ -746,7 +746,7 @@ const worker = (
       processOrder: defineHandler(contract, "processOrder", ({ payload }) => {
         // Validation errors should not be retried
         if (payload.amount <= 0) {
-          return err(new NonRetryableError("Invalid order amount")).toAsync();
+          return Err(new NonRetryableError("Invalid order amount")).toAsync();
         }
         return fromPromise(
           processPayment(payload),
@@ -771,7 +771,7 @@ For the most explicit error handling, use safe handlers that return `AsyncResult
 
 ```typescript
 import { defineHandler, RetryableError, NonRetryableError } from "@amqp-contract/worker";
-import { fromPromise, ok, type AsyncResult, type Result } from "unthrown";
+import { fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 import { match } from "ts-pattern";
 
 const worker = (
@@ -781,7 +781,7 @@ const worker = (
       processOrder: defineHandler(contract, "processOrder", ({ payload }) => {
         // Validation - non-retryable
         if (payload.amount <= 0) {
-          return err(new NonRetryableError("Invalid amount")).toAsync();
+          return Err(new NonRetryableError("Invalid amount")).toAsync();
         }
 
         // Qualify the rejection at the boundary into a modeled HandlerError.
@@ -848,7 +848,7 @@ import {
   defineConsumer,
   defineMessage,
 } from "@amqp-contract/contract";
-import { fromPromise, ok, type AsyncResult, type Result } from "unthrown";
+import { fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 import { z } from "zod";
 
 // Define exchanges
@@ -900,7 +900,7 @@ const worker = (
       processOrder: ({ payload }) => {
         // Validate before processing (don't retry validation errors)
         if (!payload.amount || payload.amount <= 0) {
-          return err(new NonRetryableError("Invalid order amount")).toAsync();
+          return Err(new NonRetryableError("Invalid order amount")).toAsync();
         }
 
         // Process with external service (retry on failure based on queue config)

--- a/docs/guide/worker-usage.md
+++ b/docs/guide/worker-usage.md
@@ -136,7 +136,7 @@ Safe handlers return `AsyncResult<void, HandlerError>` for explicit error handli
 
 ```typescript
 import { defineHandler, RetryableError, NonRetryableError } from "@amqp-contract/worker";
-import { fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
+import { Err, fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 import { contract } from "./contract";
 
 const processOrderHandler = defineHandler(contract, "processOrder", ({ payload }) =>
@@ -737,7 +737,7 @@ Use `NonRetryableError` for permanent failures that should NOT be retried:
 
 ```typescript
 import { NonRetryableError, RetryableError, defineHandler } from "@amqp-contract/worker";
-import { fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
+import { Err, fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 
 const worker = (
   await TypedAmqpWorker.create({
@@ -771,7 +771,7 @@ For the most explicit error handling, use safe handlers that return `AsyncResult
 
 ```typescript
 import { defineHandler, RetryableError, NonRetryableError } from "@amqp-contract/worker";
-import { fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
+import { Err, fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 import { match } from "ts-pattern";
 
 const worker = (
@@ -848,7 +848,7 @@ import {
   defineConsumer,
   defineMessage,
 } from "@amqp-contract/contract";
-import { fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
+import { Err, fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 import { z } from "zod";
 
 // Define exchanges

--- a/docs/index.md
+++ b/docs/index.md
@@ -103,7 +103,7 @@ await client.publish("orderCreated", {
 
 ```typescript [3. Consume]
 import { TypedAmqpWorker } from "@amqp-contract/worker";
-import { fromPromise, ok, type AsyncResult, type Result } from "unthrown";
+import { fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 import { contract } from "./contract";
 
 const worker = (
@@ -112,7 +112,7 @@ const worker = (
     handlers: {
       processOrder: ({ payload }) => {
         console.log(payload.orderId); // ✅ Fully typed!
-        return ok(undefined).toAsync();
+        return Ok(undefined).toAsync();
       },
     },
     urls: ["amqp://localhost"],

--- a/examples/basic-order-processing-client/src/index.spec.ts
+++ b/examples/basic-order-processing-client/src/index.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from "vitest";
-import { ok } from "unthrown";
+import { Ok } from "unthrown";
 import { TypedAmqpClient } from "@amqp-contract/client";
 import { it } from "@amqp-contract/testing/extension";
 import { orderContract } from "@amqp-contract-examples/basic-order-processing-contract";
@@ -29,7 +29,7 @@ describe("Basic Order Processing Client Integration", () => {
     const result = await client.publish("orderCreated", newOrder);
 
     // THEN
-    expect(result).toEqual(ok(undefined));
+    expect(result).toEqual(Ok(undefined));
 
     // CLEANUP
     (await client.close()).unwrap();
@@ -54,7 +54,7 @@ describe("Basic Order Processing Client Integration", () => {
     const result = await client.publish("orderUpdated", orderUpdate);
 
     // THEN
-    expect(result).toEqual(ok(undefined));
+    expect(result).toEqual(Ok(undefined));
 
     // CLEANUP
     (await client.close()).unwrap();

--- a/examples/basic-order-processing-worker/README.md
+++ b/examples/basic-order-processing-worker/README.md
@@ -33,11 +33,11 @@ const worker = (
     handlers: {
       processOrder: ({ payload }) => {
         // Handler logic here
-        return ok(undefined).toAsync();
+        return Ok(undefined).toAsync();
       },
       notifyOrder: ({ payload }) => {
         // Handler logic here
-        return ok(undefined).toAsync();
+        return Ok(undefined).toAsync();
       },
     },
     urls: [env.AMQP_URL],
@@ -58,7 +58,7 @@ Handlers can be organized in separate files using `defineHandler` or `defineHand
 // handlers.ts
 export const processOrderHandler = defineHandler(orderContract, "processOrder", ({ payload }) => {
   // Handler logic here
-  return ok(undefined).toAsync();
+  return Ok(undefined).toAsync();
 });
 
 // index.ts - to use external handlers, import them:

--- a/examples/basic-order-processing-worker/src/index.spec.ts
+++ b/examples/basic-order-processing-worker/src/index.spec.ts
@@ -1,4 +1,4 @@
-import { ok } from "unthrown";
+import { Ok } from "unthrown";
 import { TypedAmqpWorker, defineHandlers } from "@amqp-contract/worker";
 import { describe, expect, vi } from "vitest";
 import { it } from "@amqp-contract/testing/extension";
@@ -17,13 +17,13 @@ describe("Basic Order Processing Worker Integration", () => {
         handlers: defineHandlers(orderContract, {
           processOrder: ({ payload }) => {
             processedOrders.push(payload);
-            return ok(undefined).toAsync();
+            return Ok(undefined).toAsync();
           },
-          notifyOrder: () => ok(undefined).toAsync(),
-          shipOrder: () => ok(undefined).toAsync(),
-          handleUrgentOrder: () => ok(undefined).toAsync(),
+          notifyOrder: () => Ok(undefined).toAsync(),
+          shipOrder: () => Ok(undefined).toAsync(),
+          handleUrgentOrder: () => Ok(undefined).toAsync(),
 
-          handleFailedOrders: () => ok(undefined).toAsync(),
+          handleFailedOrders: () => Ok(undefined).toAsync(),
         }),
         urls: [amqpConnectionUrl],
       })
@@ -66,15 +66,15 @@ describe("Basic Order Processing Worker Integration", () => {
     const workerResult = await TypedAmqpWorker.create({
       contract: orderContract,
       handlers: defineHandlers(orderContract, {
-        processOrder: () => ok(undefined).toAsync(),
+        processOrder: () => Ok(undefined).toAsync(),
         notifyOrder: ({ payload }) => {
           notifications.push(payload);
-          return ok(undefined).toAsync();
+          return Ok(undefined).toAsync();
         },
-        shipOrder: () => ok(undefined).toAsync(),
-        handleUrgentOrder: () => ok(undefined).toAsync(),
+        shipOrder: () => Ok(undefined).toAsync(),
+        handleUrgentOrder: () => Ok(undefined).toAsync(),
 
-        handleFailedOrders: () => ok(undefined).toAsync(),
+        handleFailedOrders: () => Ok(undefined).toAsync(),
       }),
       urls: [amqpConnectionUrl],
     });
@@ -131,16 +131,16 @@ describe("Basic Order Processing Worker Integration", () => {
       handlers: defineHandlers(orderContract, {
         processOrder: ({ payload }) => {
           processedOrders.push(payload);
-          return ok(undefined).toAsync();
+          return Ok(undefined).toAsync();
         },
         notifyOrder: ({ payload }) => {
           notifications.push(payload);
-          return ok(undefined).toAsync();
+          return Ok(undefined).toAsync();
         },
-        shipOrder: () => ok(undefined).toAsync(),
-        handleUrgentOrder: () => ok(undefined).toAsync(),
+        shipOrder: () => Ok(undefined).toAsync(),
+        handleUrgentOrder: () => Ok(undefined).toAsync(),
 
-        handleFailedOrders: () => ok(undefined).toAsync(),
+        handleFailedOrders: () => Ok(undefined).toAsync(),
       }),
       urls: [amqpConnectionUrl],
     });

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -22,7 +22,7 @@ import {
 } from "@amqp-contract/core";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import type { AmqpConnectionManagerOptions, ConnectionUrl } from "amqp-connection-manager";
-import { err, fromPromise, fromSafePromise, ok, type AsyncResult, type Result } from "unthrown";
+import { Err, fromPromise, fromSafePromise, Ok, type AsyncResult, type Result } from "unthrown";
 import { randomUUID } from "node:crypto";
 import { compressBuffer } from "./compression.js";
 import { MessageValidationError, RpcCancelledError, RpcTimeoutError } from "./errors.js";
@@ -92,7 +92,7 @@ export type CreateClientOptions<TContract extends ContractDefinition> = {
   defaultPublishOptions?: PublishOptions | undefined;
   /**
    * Maximum time in ms to wait for the AMQP connection to become ready before
-   * `create()` resolves to an `err(TechnicalError)`. Defaults to 30s
+   * `create()` resolves to an `Err(TechnicalError)`. Defaults to 30s
    * (the {@link AmqpClient}'s `DEFAULT_CONNECT_TIMEOUT_MS`). Pass `null` to
    * disable the timeout and let amqp-connection-manager retry indefinitely.
    */
@@ -105,7 +105,7 @@ export type CreateClientOptions<TContract extends ContractDefinition> = {
 export type CallOptions = {
   /**
    * Maximum time in ms to wait for an RPC reply. If exceeded, the call resolves
-   * to `err(RpcTimeoutError)` and the in-memory correlation entry is cleared.
+   * to `Err(RpcTimeoutError)` and the in-memory correlation entry is cleared.
    * A late reply arriving after the timeout is silently dropped.
    *
    * Required: RPC without a timeout is a footgun.
@@ -200,7 +200,7 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
   private setupReplyConsumerIfNeeded(): AsyncResult<void, TechnicalError> {
     const rpcs = this.contract.rpcs ?? {};
     if (Object.keys(rpcs).length === 0) {
-      return ok(undefined).toAsync();
+      return Ok(undefined).toAsync();
     }
 
     return this.amqpClient
@@ -249,7 +249,7 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
     );
     if (!parseResult.isOk()) {
       pending.resolve(
-        err(
+        Err(
           parseResult.isErr()
             ? parseResult.error
             : new TechnicalError(
@@ -270,7 +270,7 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
       rawValidation = pending.responseSchema["~standard"].validate(parsed);
     } catch (error: unknown) {
       pending.resolve(
-        err(new TechnicalError(`RPC reply validation threw for "${pending.rpcName}"`, error)),
+        Err(new TechnicalError(`RPC reply validation threw for "${pending.rpcName}"`, error)),
       );
       return;
     }
@@ -280,14 +280,14 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
     validationPromise.then(
       (validation) => {
         if (validation.issues) {
-          pending.resolve(err(new MessageValidationError(pending.rpcName, validation.issues)));
+          pending.resolve(Err(new MessageValidationError(pending.rpcName, validation.issues)));
           return;
         }
-        pending.resolve(ok(validation.value));
+        pending.resolve(Ok(validation.value));
       },
       (error: unknown) => {
         pending.resolve(
-          err(new TechnicalError(`RPC reply validation threw for "${pending.rpcName}"`, error)),
+          Err(new TechnicalError(`RPC reply validation threw for "${pending.rpcName}"`, error)),
         );
       },
     );
@@ -330,11 +330,11 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
           new TechnicalError("Validation failed", error),
       ).flatMap((validation) => {
         if (validation.issues) {
-          return err<TechnicalError | MessageValidationError>(
+          return Err<TechnicalError | MessageValidationError>(
             new MessageValidationError(String(publisherName), validation.issues),
           );
         }
-        return ok(validation.value);
+        return Ok(validation.value);
       });
     };
 
@@ -356,7 +356,7 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
         }
 
         // No compression: use the channel's built-in JSON serialization
-        return ok(validatedMessage).toAsync();
+        return Ok(validatedMessage).toAsync();
       };
 
       return preparePayload().flatMap((payload) =>
@@ -364,7 +364,7 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
           .publish(publisher.exchange.name, publisher.routingKey ?? "", payload, publishOptions)
           .flatMap((published) => {
             if (!published) {
-              return err<TechnicalError>(
+              return Err<TechnicalError>(
                 new TechnicalError(
                   `Failed to publish message for publisher "${String(publisherName)}": Channel rejected the message (buffer full or other channel issue)`,
                 ),
@@ -378,7 +378,7 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
               compressed: !!compression,
             });
 
-            return ok(undefined);
+            return Ok(undefined);
           }),
       );
     };
@@ -439,7 +439,7 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
       options.timeoutMs <= 0 ||
       options.timeoutMs > TIMEOUT_MAX_MS
     ) {
-      return err<CallError>(
+      return Err<CallError>(
         new TechnicalError(
           `Invalid timeoutMs for RPC call to "${String(rpcName)}": expected a finite positive number ≤ ${TIMEOUT_MAX_MS}, got ${String(options.timeoutMs)}`,
         ),
@@ -476,7 +476,7 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
     const timer = setTimeout(() => {
       if (!this.pendingCalls.has(correlationId)) return;
       this.pendingCalls.delete(correlationId);
-      resolveCall(err(new RpcTimeoutError(String(rpcName), options.timeoutMs)));
+      resolveCall(Err(new RpcTimeoutError(String(rpcName), options.timeoutMs)));
     }, options.timeoutMs);
 
     this.pendingCalls.set(correlationId, {
@@ -494,7 +494,7 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
       try {
         rawValidation = requestSchema["~standard"].validate(request);
       } catch (error: unknown) {
-        return err<TechnicalError | MessageValidationError>(
+        return Err<TechnicalError | MessageValidationError>(
           new TechnicalError("RPC request validation threw", error),
         ).toAsync();
       }
@@ -506,10 +506,10 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
           new TechnicalError("RPC request validation threw", error),
       ).flatMap((validation) =>
         validation.issues
-          ? err<TechnicalError | MessageValidationError>(
+          ? Err<TechnicalError | MessageValidationError>(
               new MessageValidationError(String(rpcName), validation.issues),
             )
-          : ok(validation.value),
+          : Ok(validation.value),
       );
     };
 
@@ -532,8 +532,8 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
         .publish("", queueName, validatedRequest, publishOptions)
         .flatMap((published) =>
           published
-            ? ok(undefined)
-            : err<TechnicalError>(
+            ? Ok(undefined)
+            : Err<TechnicalError>(
                 new TechnicalError(
                   `Failed to publish RPC request for "${String(rpcName)}": channel buffer full`,
                 ),
@@ -553,7 +553,7 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
           clearTimeout(timer);
           this.pendingCalls.delete(correlationId);
         }
-        return err(error).toAsync();
+        return Err(error).toAsync();
       })
       .tap(() => {
         const durationMs = Date.now() - startTime;
@@ -575,16 +575,16 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
     // Reject pending calls first — once close() runs, no reply will arrive.
     for (const [, pending] of this.pendingCalls) {
       clearTimeout(pending.timer);
-      pending.resolve(err(new RpcCancelledError(pending.rpcName)));
+      pending.resolve(Err(new RpcCancelledError(pending.rpcName)));
     }
     this.pendingCalls.clear();
 
     const cancelReply: AsyncResult<void, TechnicalError> = this.replyConsumerTag
       ? this.amqpClient.cancel(this.replyConsumerTag).orElse((error) => {
           this.logger?.warn("Failed to cancel RPC reply consumer during close", { error });
-          return ok(undefined);
+          return Ok(undefined);
         })
-      : ok(undefined).toAsync();
+      : Ok(undefined).toAsync();
 
     return cancelReply.flatMap(() => this.amqpClient.close());
   }

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -31,7 +31,7 @@ export class RpcTimeoutError extends TaggedError("@amqp-contract/RpcTimeoutError
 /**
  * Returned from any in-flight RPC call when the client is closed before the
  * reply is received. The correlation map is cleared on close and every pending
- * caller's promise resolves with `err(RpcCancelledError)`. Carries a namespaced
+ * caller's promise resolves with `Err(RpcCancelledError)`. Carries a namespaced
  * `_tag` of `"@amqp-contract/RpcCancelledError"`; the `Error.name` is kept bare
  * (`"RpcCancelledError"`).
  */

--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -99,7 +99,7 @@ const contract = defineContract({
 });
 
 // Server handler returns the response value, not void:
-//   handlers: { calculate: ({ payload }) => ok({ sum: payload.a + payload.b }).toAsync() }
+//   handlers: { calculate: ({ payload }) => Ok({ sum: payload.a + payload.b }).toAsync() }
 //
 // Client invokes with a required timeout:
 //   const result = await client.call("calculate", { a: 1, b: 2 }, { timeoutMs: 5_000 });

--- a/packages/contract/src/builder/rpc.ts
+++ b/packages/contract/src/builder/rpc.ts
@@ -32,7 +32,7 @@ import type { MessageDefinition, QueueEntry, RpcDefinition } from "../types.js";
  * const contract = defineContract({ rpcs: { calculate } });
  *
  * // Server (worker): handler returns the typed response
- * //   handlers: { calculate: ({ payload }) => ok({ sum: payload.a + payload.b }).toAsync() }
+ * //   handlers: { calculate: ({ payload }) => Ok({ sum: payload.a + payload.b }).toAsync() }
  *
  * // Client: typed call with required timeout
  * //   const result = await client.call('calculate', { a: 1, b: 2 }, { timeoutMs: 5_000 });

--- a/packages/core/src/amqp-client.ts
+++ b/packages/core/src/amqp-client.ts
@@ -7,7 +7,7 @@ import type {
   CreateChannelOpts,
 } from "amqp-connection-manager";
 import type { Channel, ConsumeMessage, Options } from "amqplib";
-import { err, fromPromise, fromSafePromise, ok, type AsyncResult, type Result } from "unthrown";
+import { Err, fromPromise, fromSafePromise, Ok, type AsyncResult, type Result } from "unthrown";
 import { ConnectionManagerSingleton } from "./connection-manager.js";
 import { TechnicalError } from "./errors.js";
 import { setupAmqpTopology } from "./setup.js";
@@ -229,7 +229,7 @@ export class AmqpClient {
    * Wait for the channel to be connected and ready.
    *
    * If `connectTimeoutMs` was provided in the constructor options, the returned
-   * AsyncResult resolves to `err(TechnicalError)` once the timeout elapses.
+   * AsyncResult resolves to `Err(TechnicalError)` once the timeout elapses.
    * Without a timeout, this waits forever — amqp-connection-manager retries
    * connections indefinitely and never errors on its own.
    *
@@ -333,7 +333,7 @@ export class AmqpClient {
     // travel to the broker, which either rejects or interprets unexpectedly.
     if (prefetch !== undefined) {
       if (!Number.isInteger(prefetch) || prefetch < 0 || prefetch > 65_535) {
-        return err(
+        return Err(
           new TechnicalError(
             `Invalid prefetch: expected a non-negative integer ≤ 65535, got ${String(prefetch)}`,
           ),
@@ -490,7 +490,7 @@ export class AmqpClient {
       );
 
       if (channelResult.isErr() && releaseResult.isErr()) {
-        return err(
+        return Err(
           new TechnicalError(
             "Failed to close channel and release connection",
             new AggregateError(
@@ -503,7 +503,7 @@ export class AmqpClient {
 
       if (channelResult.isErr()) return channelResult;
       if (releaseResult.isErr()) return releaseResult;
-      return ok(undefined);
+      return Ok(undefined);
     })();
 
     // `inner` is structured to never reject, so lift it with `fromSafePromise`

--- a/packages/worker/README.md
+++ b/packages/worker/README.md
@@ -129,13 +129,13 @@ Worker handlers return `AsyncResult<void, HandlerError>` for explicit error hand
 
 ```typescript
 import { RetryableError, NonRetryableError } from "@amqp-contract/worker";
-import { err, fromPromise, type AsyncResult } from "unthrown";
+import { Err, fromPromise, type AsyncResult } from "unthrown";
 
 handlers: {
   processOrder: ({ payload }) => {
     // Validation errors - non-retryable
     if (payload.amount <= 0) {
-      return err(new NonRetryableError("Invalid amount")).toAsync();
+      return Err(new NonRetryableError("Invalid amount")).toAsync();
     }
 
     // Transient errors - retryable

--- a/packages/worker/src/__tests__/worker-double-ack.spec.ts
+++ b/packages/worker/src/__tests__/worker-double-ack.spec.ts
@@ -7,7 +7,7 @@ import {
   defineQueue,
 } from "@amqp-contract/contract";
 import type { TelemetryProvider } from "@amqp-contract/core";
-import { ok } from "unthrown";
+import { Ok } from "unthrown";
 import { describe, expect, vi } from "vitest";
 import { z } from "zod";
 import { TypedAmqpWorker } from "../worker.js";
@@ -76,7 +76,7 @@ describe("Worker defensive nack guard", () => {
         handlers: {
           testConsumer: ({ payload }) => {
             processed.push(payload.id);
-            return ok(undefined).toAsync();
+            return Ok(undefined).toAsync();
           },
         },
         urls: [amqpConnectionUrl],

--- a/packages/worker/src/__tests__/worker-retry.spec.ts
+++ b/packages/worker/src/__tests__/worker-retry.spec.ts
@@ -6,7 +6,7 @@ import {
   defineMessage,
   defineQueue,
 } from "@amqp-contract/contract";
-import { err, ok } from "unthrown";
+import { Err, Ok } from "unthrown";
 import { describe, expect, vi } from "vitest";
 import { z } from "zod";
 import { RetryableError } from "../errors.js";
@@ -56,9 +56,9 @@ describe("Worker Retry Mechanism", () => {
         testConsumer: () => {
           attemptCount++;
           if (attemptCount === 1) {
-            return err(new RetryableError("First attempt failed")).toAsync();
+            return Err(new RetryableError("First attempt failed")).toAsync();
           }
-          return ok(undefined).toAsync();
+          return Ok(undefined).toAsync();
         },
       });
 
@@ -155,7 +155,7 @@ describe("Worker Retry Mechanism", () => {
       });
 
       await workerFactory(contract, {
-        testConsumer: () => err(new RetryableError("Always fails")).toAsync(),
+        testConsumer: () => Err(new RetryableError("Always fails")).toAsync(),
       });
 
       // Set up DLQ manually for verification (after worker creates the DLX exchange)
@@ -247,7 +247,7 @@ describe("Worker Retry Mechanism", () => {
       await workerFactory(contract, {
         testConsumer: () => {
           attemptCount++;
-          return err(new RetryableError("Always fails")).toAsync();
+          return Err(new RetryableError("Always fails")).toAsync();
         },
       });
 
@@ -323,7 +323,7 @@ describe("Worker Retry Mechanism", () => {
       });
 
       await workerFactory(contract, {
-        testConsumer: () => err(new RetryableError("Test error message")).toAsync(),
+        testConsumer: () => Err(new RetryableError("Test error message")).toAsync(),
       });
 
       // WHEN publishing a message that fails
@@ -383,7 +383,7 @@ describe("Worker Retry Mechanism", () => {
       await workerFactory(contract, {
         testConsumer: () => {
           attemptCount++;
-          return err(new RetryableError("Will not retry")).toAsync();
+          return Err(new RetryableError("Will not retry")).toAsync();
         },
       });
 
@@ -438,7 +438,7 @@ describe("Worker Retry Mechanism", () => {
       await workerFactory(contract, {
         testConsumer: () => {
           attemptCount++;
-          return err(new RetryableError("No retry")).toAsync();
+          return Err(new RetryableError("No retry")).toAsync();
         },
       });
 
@@ -516,9 +516,9 @@ describe("Worker Retry Mechanism", () => {
             attemptCount++;
             if (attemptCount < 2) {
               // This triggers a requeue in immediate-requeue mode
-              return err(new RetryableError("Simulated failure")).toAsync();
+              return Err(new RetryableError("Simulated failure")).toAsync();
             }
-            return ok(undefined).toAsync();
+            return Ok(undefined).toAsync();
           },
         });
 
@@ -579,7 +579,7 @@ describe("Worker Retry Mechanism", () => {
           testConsumer: () => {
             attemptCount++;
             // Always fail - message should be dead-lettered after exceeding maxRetries
-            return err(new RetryableError("Always fails")).toAsync();
+            return Err(new RetryableError("Always fails")).toAsync();
           },
         });
 
@@ -653,9 +653,9 @@ describe("Worker Retry Mechanism", () => {
             attemptCount++;
             if (attemptCount < 2) {
               // This triggers a requeue in immediate-requeue mode
-              return err(new RetryableError("Simulated failure")).toAsync();
+              return Err(new RetryableError("Simulated failure")).toAsync();
             }
-            return ok(undefined).toAsync();
+            return Ok(undefined).toAsync();
           },
         });
 
@@ -717,7 +717,7 @@ describe("Worker Retry Mechanism", () => {
           testConsumer: () => {
             attemptCount++;
             // Always fail - message should be dead-lettered after exceeding maxRetries
-            return err(new RetryableError("Always fails")).toAsync();
+            return Err(new RetryableError("Always fails")).toAsync();
           },
         });
 
@@ -788,9 +788,9 @@ describe("Worker Retry Mechanism", () => {
           testConsumer: () => {
             attemptCount++;
             if (attemptCount < 2) {
-              return err(new RetryableError("Fail once")).toAsync();
+              return Err(new RetryableError("Fail once")).toAsync();
             }
-            return ok(undefined).toAsync();
+            return Ok(undefined).toAsync();
           },
         });
 
@@ -868,13 +868,13 @@ describe("Worker Retry Mechanism", () => {
 
             // Fail first two attempts to trigger retries
             if (attemptCount === 1) {
-              return err(new RetryableError("First failure")).toAsync();
+              return Err(new RetryableError("First failure")).toAsync();
             } else if (attemptCount === 2) {
-              return err(new RetryableError("Second failure")).toAsync();
+              return Err(new RetryableError("Second failure")).toAsync();
             }
 
             // Succeed on third attempt
-            return ok(undefined).toAsync();
+            return Ok(undefined).toAsync();
           },
         });
 
@@ -948,9 +948,9 @@ describe("Worker Retry Mechanism", () => {
         testConsumer: () => {
           attemptCount++;
           if (attemptCount === 1) {
-            return err(new RetryableError("First attempt failed")).toAsync();
+            return Err(new RetryableError("First attempt failed")).toAsync();
           }
-          return ok(undefined).toAsync();
+          return Ok(undefined).toAsync();
         },
       });
 
@@ -1047,9 +1047,9 @@ describe("Worker Retry Mechanism", () => {
         testConsumer: () => {
           attemptCount++;
           if (attemptCount === 1) {
-            return err(new RetryableError("First attempt failed")).toAsync();
+            return Err(new RetryableError("First attempt failed")).toAsync();
           }
-          return ok(undefined).toAsync();
+          return Ok(undefined).toAsync();
         },
       });
 
@@ -1132,9 +1132,9 @@ describe("Worker Retry Mechanism", () => {
           // Capture the routing key from the message
           capturedRoutingKeys.push(msg.fields.routingKey);
           if (attemptCount === 1) {
-            return err(new RetryableError("First attempt failed")).toAsync();
+            return Err(new RetryableError("First attempt failed")).toAsync();
           }
-          return ok(undefined).toAsync();
+          return Ok(undefined).toAsync();
         },
       });
 
@@ -1192,7 +1192,7 @@ describe("Worker Retry Mechanism", () => {
         testConsumer: () => {
           attemptCount++;
           // Always fail
-          return err(new RetryableError("Always fails")).toAsync();
+          return Err(new RetryableError("Always fails")).toAsync();
         },
       });
 

--- a/packages/worker/src/__tests__/worker.spec.ts
+++ b/packages/worker/src/__tests__/worker.spec.ts
@@ -7,7 +7,7 @@ import {
   defineQueue,
   extractQueue,
 } from "@amqp-contract/contract";
-import { err, ok } from "unthrown";
+import { Err, Ok } from "unthrown";
 import { describe, expect, vi } from "vitest";
 import { z } from "zod";
 import { RetryableError } from "../errors.js";
@@ -44,7 +44,7 @@ describe("AmqpWorker Integration", () => {
       defineHandlers(contract, {
         testConsumer: ({ payload }) => {
           messages.push(payload);
-          return ok(undefined).toAsync();
+          return Ok(undefined).toAsync();
         },
       }),
     );
@@ -95,7 +95,7 @@ describe("AmqpWorker Integration", () => {
       defineHandlers(contract, {
         testConsumer: ({ payload }) => {
           messages.push(payload);
-          return ok(undefined).toAsync();
+          return Ok(undefined).toAsync();
         },
       }),
     );
@@ -152,7 +152,7 @@ describe("AmqpWorker Integration", () => {
         testConsumer: ({ payload, headers }) => {
           messages.push(payload);
           messageHeaders.push(headers);
-          return ok(undefined).toAsync();
+          return Ok(undefined).toAsync();
         },
       }),
     );
@@ -219,7 +219,7 @@ describe("AmqpWorker Integration", () => {
       defineHandlers(contract, {
         testConsumer: ({ payload }) => {
           messages.push(payload);
-          return ok(undefined).toAsync();
+          return Ok(undefined).toAsync();
         },
       }),
     );
@@ -270,11 +270,11 @@ describe("AmqpWorker Integration", () => {
       defineHandlers(contract, {
         consumer1: ({ payload }) => {
           messages1.push(payload);
-          return ok(undefined).toAsync();
+          return Ok(undefined).toAsync();
         },
         consumer2: ({ payload }) => {
           messages2.push(payload);
-          return ok(undefined).toAsync();
+          return Ok(undefined).toAsync();
         },
       }),
     );
@@ -324,7 +324,7 @@ describe("AmqpWorker Integration", () => {
       defineHandlers(contract, {
         testConsumer: ({ payload }) => {
           messages.push(payload);
-          return ok(undefined).toAsync();
+          return Ok(undefined).toAsync();
         },
       }),
     );
@@ -371,10 +371,10 @@ describe("AmqpWorker Integration", () => {
         testConsumer: ({ payload }) => {
           attemptCount++;
           if (payload.shouldFail && attemptCount === 1) {
-            return err(new RetryableError("Handler error on first attempt")).toAsync();
+            return Err(new RetryableError("Handler error on first attempt")).toAsync();
           }
           messages.push(payload);
-          return ok(undefined).toAsync();
+          return Ok(undefined).toAsync();
         },
       }),
     );
@@ -422,7 +422,7 @@ describe("AmqpWorker Integration", () => {
       defineHandlers(contract, {
         destConsumer: ({ payload }) => {
           messages.push(payload);
-          return ok(undefined).toAsync();
+          return Ok(undefined).toAsync();
         },
       }),
     );
@@ -467,7 +467,7 @@ describe("AmqpWorker Integration", () => {
       defineHandlers(contract, {
         testConsumer: ({ payload }) => {
           messages.push(payload);
-          return ok(undefined).toAsync();
+          return Ok(undefined).toAsync();
         },
       }),
     );
@@ -534,11 +534,11 @@ describe("AmqpWorker Integration", () => {
       defineHandlers(contract, {
         orderConsumer: ({ payload }) => {
           orders.push(payload);
-          return ok(undefined).toAsync();
+          return Ok(undefined).toAsync();
         },
         notificationConsumer: ({ payload }) => {
           notifications.push(payload);
-          return ok(undefined).toAsync();
+          return Ok(undefined).toAsync();
         },
       }),
     );
@@ -641,7 +641,7 @@ describe("AmqpWorker Integration", () => {
       await TypedAmqpWorker.create({
         contract,
         handlers: {
-          testConsumer: defineHandler(contract, "testConsumer", (_msg) => ok(undefined).toAsync()),
+          testConsumer: defineHandler(contract, "testConsumer", (_msg) => Ok(undefined).toAsync()),
         },
         urls: [amqpConnectionUrl],
         logger: mockLogger,

--- a/packages/worker/src/decompression.ts
+++ b/packages/worker/src/decompression.ts
@@ -1,5 +1,5 @@
 import { TechnicalError } from "@amqp-contract/core";
-import { err, fromPromise, ok, type AsyncResult } from "unthrown";
+import { Err, fromPromise, Ok, type AsyncResult } from "unthrown";
 import { gunzip, inflate } from "node:zlib";
 import { promisify } from "node:util";
 
@@ -37,13 +37,13 @@ export function decompressBuffer(
   contentEncoding: string | undefined,
 ): AsyncResult<Buffer, TechnicalError> {
   if (!contentEncoding) {
-    return ok(buffer).toAsync();
+    return Ok(buffer).toAsync();
   }
 
   const normalizedEncoding = contentEncoding.toLowerCase();
 
   if (!isSupportedEncoding(normalizedEncoding)) {
-    return err(
+    return Err(
       new TechnicalError(
         `Unsupported content-encoding: "${contentEncoding}". ` +
           `Supported encodings are: ${SUPPORTED_ENCODINGS.join(", ")}. ` +

--- a/packages/worker/src/errors.ts
+++ b/packages/worker/src/errors.ts
@@ -181,17 +181,17 @@ export function retryable(message: string, cause?: unknown): RetryableError {
  * @example
  * ```typescript
  * import { nonRetryable } from '@amqp-contract/worker';
- * import { err, ok } from 'unthrown';
+ * import { Err, Ok } from 'unthrown';
  *
  * const handler = ({ payload }) => {
  *   if (!isValidPayload(payload)) {
- *     return err(nonRetryable('Invalid payload format')).toAsync();
+ *     return Err(nonRetryable('Invalid payload format')).toAsync();
  *   }
- *   return ok(undefined).toAsync();
+ *   return Ok(undefined).toAsync();
  * };
  *
  * // Equivalent to:
- * // return err(new NonRetryableError('Invalid payload format')).toAsync();
+ * // return Err(new NonRetryableError('Invalid payload format')).toAsync();
  * ```
  */
 export function nonRetryable(message: string, cause?: unknown): NonRetryableError {

--- a/packages/worker/src/handlers.spec.ts
+++ b/packages/worker/src/handlers.spec.ts
@@ -1,4 +1,4 @@
-import { err, ok } from "unthrown";
+import { Err, Ok } from "unthrown";
 import { NonRetryableError, RetryableError } from "./errors.js";
 import {
   defineConsumer,
@@ -72,7 +72,7 @@ describe("handlers", () => {
       // GIVEN
       const handler = ({ payload }: { payload: { id: string; data: string } }) => {
         console.log(payload.id);
-        return ok(undefined).toAsync();
+        return Ok(undefined).toAsync();
       };
 
       // WHEN
@@ -86,7 +86,7 @@ describe("handlers", () => {
       // GIVEN
       const handler = ({ payload }: { payload: { id: string; data: string } }) => {
         console.log(payload.id);
-        return ok(undefined).toAsync();
+        return Ok(undefined).toAsync();
       };
 
       // WHEN
@@ -99,7 +99,7 @@ describe("handlers", () => {
     it("should create an RPC handler returning a typed response", () => {
       // GIVEN
       const handler = ({ payload }: { payload: { a: number; b: number } }) =>
-        ok({ sum: payload.a + payload.b }).toAsync();
+        Ok({ sum: payload.a + payload.b }).toAsync();
 
       // WHEN
       const result = defineHandler(testContract, "calculate", handler);
@@ -111,7 +111,7 @@ describe("handlers", () => {
     it("should create an RPC handler with options", () => {
       // GIVEN
       const handler = ({ payload }: { payload: { a: number; b: number } }) =>
-        ok({ sum: payload.a + payload.b }).toAsync();
+        Ok({ sum: payload.a + payload.b }).toAsync();
 
       // WHEN
       const result = defineHandler(testContract, "calculate", handler, { prefetch: 5 });
@@ -124,7 +124,7 @@ describe("handlers", () => {
       // GIVEN
       const handler = ({ payload }: { payload: { id: string; data: string } }) => {
         console.log(payload.id);
-        return ok(undefined).toAsync();
+        return Ok(undefined).toAsync();
       };
 
       // WHEN/THEN
@@ -143,14 +143,14 @@ describe("handlers", () => {
       const handlers = {
         testConsumer: ({ payload }: { payload: { id: string; data: string } }) => {
           console.log(payload.id);
-          return ok(undefined).toAsync();
+          return Ok(undefined).toAsync();
         },
         anotherConsumer: ({ payload }: { payload: { id: string; data: string } }) => {
           console.log(payload.data);
-          return ok(undefined).toAsync();
+          return Ok(undefined).toAsync();
         },
         calculate: ({ payload }: { payload: { a: number; b: number } }) =>
-          ok({ sum: payload.a + payload.b }).toAsync(),
+          Ok({ sum: payload.a + payload.b }).toAsync(),
       };
 
       // WHEN
@@ -165,17 +165,17 @@ describe("handlers", () => {
       const handlers = {
         testConsumer: ({ payload }: { payload: { id: string; data: string } }) => {
           console.log(payload.id);
-          return ok(undefined).toAsync();
+          return Ok(undefined).toAsync();
         },
         anotherConsumer: ({ payload }: { payload: { id: string; data: string } }) => {
           console.log(payload.data);
-          return ok(undefined).toAsync();
+          return Ok(undefined).toAsync();
         },
         calculate: ({ payload }: { payload: { a: number; b: number } }) =>
-          ok({ sum: payload.a + payload.b }).toAsync(),
+          Ok({ sum: payload.a + payload.b }).toAsync(),
         nonExistent: ({ payload }: { payload: { id: string; data: string } }) => {
           console.log(payload.data);
-          return ok(undefined).toAsync();
+          return Ok(undefined).toAsync();
         },
       };
 
@@ -195,7 +195,7 @@ describe("handlers", () => {
         _message: { payload: { id: string; data: string } },
         _rawMessage: ConsumeMessage,
       ) => {
-        return err(new RetryableError("Transient failure")).toAsync();
+        return Err(new RetryableError("Transient failure")).toAsync();
       };
 
       // WHEN
@@ -218,7 +218,7 @@ describe("handlers", () => {
         _message: { payload: { id: string; data: string } },
         _rawMessage: ConsumeMessage,
       ) => {
-        return err(new NonRetryableError("Invalid message")).toAsync();
+        return Err(new NonRetryableError("Invalid message")).toAsync();
       };
 
       // WHEN

--- a/packages/worker/src/handlers.ts
+++ b/packages/worker/src/handlers.ts
@@ -96,7 +96,7 @@ function validateHandlers<TContract extends ContractDefinition>(
  * @example Consumer handler
  * ```typescript
  * import { defineHandler, RetryableError, NonRetryableError } from '@amqp-contract/worker';
- * import { fromPromise, ok } from 'unthrown';
+ * import { fromPromise, Ok } from 'unthrown';
  *
  * const processOrderHandler = defineHandler(
  *   orderContract,
@@ -114,7 +114,7 @@ function validateHandlers<TContract extends ContractDefinition>(
  * const calculateHandler = defineHandler(
  *   rpcContract,
  *   'calculate',
- *   ({ payload }) => ok({ sum: payload.a + payload.b }).toAsync(),
+ *   ({ payload }) => Ok({ sum: payload.a + payload.b }).toAsync(),
  * );
  * ```
  */
@@ -183,7 +183,7 @@ export function defineHandler<
  * @example
  * ```typescript
  * import { defineHandlers, RetryableError } from '@amqp-contract/worker';
- * import { fromPromise, ok } from 'unthrown';
+ * import { fromPromise, Ok } from 'unthrown';
  *
  * const handlers = defineHandlers(orderContract, {
  *   processOrder: ({ payload }) =>
@@ -191,7 +191,7 @@ export function defineHandler<
  *       processPayment(payload),
  *       (error) => new RetryableError('Payment failed', error),
  *     ).map(() => undefined),
- *   calculate: ({ payload }) => ok({ sum: payload.a + payload.b }).toAsync(),
+ *   calculate: ({ payload }) => Ok({ sum: payload.a + payload.b }).toAsync(),
  * });
  * ```
  */

--- a/packages/worker/src/retry.spec.ts
+++ b/packages/worker/src/retry.spec.ts
@@ -1,7 +1,7 @@
 import type { ResolvedTtlBackoffRetryOptions } from "@amqp-contract/contract";
 import type { AmqpClient } from "@amqp-contract/core";
 import type { ConsumeMessage } from "amqplib";
-import { err, ok } from "unthrown";
+import { Err, Ok } from "unthrown";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { _internalForTesting } from "./retry.js";
 
@@ -158,12 +158,12 @@ function createMockClient(publishImpl: () => ReturnType<AmqpClient["publish"]>):
 
 describe("publishForRetry", () => {
   it("acks the original message only AFTER a successful retry publish", async () => {
-    const { client, ack, publish } = createMockClient(() => ok(true).toAsync());
+    const { client, ack, publish } = createMockClient(() => Ok(true).toAsync());
     const callOrder: string[] = [];
     (client.ack as ReturnType<typeof vi.fn>).mockImplementation(() => callOrder.push("ack"));
     (client.publish as ReturnType<typeof vi.fn>).mockImplementation(() => {
       callOrder.push("publish");
-      return ok(true).toAsync();
+      return Ok(true).toAsync();
     });
 
     const msg = createMockConsumeMessage();
@@ -187,7 +187,7 @@ describe("publishForRetry", () => {
   });
 
   it("does NOT ack the original when publish reports the channel buffer is full", async () => {
-    const { client, ack, nack, publish } = createMockClient(() => ok(false).toAsync());
+    const { client, ack, nack, publish } = createMockClient(() => Ok(false).toAsync());
 
     const msg = createMockConsumeMessage();
 
@@ -213,7 +213,7 @@ describe("publishForRetry", () => {
 
   it("does NOT ack the original when publish itself rejects", async () => {
     const { client, ack, nack, publish } = createMockClient(() =>
-      err(new Error("publish exploded") as never).toAsync(),
+      Err(new Error("publish exploded") as never).toAsync(),
     );
 
     const msg = createMockConsumeMessage();
@@ -238,7 +238,7 @@ describe("publishForRetry", () => {
   });
 
   it("propagates retry headers and increments x-retry-count on publish", async () => {
-    const { client, publish } = createMockClient(() => ok(true).toAsync());
+    const { client, publish } = createMockClient(() => Ok(true).toAsync());
 
     const msg = createMockConsumeMessage({
       properties: {

--- a/packages/worker/src/retry.ts
+++ b/packages/worker/src/retry.ts
@@ -7,7 +7,7 @@ import {
 } from "@amqp-contract/contract";
 import { type AmqpClient, type Logger, TechnicalError } from "@amqp-contract/core";
 import type { ConsumeMessage } from "amqplib";
-import { err, ok, type AsyncResult } from "unthrown";
+import { Err, Ok, type AsyncResult } from "unthrown";
 import { NonRetryableError } from "./errors.js";
 
 type RetryContext = {
@@ -45,7 +45,7 @@ export function handleError(
   // decision log inside `sendToDLQ`.
   if (error instanceof NonRetryableError) {
     sendToDLQ(ctx, msg, consumer);
-    return ok(undefined).toAsync();
+    return Ok(undefined).toAsync();
   }
 
   // Get retry config from the queue definition in the contract
@@ -70,7 +70,7 @@ export function handleError(
     queueName: extractQueue(consumer.queue).name,
   });
   sendToDLQ(ctx, msg, consumer);
-  return ok(undefined).toAsync();
+  return Ok(undefined).toAsync();
 }
 
 /**
@@ -111,7 +111,7 @@ function handleErrorImmediateRequeue(
       maxRetries: config.maxRetries,
     });
     sendToDLQ(ctx, msg, consumer);
-    return ok(undefined).toAsync();
+    return Ok(undefined).toAsync();
   }
 
   ctx.logger?.info("Retrying message (immediate-requeue mode)", {
@@ -124,7 +124,7 @@ function handleErrorImmediateRequeue(
   if (queue.type === "quorum") {
     // For quorum queues, nack with requeue=true to trigger native retry mechanism
     ctx.amqpClient.nack(msg, false, true);
-    return ok(undefined).toAsync();
+    return Ok(undefined).toAsync();
   } else {
     // For classic queues, re-publish the message to the same exchange / routing key immediately with an incremented x-retry-count header
     return publishForRetry(ctx, {
@@ -176,7 +176,7 @@ function handleErrorTtlBackoff(
       consumerName,
       queueName: consumer.queue.name,
     });
-    return err(new TechnicalError("Queue does not have TTL-backoff infrastructure")).toAsync();
+    return Err(new TechnicalError("Queue does not have TTL-backoff infrastructure")).toAsync();
   }
 
   const queueEntry = consumer.queue;
@@ -196,7 +196,7 @@ function handleErrorTtlBackoff(
       maxRetries: config.maxRetries,
     });
     sendToDLQ(ctx, msg, consumer);
-    return ok(undefined).toAsync();
+    return Ok(undefined).toAsync();
   }
 
   // Retry with exponential backoff
@@ -353,7 +353,7 @@ function publishForRetry(
           retryCount: newRetryCount,
           ...(delayMs !== undefined ? { delayMs } : {}),
         });
-        return err(new TechnicalError("Failed to publish message for retry (write buffer full)"));
+        return Err(new TechnicalError("Failed to publish message for retry (write buffer full)"));
       }
 
       // Publish confirmed by the broker — safe to ack the original now.
@@ -364,7 +364,7 @@ function publishForRetry(
         retryCount: newRetryCount,
         ...(delayMs !== undefined ? { delayMs } : {}),
       });
-      return ok(undefined);
+      return Ok(undefined);
     })
     .orElse((publishError) => {
       // Publish threw (network error, channel close, etc.). Same policy: do
@@ -375,7 +375,7 @@ function publishForRetry(
         ...(delayMs !== undefined ? { delayMs } : {}),
         error: publishError,
       });
-      return err(publishError);
+      return Err(publishError);
     });
 }
 

--- a/packages/worker/src/types.ts
+++ b/packages/worker/src/types.ts
@@ -149,7 +149,7 @@ export type WorkerInferRpcResponse<
  *   console.log(message.payload.orderId);  // Typed payload
  *   console.log(message.headers?.priority); // Typed headers (if defined)
  *   console.log(rawMessage.fields.deliveryTag); // Raw AMQP message
- *   return ok(undefined).toAsync();
+ *   return Ok(undefined).toAsync();
  * });
  * ```
  */
@@ -250,7 +250,7 @@ export type WorkerInferRpcHandlerEntry<
  *       processPayment(payload),
  *       (error) => new RetryableError('Payment failed', error),
  *     ).map(() => undefined),
- *   calculate: ({ payload }) => ok({ sum: payload.a + payload.b }).toAsync(),
+ *   calculate: ({ payload }) => Ok({ sum: payload.a + payload.b }).toAsync(),
  * };
  * ```
  */

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -24,10 +24,10 @@ import type { AmqpConnectionManagerOptions, ConnectionUrl } from "amqp-connectio
 import type { ConsumeMessage } from "amqplib";
 import {
   allAsync,
-  err,
+  Err,
   fromPromise,
   fromSafePromise,
-  ok,
+  Ok,
   type AsyncResult,
   type Result,
 } from "unthrown";
@@ -77,13 +77,13 @@ function isHandlerTuple(entry: unknown): entry is [unknown, ConsumerOptions] {
  *     // Simple handler
  *     processOrder: ({ payload }) => {
  *       console.log('Processing order:', payload.orderId);
- *       return ok(undefined).toAsync();
+ *       return Ok(undefined).toAsync();
  *     },
  *     // Handler with prefetch configuration
  *     processPayment: [
  *       ({ payload }) => {
  *         console.log('Processing payment:', payload.paymentId);
- *         return ok(undefined).toAsync();
+ *         return Ok(undefined).toAsync();
  *       },
  *       { prefetch: 10 }
  *     ]
@@ -135,7 +135,7 @@ export type CreateWorkerOptions<TContract extends ContractDefinition> = {
   defaultConsumerOptions?: ConsumerOptions | undefined;
   /**
    * Maximum time in ms to wait for the AMQP connection to become ready before
-   * `create()` resolves to an `err(TechnicalError)`. Defaults to 30s
+   * `create()` resolves to an `Err(TechnicalError)`. Defaults to 30s
    * (the {@link AmqpClient}'s `DEFAULT_CONNECT_TIMEOUT_MS`). Pass `null` to
    * disable the timeout and let amqp-connection-manager retry indefinitely.
    */
@@ -154,7 +154,7 @@ export type CreateWorkerOptions<TContract extends ContractDefinition> = {
  * ```typescript
  * import { TypedAmqpWorker } from '@amqp-contract/worker';
  * import { defineQueue, defineMessage, defineContract, defineConsumer } from '@amqp-contract/contract';
- * import { ok } from 'unthrown';
+ * import { Ok } from 'unthrown';
  * import { z } from 'zod';
  *
  * const orderQueue = defineQueue('order-processing');
@@ -174,7 +174,7 @@ export type CreateWorkerOptions<TContract extends ContractDefinition> = {
  *   handlers: {
  *     processOrder: ({ payload }) => {
  *       console.log('Processing order', payload.orderId);
- *       return ok(undefined).toAsync();
+ *       return Ok(undefined).toAsync();
  *     },
  *   },
  *   urls: ['amqp://localhost'],
@@ -279,7 +279,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
    * const result = await TypedAmqpWorker.create({
    *   contract: myContract,
    *   handlers: {
-   *     processOrder: ({ payload }) => ok(undefined).toAsync(),
+   *     processOrder: ({ payload }) => Ok(undefined).toAsync(),
    *   },
    *   urls: ['amqp://localhost'],
    * });
@@ -353,7 +353,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
       // cleanup and we still want to release the underlying connection.
       this.amqpClient.cancel(consumerTag).orElse((error) => {
         this.logger?.warn("Failed to cancel consumer during close", { consumerTag, error });
-        return ok(undefined);
+        return Ok(undefined);
       }),
     );
 
@@ -415,14 +415,14 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
       (error) => new TechnicalError(`Error validating ${context.field}`, error),
     ).flatMap((result) => {
       if (result.issues) {
-        return err(
+        return Err(
           new TechnicalError(
             `${context.field} validation failed`,
             new MessageValidationError(context.consumerName, result.issues),
           ),
         );
       }
-      return ok(result.value);
+      return Ok(result.value);
     });
   }
 
@@ -460,7 +460,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
             field: "headers",
           },
         )
-      : ok(undefined).toAsync();
+      : Ok(undefined).toAsync();
 
     return allAsync([parsePayload, parseHeaders]).map(([payload, headers]) => ({
       payload,
@@ -501,7 +501,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
         "RPC handler returned a response but the incoming message has no replyTo",
         { rpcName: String(rpcName), queueName },
       );
-      return err(
+      return Err(
         new NonRetryableError(
           `RPC "${String(rpcName)}" received a message without replyTo; cannot deliver response`,
         ),
@@ -514,7 +514,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
         "RPC handler returned a response but the incoming message has no correlationId",
         { rpcName: String(rpcName), queueName, replyTo },
       );
-      return err(
+      return Err(
         new NonRetryableError(
           `RPC "${String(rpcName)}" received a message without correlationId; cannot deliver response`,
         ),
@@ -528,7 +528,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
     try {
       rawValidation = responseSchema["~standard"].validate(response);
     } catch (error: unknown) {
-      return err(new NonRetryableError("RPC response schema validation threw", error)).toAsync();
+      return Err(new NonRetryableError("RPC response schema validation threw", error)).toAsync();
     }
     const validationPromise =
       rawValidation instanceof Promise ? rawValidation : Promise.resolve(rawValidation);
@@ -540,14 +540,14 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
     )
       .flatMap((validation) => {
         if (validation.issues) {
-          return err<HandlerError>(
+          return Err<HandlerError>(
             new NonRetryableError(
               `RPC response for "${String(rpcName)}" failed schema validation`,
               new MessageValidationError(String(rpcName), validation.issues),
             ),
           );
         }
-        return ok(validation.value);
+        return Ok(validation.value);
       })
       .flatMap((validatedResponse) =>
         this.amqpClient
@@ -566,8 +566,8 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
           )
           .flatMap((published) =>
             published
-              ? ok(undefined)
-              : err<HandlerError>(
+              ? Ok(undefined)
+              : Err<HandlerError>(
                   new NonRetryableError("Failed to publish RPC response: channel buffer full"),
                 ),
           ),
@@ -587,7 +587,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
   ): AsyncResult<{ payload: unknown; headers: unknown }, TechnicalError> {
     return this.parseAndValidateMessage(msg, consumer, name).orElse((parseError) => {
       this.amqpClient.nack(msg, false, false);
-      return err(parseError).toAsync();
+      return Err(parseError).toAsync();
     });
   }
 
@@ -608,7 +608,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
   /**
    * For RPC handlers, validate and publish the reply on the caller's
    * `replyTo` / `correlationId`. For non-RPC consumers, this is a no-op that
-   * resolves to `ok(undefined).toAsync()`.
+   * resolves to `Ok(undefined).toAsync()`.
    */
   private publishReplyIfRpc(
     msg: ConsumeMessage,
@@ -617,7 +617,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
     handlerResponse: unknown,
   ): AsyncResult<void, HandlerError> {
     if (!view.isRpc || !view.responseSchema) {
-      return ok(undefined).toAsync();
+      return Ok(undefined).toAsync();
     }
     const queueName = extractQueue(view.consumer.queue).name;
     return this.publishRpcResponse(msg, queueName, name, view.responseSchema, handlerResponse);
@@ -632,7 +632,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
    * is still needed (see {@link consumeSingle}).
    *
    * Success-vs-failure telemetry is data-driven: the chain resolves to
-   * `ok(undefined)` only on handler success (and reply-publish success for
+   * `Ok(undefined)` only on handler success (and reply-publish success for
    * RPC). Handler failures — even when {@link handleError} routes them
    * successfully to retry/DLQ — are classified as failures for metrics by
    * re-failing the chain with a `TechnicalError` whose `cause` is the
@@ -712,7 +712,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
                 state.messageHandled = true;
               })
               .flatMap(() =>
-                err(
+                Err(
                   new TechnicalError(
                     `Handler "${String(name)}" failed: ${handlerError.message}`,
                     handlerError,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ catalogs:
       specifier: 24.13.2
       version: 24.13.2
     '@unthrown/vitest':
-      specifier: 0.2.0
-      version: 0.2.0
+      specifier: 1.0.0
+      version: 1.0.0
     '@vitest/coverage-v8':
       specifier: 4.1.9
       version: 4.1.9
@@ -100,8 +100,8 @@ catalogs:
       specifier: 6.0.3
       version: 6.0.3
     unthrown:
-      specifier: 0.2.0
-      version: 0.2.0
+      specifier: 1.0.0
+      version: 1.0.0
     valibot:
       specifier: 1.4.1
       version: 1.4.1
@@ -233,7 +233,7 @@ importers:
         version: 6.0.3
       unthrown:
         specifier: 'catalog:'
-        version: 0.2.0
+        version: 1.0.0
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -288,7 +288,7 @@ importers:
         version: 13.1.3
       unthrown:
         specifier: 'catalog:'
-        version: 0.2.0
+        version: 1.0.0
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -392,7 +392,7 @@ importers:
         version: 5.9.0
       unthrown:
         specifier: 'catalog:'
-        version: 0.2.0
+        version: 1.0.0
     devDependencies:
       '@amqp-contract/testing':
         specifier: workspace:*
@@ -408,7 +408,7 @@ importers:
         version: 24.13.2
       '@unthrown/vitest':
         specifier: 'catalog:'
-        version: 0.2.0(vitest@4.1.9)
+        version: 1.0.0(vitest@4.1.9)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.9(vitest@4.1.9)
@@ -487,7 +487,7 @@ importers:
         version: 2.0.1
       unthrown:
         specifier: 'catalog:'
-        version: 0.2.0
+        version: 1.0.0
     devDependencies:
       '@amqp-contract/testing':
         specifier: workspace:*
@@ -506,7 +506,7 @@ importers:
         version: 24.13.2
       '@unthrown/vitest':
         specifier: 'catalog:'
-        version: 0.2.0(vitest@4.1.9)
+        version: 1.0.0(vitest@4.1.9)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.9(vitest@4.1.9)
@@ -573,7 +573,7 @@ importers:
         version: 1.1.0
       unthrown:
         specifier: 'catalog:'
-        version: 0.2.0
+        version: 1.0.0
     devDependencies:
       '@amqp-contract/testing':
         specifier: workspace:*
@@ -589,7 +589,7 @@ importers:
         version: 24.13.2
       '@unthrown/vitest':
         specifier: 'catalog:'
-        version: 0.2.0(vitest@4.1.9)
+        version: 1.0.0(vitest@4.1.9)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.9(vitest@4.1.9)
@@ -637,7 +637,7 @@ importers:
         version: link:../packages/worker
       unthrown:
         specifier: 'catalog:'
-        version: 0.2.0
+        version: 1.0.0
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -2662,8 +2662,8 @@ packages:
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
-  '@unthrown/vitest@0.2.0':
-    resolution: {integrity: sha512-0IavcCbccDw5l6NI9Y8EkF+7tDZkz7mYfYalzsYdPMW5z7f/mTRiaUJkZ6qgd4bVPuD1TiQmKTyK3CFZXGi76Q==}
+  '@unthrown/vitest@1.0.0':
+    resolution: {integrity: sha512-MEqpq2m6AOae3YGOsPzEmEJ6S5K9+pFFgRFG7BjSUoS4Tu49laPQPsbrCKfYAa//RjS2AfxfwAlPhbms8jEFsg==}
     engines: {node: '>=22.19'}
     peerDependencies:
       vitest: ^4
@@ -5159,8 +5159,8 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
-  unthrown@0.2.0:
-    resolution: {integrity: sha512-scackbGqniNj2OhQvsr+3x1HaVqcG7NWDrEViTZgtXcalayTl40DDB/0Ck3xkZay/Z8+oGWnFhqZD3RmpqHLUQ==}
+  unthrown@1.0.0:
+    resolution: {integrity: sha512-96rhOxlnYSyCmFiHp4HqVMawvXA0H8Poks+ph4p+Uxax1OmS/9aekHZBaiCHEm/d0jApGpbSiuVvxW2NkUGTeA==}
     engines: {node: '>=22.19'}
 
   urijs@1.19.11:
@@ -7320,9 +7320,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@unthrown/vitest@0.2.0(vitest@4.1.9)':
+  '@unthrown/vitest@1.0.0(vitest@4.1.9)':
     dependencies:
-      unthrown: 0.2.0
+      unthrown: 1.0.0
       vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@upsetjs/venn.js@2.0.0':
@@ -10126,7 +10126,7 @@ snapshots:
 
   universalify@0.1.2: {}
 
-  unthrown@0.2.0: {}
+  unthrown@1.0.0: {}
 
   urijs@1.19.11: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,7 +31,7 @@ catalog:
   "@orpc/zod": 1.14.6
   "@standard-schema/spec": 1.1.0
   "@types/node": 24.13.2
-  "@unthrown/vitest": 0.2.0
+  "@unthrown/vitest": 1.0.0
   "@vitest/coverage-v8": 4.1.9
   amqp-connection-manager: 5.0.0
   amqplib: 2.0.1
@@ -51,7 +51,7 @@ catalog:
   typedoc: 0.28.19
   typedoc-plugin-markdown: 4.12.0
   typescript: 6.0.3
-  unthrown: 0.2.0
+  unthrown: 1.0.0
   valibot: 1.4.1
   vitepress: 1.6.4
   vitepress-plugin-mermaid: 2.0.17

--- a/tests/src/client-worker.spec.ts
+++ b/tests/src/client-worker.spec.ts
@@ -10,7 +10,7 @@ import {
 } from "@amqp-contract/contract";
 import { it as baseIt } from "@amqp-contract/testing/extension";
 import { TypedAmqpWorker, type WorkerInferHandlers, defineHandlers } from "@amqp-contract/worker";
-import { ok } from "unthrown";
+import { Ok } from "unthrown";
 import { describe, expect, vi } from "vitest";
 import { z } from "zod";
 
@@ -139,7 +139,7 @@ describe("Client and Worker Integration", () => {
       });
 
       // GIVEN
-      const mockHandler = vi.fn().mockReturnValue(ok(undefined).toAsync());
+      const mockHandler = vi.fn().mockReturnValue(Ok(undefined).toAsync());
       await workerFactory(contract, {
         processOrder: mockHandler,
       });
@@ -166,7 +166,7 @@ describe("Client and Worker Integration", () => {
       );
 
       // THEN
-      expect(publishResult).toEqual(ok(undefined));
+      expect(publishResult).toEqual(Ok(undefined));
 
       await vi.waitFor(
         () => {
@@ -223,7 +223,7 @@ describe("Client and Worker Integration", () => {
       const receivedMessages: unknown[] = [];
       const mockHandler = vi.fn().mockImplementation((message: unknown) => {
         receivedMessages.push(message);
-        return ok(undefined).toAsync();
+        return Ok(undefined).toAsync();
       });
       await workerFactory(contract, {
         processEvent: mockHandler,
@@ -242,7 +242,7 @@ describe("Client and Worker Integration", () => {
 
       for (const message of messages) {
         const result = await client.publish("eventPublisher", message);
-        expect(result).toEqual(ok(undefined));
+        expect(result).toEqual(Ok(undefined));
       }
 
       // THEN
@@ -289,7 +289,7 @@ describe("Client and Worker Integration", () => {
         },
       });
 
-      const mockHandler = vi.fn().mockReturnValue(ok(undefined).toAsync());
+      const mockHandler = vi.fn().mockReturnValue(Ok(undefined).toAsync());
       await workerFactory(contract, {
         processStrict: mockHandler,
       });
@@ -314,7 +314,7 @@ describe("Client and Worker Integration", () => {
       });
 
       // THEN
-      expect(validResult).toEqual(ok(undefined));
+      expect(validResult).toEqual(Ok(undefined));
 
       await vi.waitFor(
         () => {
@@ -365,8 +365,8 @@ describe("Client and Worker Integration", () => {
       });
 
       // GIVEN
-      const emailHandler = vi.fn().mockReturnValue(ok(undefined).toAsync());
-      const smsHandler = vi.fn().mockReturnValue(ok(undefined).toAsync());
+      const emailHandler = vi.fn().mockReturnValue(Ok(undefined).toAsync());
+      const smsHandler = vi.fn().mockReturnValue(Ok(undefined).toAsync());
 
       await workerFactory(contract, {
         processEmail: emailHandler,
@@ -382,14 +382,14 @@ describe("Client and Worker Integration", () => {
         recipient: "user@example.com",
         message: "Test email",
       });
-      expect(emailResult).toEqual(ok(undefined));
+      expect(emailResult).toEqual(Ok(undefined));
 
       // WHEN
       const smsResult = await client.publish("smsNotification", {
         recipient: "+1234567890",
         message: "Test SMS",
       });
-      expect(smsResult).toEqual(ok(undefined));
+      expect(smsResult).toEqual(Ok(undefined));
 
       // THEN
       await vi.waitFor(

--- a/tests/src/rpc.spec.ts
+++ b/tests/src/rpc.spec.ts
@@ -14,7 +14,7 @@ import {
 import { TechnicalError } from "@amqp-contract/core";
 import { it as baseIt } from "@amqp-contract/testing/extension";
 import { TypedAmqpWorker } from "@amqp-contract/worker";
-import { fromSafePromise, ok } from "unthrown";
+import { fromSafePromise, Ok } from "unthrown";
 import { describe, expect } from "vitest";
 import { z } from "zod";
 
@@ -91,7 +91,7 @@ describe("TypedAmqpClient RPC", () => {
     const contract = buildContract("rpc.calculate.success");
 
     await workerFactory(contract, {
-      calculate: ({ payload }) => ok({ sum: payload.a + payload.b }).toAsync(),
+      calculate: ({ payload }) => Ok({ sum: payload.a + payload.b }).toAsync(),
     });
     const client = await clientFactory(contract);
 
@@ -124,7 +124,7 @@ describe("TypedAmqpClient RPC", () => {
     await workerFactory(contract, {
       // Cast through unknown to deliberately return a wrong shape — the worker's
       // response-schema validation drops the reply, so the client times out.
-      calculate: () => ok({ wrong: "shape" } as unknown as { sum: number }).toAsync(),
+      calculate: () => Ok({ wrong: "shape" } as unknown as { sum: number }).toAsync(),
     });
     const client = await clientFactory(contract);
 


### PR DESCRIPTION
## What

Upgrades [`unthrown`](https://github.com/btravstack/unthrown) (and `@unthrown/vitest`) from `0.2.0` to **`1.0.0`**.

## Breaking change in 1.0.0

unthrown 1.0 renames the value constructors — **`ok` → `Ok`, `err` → `Err`, `defect` → `Defect`** (the lowercase forms are removed). This is the only change that affected us.

```diff
- import { ok, err } from "unthrown";
- return ok(undefined).toAsync();
- return err(new RetryableError("...")).toAsync();
+ import { Ok, Err } from "unthrown";
+ return Ok(undefined).toAsync();
+ return Err(new RetryableError("...")).toAsync();
```

Everything else is unchanged: `fromPromise` / `fromSafePromise` / `fromThrowable` / `all` / `allAsync` / `TaggedError(tag, { name })` / `.isOk()` / `.isErr()` narrowing / `.toAsync()` / `.unwrap()` keep the same signatures, and the **`.match({ ok, err, defect })` handler keys stay lowercase** (they're case branches, not constructors).

## Scope

- **Catalog:** `unthrown` + `@unthrown/vitest` → `1.0.0`.
- **Code:** context-aware rename of 137 constructor call sites (including generic `Err<HandlerError>(...)`) plus every `from "unthrown"` import — across `core`, `client`, `worker`, examples, integration tests (`tests/`), and docs. Preserved the lowercase `.match` keys, local `err` variables, `unwrapErr`, and `.error` accesses.
- **Docs:** guide pages, agent rules, `AGENTS.md` (+ a new common-mistakes note about the capitalization), READMEs.
- **Untouched:** auto-generated `CHANGELOG.md` files (historical records) and generated typedoc output.
- **Changeset:** `major` (bumps all six `fixed`-group packages — breaking for consumers that build `Result`/`AsyncResult` values directly).

## Verification

- ✅ `pnpm build` (14/14), `pnpm typecheck` (16/16), `pnpm test` unit (client 4 / core 19 / worker 48 / contract 120 / asyncapi 14), `pnpm lint`, `oxfmt --check`, `pnpm knip`, typedoc (0 errors) — all green locally.
- ⚠️ Integration tests (`tests/`, `__tests__/*.spec.ts`) require Docker; migrated and typecheck but **not executed** here. Please confirm in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
