### PR TITLE
chore(deps): pin @types/node to 24.x tree-wide via pnpm override

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,9 +36,6 @@ catalogs:
     '@standard-schema/spec':
       specifier: 1.1.0
       version: 1.1.0
-    '@types/node':
-      specifier: 24.13.2
-      version: 24.13.2
     '@unthrown/vitest':
       specifier: 1.0.0
       version: 1.0.0
@@ -125,6 +122,7 @@ overrides:
   tsx>esbuild: ^0.28.1
   vite@>=6>esbuild: ^0.28.1
   undici: ^8.5.0
+  '@types/node': 24.13.2
 
 importers:
 
@@ -132,10 +130,10 @@ importers:
     devDependencies:
       '@changesets/cli':
         specifier: 'catalog:'
-        version: 2.31.0(@types/node@26.0.1)
+        version: 2.31.0(@types/node@24.13.2)
       '@commitlint/cli':
         specifier: 'catalog:'
-        version: 21.1.0(@types/node@26.0.1)(conventional-commits-parser@6.4.0)(typescript@6.0.3)
+        version: 21.1.0(@types/node@24.13.2)(conventional-commits-parser@6.4.0)(typescript@6.0.3)
       '@commitlint/config-conventional':
         specifier: 'catalog:'
         version: 21.1.0
@@ -180,7 +178,7 @@ importers:
         specifier: workspace:*
         version: link:../tools/tsconfig
       '@types/node':
-        specifier: 'catalog:'
+        specifier: 24.13.2
         version: 24.13.2
       mermaid:
         specifier: 'catalog:'
@@ -220,7 +218,7 @@ importers:
         specifier: workspace:*
         version: link:../../tools/tsconfig
       '@types/node':
-        specifier: 'catalog:'
+        specifier: 24.13.2
         version: 24.13.2
       '@vitest/coverage-v8':
         specifier: 'catalog:'
@@ -257,7 +255,7 @@ importers:
         specifier: 'catalog:'
         version: 1.14.6(@opentelemetry/api@1.9.1)(@orpc/contract@1.14.6(@opentelemetry/api@1.9.1))(@orpc/server@1.14.6(@opentelemetry/api@1.9.1))(zod@4.4.3)
       '@types/node':
-        specifier: 'catalog:'
+        specifier: 24.13.2
         version: 24.13.2
       tsdown:
         specifier: 'catalog:'
@@ -300,7 +298,7 @@ importers:
         specifier: workspace:*
         version: link:../../tools/tsconfig
       '@types/node':
-        specifier: 'catalog:'
+        specifier: 24.13.2
         version: 24.13.2
       '@vitest/coverage-v8':
         specifier: 'catalog:'
@@ -346,7 +344,7 @@ importers:
         specifier: 'catalog:'
         version: 1.14.6(@opentelemetry/api@1.9.1)(@orpc/contract@1.14.6(@opentelemetry/api@1.9.1))(@orpc/server@1.14.6(@opentelemetry/api@1.9.1))(zod@4.4.3)
       '@types/node':
-        specifier: 'catalog:'
+        specifier: 24.13.2
         version: 24.13.2
       '@vitest/coverage-v8':
         specifier: 'catalog:'
@@ -404,7 +402,7 @@ importers:
         specifier: workspace:*
         version: link:../../tools/typedoc
       '@types/node':
-        specifier: 'catalog:'
+        specifier: 24.13.2
         version: 24.13.2
       '@unthrown/vitest':
         specifier: 'catalog:'
@@ -450,7 +448,7 @@ importers:
         specifier: workspace:*
         version: link:../../tools/typedoc
       '@types/node':
-        specifier: 'catalog:'
+        specifier: 24.13.2
         version: 24.13.2
       '@vitest/coverage-v8':
         specifier: 'catalog:'
@@ -502,7 +500,7 @@ importers:
         specifier: 'catalog:'
         version: 1.9.1
       '@types/node':
-        specifier: 'catalog:'
+        specifier: 24.13.2
         version: 24.13.2
       '@unthrown/vitest':
         specifier: 'catalog:'
@@ -542,7 +540,7 @@ importers:
         specifier: workspace:*
         version: link:../../tools/typedoc
       '@types/node':
-        specifier: 'catalog:'
+        specifier: 24.13.2
         version: 24.13.2
       tsdown:
         specifier: 'catalog:'
