### PR TITLE
chore(deps): reference catalog in @types/node override

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -75,8 +75,9 @@ overrides:
   undici: ^8.5.0
   # Keep @types/node on the supported Node major (24.x) everywhere — dev tooling
   # (@changesets/cli, @commitlint/cli) would otherwise pull @types/node@26
-  # transitively. Types-only, so this has no runtime effect.
-  "@types/node": 24.13.2
+  # transitively. Types-only, so this has no runtime effect. `catalog:` keeps it
+  # in sync with the catalog entry above (single source of truth).
+  "@types/node": "catalog:"
 
 auditConfig:
   ignoreGhsas:


### PR DESCRIPTION
## What

Follow-up to #503. That PR added a tree-wide `@types/node` override but **hardcoded** `24.13.2`, duplicating the catalog entry — two sources of truth that can silently drift on a future bump (flagged in review).

This switches the override to the **`catalog:` protocol** so it resolves from the single catalog pin:

```yaml
catalog:
  "@types/node": 24.13.2   # single source of truth
overrides:
  "@types/node": "catalog:"  # stays in sync
```

## Impact

None functionally — lockfile resolution is unchanged (`@types/node` still resolves to `24.13.2` tree-wide; `pnpm-lock.yaml` is byte-identical, so this is a one-line `pnpm-workspace.yaml` change). `pnpm install` succeeds and `@types/node@26` stays absent from the lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)