### PR TITLE
docs: adopt @btravstack/theme npm package (drop jsDelivr pin)

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -70,6 +70,17 @@ export default withMermaid(
       class: "mermaid",
     },
 
+    // `@btravstack/theme` imports `vitepress/theme` (which side-effect-imports the
+    // default theme's CSS) plus its own `style.css`. VitePress externalizes the
+    // package during the SSR build, so Node's ESM loader hits those `.css` files
+    // and throws `ERR_UNKNOWN_FILE_EXTENSION`. Mark it `noExternal` so Vite
+    // processes (and strips) the CSS for the server bundle instead.
+    vite: {
+      ssr: {
+        noExternal: ["@btravstack/theme"],
+      },
+    },
+
     themeConfig: {
       // https://vitepress.dev/reference/default-theme-config
       logo: { light: "/logo-light.svg", dark: "/logo-dark.svg" },

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,9 +1,0 @@
-/**
- * btravstack shared design system.
- * Keeps these docs in visual sync with the landing page and the other
- * btravstack projects. Source of truth:
- *   https://github.com/btravstack/btravstack.github.io/tree/main/theme
- * Pinned to an immutable commit SHA for reproducible builds — to pull in
- * upstream token changes, bump the SHA below. Do not fork colors here.
- */
-@import "https://cdn.jsdelivr.net/gh/btravstack/btravstack.github.io@v1.0.0/theme/vitepress.css";

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,6 +1,3 @@
-import DefaultTheme from "vitepress/theme";
+import Theme from "@btravstack/theme";
 
-// eslint-disable-next-line sort-imports this CSS import must come after DefaultTheme so that it can override
-import "./custom.css";
-
-export default DefaultTheme;
+export default Theme;

--- a/docs/package.json
+++ b/docs/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@amqp-contract/tsconfig": "workspace:*",
-    "@btravstack/theme": "^1.2.0",
+    "@btravstack/theme": "catalog:",
     "@types/node": "catalog:",
     "mermaid": "catalog:",
     "tsx": "catalog:",

--- a/docs/package.json
+++ b/docs/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@amqp-contract/tsconfig": "workspace:*",
+    "@btravstack/theme": "^1.2.0",
     "@types/node": "catalog:",
     "mermaid": "catalog:",
     "tsx": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     '@asyncapi/parser':
       specifier: 3.6.0
       version: 3.6.0
+    '@btravstack/theme':
+      specifier: 1.2.0
+      version: 1.2.0
     '@changesets/cli':
       specifier: 2.31.0
       version: 2.31.0
@@ -178,7 +181,7 @@ importers:
         specifier: workspace:*
         version: link:../tools/tsconfig
       '@btravstack/theme':
-        specifier: ^1.2.0
+        specifier: 'catalog:'
         version: 1.2.0(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3))
       '@types/node':
         specifier: 24.13.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,9 @@ importers:
       '@amqp-contract/tsconfig':
         specifier: workspace:*
         version: link:../tools/tsconfig
+      '@btravstack/theme':
+        specifier: ^1.2.0
+        version: 1.2.0(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3))
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
@@ -808,6 +811,11 @@ packages:
 
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@btravstack/theme@1.2.0':
+    resolution: {integrity: sha512-T6zN2V8xPY3ohlbjILbP01AMO1xbGl39HuPeVoY2qlJYTRVBRW3RBvuXJVeQAuRdLFcl0xTgFjzHsl9B8RLlkA==}
+    peerDependencies:
+      vitepress: ^1.6.0
 
   '@changesets/apply-release-plan@7.1.1':
     resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
@@ -5606,6 +5614,10 @@ snapshots:
     optional: true
 
   '@braintree/sanitize-url@7.1.2': {}
+
+  '@btravstack/theme@1.2.0(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3))':
+    dependencies:
+      vitepress: 1.6.4(@algolia/client-search@5.53.0)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3)
 
   '@changesets/apply-release-plan@7.1.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -65,6 +65,7 @@ minimumReleaseAgeStrict: true
 # from the release-age maturity gate so freshly published versions can be adopted
 # immediately.
 minimumReleaseAgeExclude:
+  - "@btravstack/theme"
   - unthrown
   - "@unthrown/vitest"
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,7 @@ packages:
 
 catalog:
   "@asyncapi/parser": 3.6.0
+  "@btravstack/theme": 1.2.0
   "@changesets/cli": 2.31.0
   "@commitlint/cli": 21.1.0
   "@commitlint/config-conventional": 21.1.0


### PR DESCRIPTION
Migrates the docs site onto the published **`@btravstack/theme@^1.2.0`** package, replacing the old jsDelivr `custom.css` import that was pinned to a git tag.

### What changed
- `docs/.vitepress/theme/index.ts` now `export default`s the shared theme (it extends VitePress's default theme and layers the btravstack design tokens).
- Deleted `docs/.vitepress/theme/custom.css` (the `@import "https://cdn.jsdelivr.net/.../theme/vitepress.css"`).
- Added `@btravstack/theme@^1.2.0` to `@amqp-contract/docs`.
- Exempted `@btravstack/theme` from the `minimumReleaseAge` gate — it's a first-party btravstack package, so the supply-chain maturity delay doesn't apply.

### Why
A versioned npm dependency replaces a CDN URL pinned to a tag: upstream token/theme changes now arrive via a normal version bump (and Renovate/Changesets), builds are reproducible, and there's no ~12h CDN cache lag or build-time SHA drift.

### Verification
`vitepress build` emits the 1.2.0 design tokens in the output CSS — `--accent #E0589A`, `--display-accent #E0589A`, and `--text-accent` darkening to `#D6246F` in light mode / `#E0589A` in dark (the WCAG-AA fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)