@@ -585,7 +583,7 @@ importers:
         specifier: workspace:*
         version: link:../../tools/typedoc
       '@types/node':
-        specifier: 'catalog:'
+        specifier: 24.13.2
         version: 24.13.2
       '@unthrown/vitest':
         specifier: 'catalog:'
@@ -640,7 +638,7 @@ importers:
         version: 1.0.0
     devDependencies:
       '@types/node':
-        specifier: 'catalog:'
+        specifier: 24.13.2
         version: 24.13.2
       '@vitest/coverage-v8':
         specifier: 'catalog:'
@@ -1321,7 +1319,7 @@ packages:
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': 24.13.2
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -2626,17 +2624,8 @@ packages:
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
-  '@types/node@12.20.55':
-    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
-
-  '@types/node@18.19.130':
-    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
-
   '@types/node@24.13.2':
     resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
-
-  '@types/node@26.0.1':
-    resolution: {integrity: sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==}
 
   '@types/ssh2-streams@0.1.13':
     resolution: {integrity: sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==}
@@ -3167,7 +3156,7 @@ packages:
     resolution: {integrity: sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==}
     engines: {node: '>=v18'}
     peerDependencies:
-      '@types/node': '*'
+      '@types/node': 24.13.2
       cosmiconfig: '>=9'
       typescript: '>=5'
 
@@ -5127,14 +5116,8 @@ packages:
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
-
-  undici-types@8.3.0:
-    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   undici@8.5.0:
     resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
@@ -5196,7 +5179,7 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
+      '@types/node': 24.13.2
       less: '*'
       lightningcss: ^1.21.0
       sass: '*'
@@ -5227,7 +5210,7 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
+      '@types/node': 24.13.2
       '@vitejs/devtools': ^0.1.18
       esbuild: ^0.28.1
       jiti: '>=1.21.0'
@@ -5290,7 +5273,7 @@ packages:
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
-      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@types/node': 24.13.2
       '@vitest/browser-playwright': 4.1.9
       '@vitest/browser-preview': 4.1.9
       '@vitest/browser-webdriverio': 4.1.9
@@ -5653,7 +5636,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.31.0(@types/node@26.0.1)':
+  '@changesets/cli@2.31.0(@types/node@24.13.2)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
       '@changesets/assemble-release-plan': 6.0.10
@@ -5669,7 +5652,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@26.0.1)
+      '@inquirer/external-editor': 1.0.3(@types/node@24.13.2)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       enquirer: 2.4.1
@@ -5769,12 +5752,12 @@ snapshots:
 
   '@chevrotain/types@11.1.2': {}
 
-  '@commitlint/cli@21.1.0(@types/node@26.0.1)(conventional-commits-parser@6.4.0)(typescript@6.0.3)':
+  '@commitlint/cli@21.1.0(@types/node@24.13.2)(conventional-commits-parser@6.4.0)(typescript@6.0.3)':
     dependencies:
       '@commitlint/config-conventional': 21.1.0
       '@commitlint/format': 21.1.0
       '@commitlint/lint': 21.1.0
-      '@commitlint/load': 21.1.0(@types/node@26.0.1)(typescript@6.0.3)
+      '@commitlint/load': 21.1.0(@types/node@24.13.2)(typescript@6.0.3)
       '@commitlint/read': 21.1.0(conventional-commits-parser@6.4.0)
       '@commitlint/types': 21.1.0
       tinyexec: 1.2.4
@@ -5819,14 +5802,14 @@ snapshots:
       '@commitlint/rules': 21.1.0
       '@commitlint/types': 21.1.0
 
-  '@commitlint/load@21.1.0(@types/node@26.0.1)(typescript@6.0.3)':
+  '@commitlint/load@21.1.0(@types/node@24.13.2)(typescript@6.0.3)':
     dependencies:
       '@commitlint/config-validator': 21.1.0
       '@commitlint/execute-rule': 21.0.1
       '@commitlint/resolve-extends': 21.1.0
       '@commitlint/types': 21.1.0
       cosmiconfig: 9.0.2(typescript@6.0.3)
-      cosmiconfig-typescript-loader: 6.3.0(@types/node@26.0.1)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@24.13.2)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3)
       es-toolkit: 1.47.0
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
@@ -6137,12 +6120,12 @@ snapshots:
       '@iconify/types': 2.0.0
       import-meta-resolve: 4.2.0
 
