### PR TITLE
chore(docs): bump @btravstack/theme to 1.3.0 (chrome refinements)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: 3.6.0
       version: 3.6.0
     '@btravstack/theme':
-      specifier: 1.2.1
-      version: 1.2.1
+      specifier: 1.3.0
+      version: 1.3.0
     '@changesets/cli':
       specifier: 2.31.0
       version: 2.31.0
@@ -182,7 +182,7 @@ importers:
         version: link:../tools/tsconfig
       '@btravstack/theme':
         specifier: 'catalog:'
-        version: 1.2.1(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3))
+        version: 1.3.0(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3))
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
@@ -815,8 +815,8 @@ packages:
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
-  '@btravstack/theme@1.2.1':
-    resolution: {integrity: sha512-v9FGRapJxIOpiniwVNFcn3ht18VIowf4K0bPwl9z5V1nfRW7YpqFYe3/JGGimNh6/Ukof0qtHmeuqYB8Hfpagg==}
+  '@btravstack/theme@1.3.0':
+    resolution: {integrity: sha512-7lyrA0XjH8Fm1BDPOVWji3iIVYTYFYBpeAdITenaV0KXdvImZSMPDhUr/XQRV8LHCMfo8E9FVxRMDRhNCHEdKg==}
     peerDependencies:
       vitepress: ^1.6.0
 
@@ -5618,7 +5618,7 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
-  '@btravstack/theme@1.2.1(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3))':
+  '@btravstack/theme@1.3.0(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3))':
     dependencies:
       vitepress: 1.6.4(@algolia/client-search@5.53.0)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ packages:
 
 catalog:
   "@asyncapi/parser": 3.6.0
-  "@btravstack/theme": 1.2.1
+  "@btravstack/theme": 1.3.0
   "@changesets/cli": 2.31.0
   "@commitlint/cli": 21.1.0
   "@commitlint/config-conventional": 21.1.0


### PR DESCRIPTION
Bumps the shared theme to **1.3.0**, picking up the docs chrome refinements:

- **Navbar logo** sized up via `--vp-nav-logo-height` (30px / 26px mobile) — no longer a speck next to the wordmark.
- **Home hero** type tightened.
- **Feature cards** get a hairline border + soft hover-lift (echoing the landing's package cards) + brand-tinted icon chip.

Catalog-only change (`@btravstack/theme 1.2.1 → 1.3.0` + lockfile); the docs package keeps its `catalog:` reference. Already exempt from the release-age gate. Merging redeploys the docs with the refinements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)