-  '@inquirer/external-editor@1.0.3(@types/node@26.0.1)':
+  '@inquirer/external-editor@1.0.3(@types/node@24.13.2)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 26.0.1
+      '@types/node': 24.13.2
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -6190,7 +6173,7 @@ snapshots:
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@types/node': 12.20.55
+      '@types/node': 24.13.2
       find-up: 4.1.0
       fs-extra: 8.1.0
 
@@ -7244,18 +7227,18 @@ snapshots:
 
   '@types/docker-modem@3.0.6':
     dependencies:
-      '@types/node': 26.0.1
+      '@types/node': 24.13.2
       '@types/ssh2': 1.15.5
 
   '@types/dockerode@4.0.1':
     dependencies:
       '@types/docker-modem': 3.0.6
-      '@types/node': 26.0.1
+      '@types/node': 24.13.2
       '@types/ssh2': 1.15.5
 
   '@types/es-aggregate-error@1.0.6':
     dependencies:
-      '@types/node': 26.0.1
+      '@types/node': 24.13.2
 
   '@types/estree@1.0.9': {}
 
@@ -7282,32 +7265,22 @@ snapshots:
 
   '@types/mdurl@2.0.0': {}
 
-  '@types/node@12.20.55': {}
-
-  '@types/node@18.19.130':
-    dependencies:
-      undici-types: 5.26.5
-
   '@types/node@24.13.2':
     dependencies:
       undici-types: 7.18.2
 
-  '@types/node@26.0.1':
-    dependencies:
-      undici-types: 8.3.0
-
   '@types/ssh2-streams@0.1.13':
     dependencies:
-      '@types/node': 26.0.1
+      '@types/node': 24.13.2
 
   '@types/ssh2@0.5.52':
     dependencies:
-      '@types/node': 26.0.1
+      '@types/node': 24.13.2
       '@types/ssh2-streams': 0.1.13
 
   '@types/ssh2@1.15.5':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 24.13.2
 
   '@types/trusted-types@2.0.7':
     optional: true
@@ -7845,9 +7818,9 @@ snapshots:
     dependencies:
       layout-base: 2.0.1
 
-  cosmiconfig-typescript-loader@6.3.0(@types/node@26.0.1)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3):
+  cosmiconfig-typescript-loader@6.3.0(@types/node@24.13.2)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
-      '@types/node': 26.0.1
+      '@types/node': 24.13.2
       cosmiconfig: 9.0.2(typescript@6.0.3)
       jiti: 2.6.1
       typescript: 6.0.3
@@ -9413,7 +9386,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
-      '@types/node': 26.0.1
+      '@types/node': 24.13.2
       long: 5.3.2
 
   pump@3.0.4:
@@ -10093,11 +10066,7 @@ snapshots:
       '@quansync/fs': 1.0.0
       quansync: 1.0.0
 
-  undici-types@5.26.5: {}
-
   undici-types@7.18.2: {}
-
-  undici-types@8.3.0: {}
 
   undici@8.5.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -73,6 +73,10 @@ overrides:
   vite@>=6>esbuild: ^0.28.1
   # Force patched undici (testcontainers pulls in <8.5.0, vulnerable to WebSocket DoS)
   undici: ^8.5.0
+  # Keep @types/node on the supported Node major (24.x) everywhere — dev tooling
+  # (@changesets/cli, @commitlint/cli) would otherwise pull @types/node@26
+  # transitively. Types-only, so this has no runtime effect.
+  "@types/node": 24.13.2
 
 auditConfig:
   ignoreGhsas:


### PR DESCRIPTION
## What

Follow-up to #499. That PR pinned `@types/node` to `24.13.2` in the catalog, but the lockfile still resolved **`@types/node@26.0.1`** transitively for `@changesets/cli` and `@commitlint/cli` (flagged in review). This adds a pnpm `override` so the entire tree resolves `24.13.2`.

```yaml
overrides:
  # ...
  "@types/node": 24.13.2
```

## Why it's safe

`@types/node` is types-only — it's stripped at build and never present at runtime. The transitive `26.x` lived only in isolated dev-tool subtrees and didn't affect our packages' typecheck (those already resolved `24.13.2` via the catalog). The override just makes the lockfile consistent with the stated intent.

## Verification

- `pnpm install` regenerates the lockfile with **0** references to `@types/node@26` (only `24.13.2` remains).
- `pnpm typecheck` (16/16) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
