### PR TITLE
feat: upgrade unthrown to v2.0.0

### DIFF
--- a/.changeset/unthrown-v2.md
+++ b/.changeset/unthrown-v2.md
@@ -1,0 +1,9 @@
+---
+"@amqp-contract/contract": minor
+---
+
+Upgrade [`unthrown`](https://github.com/btravstack/unthrown) (and `@unthrown/vitest`) to `2.0.0`.
+
+unthrown 2.0 is **additive** relative to 1.x — it adds an `AsyncResult` value namespace (`AsyncResult.fromPromise` / `.all` / …), a `flatTapErr` combinator, and an `isResult` guard. None of amqp-contract's public API changed: the `Result` / `AsyncResult` types you receive from the client and worker keep the same shape (2.0's types are a superset of 1.x's), and `Ok` / `Err` / `fromPromise` / `matchTags` / `TaggedError` / `.isOk()` / `.match()` are unchanged.
+
+No code changes are required to adopt this. If you import `unthrown` directly alongside amqp-contract, bump your own dependency to `^2.0.0` so a single copy is shared.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ catalogs:
       specifier: 1.1.0
       version: 1.1.0
     '@unthrown/vitest':
-      specifier: 1.0.0
-      version: 1.0.0
+      specifier: 2.0.0
+      version: 2.0.0
     '@vitest/coverage-v8':
       specifier: 4.1.9
       version: 4.1.9
@@ -100,8 +100,8 @@ catalogs:
       specifier: 6.0.3
       version: 6.0.3
     unthrown:
-      specifier: 1.0.0
-      version: 1.0.0
+      specifier: 2.0.0
+      version: 2.0.0
     valibot:
       specifier: 1.4.1
       version: 1.4.1
@@ -237,7 +237,7 @@ importers:
         version: 6.0.3
       unthrown:
         specifier: 'catalog:'
-        version: 1.0.0
+        version: 2.0.0
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -292,7 +292,7 @@ importers:
         version: 13.1.3
       unthrown:
         specifier: 'catalog:'
-        version: 1.0.0
+        version: 2.0.0
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -396,7 +396,7 @@ importers:
         version: 5.9.0
       unthrown:
         specifier: 'catalog:'
-        version: 1.0.0
+        version: 2.0.0
     devDependencies:
       '@amqp-contract/testing':
         specifier: workspace:*
@@ -412,7 +412,7 @@ importers:
         version: 24.13.2
       '@unthrown/vitest':
         specifier: 'catalog:'
-        version: 1.0.0(vitest@4.1.9)
+        version: 2.0.0(vitest@4.1.9)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.9(vitest@4.1.9)
@@ -491,7 +491,7 @@ importers:
         version: 2.0.1
       unthrown:
         specifier: 'catalog:'
-        version: 1.0.0
+        version: 2.0.0
     devDependencies:
       '@amqp-contract/testing':
         specifier: workspace:*
@@ -510,7 +510,7 @@ importers:
         version: 24.13.2
       '@unthrown/vitest':
         specifier: 'catalog:'
-        version: 1.0.0(vitest@4.1.9)
+        version: 2.0.0(vitest@4.1.9)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.9(vitest@4.1.9)
@@ -577,7 +577,7 @@ importers:
         version: 1.1.0
       unthrown:
         specifier: 'catalog:'
-        version: 1.0.0
+        version: 2.0.0
     devDependencies:
       '@amqp-contract/testing':
         specifier: workspace:*
@@ -593,7 +593,7 @@ importers:
         version: 24.13.2
       '@unthrown/vitest':
         specifier: 'catalog:'
-        version: 1.0.0(vitest@4.1.9)
+        version: 2.0.0(vitest@4.1.9)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.9(vitest@4.1.9)
@@ -641,7 +641,7 @@ importers:
         version: link:../packages/worker
       unthrown:
         specifier: 'catalog:'
-        version: 1.0.0
+        version: 2.0.0
     devDependencies:
       '@types/node':
         specifier: 24.13.2
@@ -2662,8 +2662,8 @@ packages:
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
-  '@unthrown/vitest@1.0.0':
-    resolution: {integrity: sha512-MEqpq2m6AOae3YGOsPzEmEJ6S5K9+pFFgRFG7BjSUoS4Tu49laPQPsbrCKfYAa//RjS2AfxfwAlPhbms8jEFsg==}
+  '@unthrown/vitest@2.0.0':
+    resolution: {integrity: sha512-ZnpksMED7VX/aOSb1dinVU34SgrQ7BHbmX3iSeYGRXhryZ1YdcsKF4Zb4T8dZQWURshxoog2Thy9cD336V/McQ==}
     engines: {node: '>=22.19'}
     peerDependencies:
       vitest: ^4
@@ -5153,8 +5153,8 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
-  unthrown@1.0.0:
-    resolution: {integrity: sha512-96rhOxlnYSyCmFiHp4HqVMawvXA0H8Poks+ph4p+Uxax1OmS/9aekHZBaiCHEm/d0jApGpbSiuVvxW2NkUGTeA==}
+  unthrown@2.0.0:
+    resolution: {integrity: sha512-Pu2Zu7rvA5CajF9oxw0Ft/Y00PPc0Q+TWZqA6jWzEzoWPCqvB7xEhetJhr+3azBcItTIuUgIchMqb5zz+MexJA==}
     engines: {node: '>=22.19'}
 
   urijs@1.19.11:
@@ -7308,9 +7308,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@unthrown/vitest@1.0.0(vitest@4.1.9)':
+  '@unthrown/vitest@2.0.0(vitest@4.1.9)':
     dependencies:
-      unthrown: 1.0.0
+      unthrown: 2.0.0
       vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@upsetjs/venn.js@2.0.0':
@@ -10110,7 +10110,7 @@ snapshots:
 
   universalify@0.1.2: {}
 
-  unthrown@1.0.0: {}
+  unthrown@2.0.0: {}
 
   urijs@1.19.11: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,7 +32,7 @@ catalog:
   "@orpc/zod": 1.14.6
   "@standard-schema/spec": 1.1.0
   "@types/node": 24.13.2
-  "@unthrown/vitest": 1.0.0
+  "@unthrown/vitest": 2.0.0
   "@vitest/coverage-v8": 4.1.9
   amqp-connection-manager: 5.0.0
   amqplib: 2.0.1
@@ -52,7 +52,7 @@ catalog:
   typedoc: 0.28.19
   typedoc-plugin-markdown: 4.12.0
   typescript: 6.0.3
-  unthrown: 1.0.0
+  unthrown: 2.0.0
   valibot: 1.4.1
   vitepress: 1.6.4
   vitepress-plugin-mermaid: 2.0.17


### PR DESCRIPTION
## What

Upgrades [`unthrown`](https://github.com/btravstack/unthrown) and `@unthrown/vitest` from `1.0.0` to **`2.0.0`**.

## No code changes required

Despite the major version, unthrown 2.0 is **purely additive** relative to 1.x — I diffed the `.d.ts` surface and nothing amqp-contract uses changed:

- **Added:** an `AsyncResult` value namespace (`AsyncResult.fromPromise` / `.all` / …), a `flatTapErr` combinator, and an `isResult` guard.
- **Unchanged:** `Ok` / `Err` / `Defect`, `fromPromise` / `fromSafePromise` / `fromThrowable`, `all` / `allAsync`, `matchTags`, `TaggedError(tag, { name })`, `.match({ ok, err, defect })`, `.isOk()` / `.isErr()` narrowing, `.map` / `.flatMap` / `.unwrap` / `.toAsync()`.

The only diff is the catalog bump + lockfile.

## Changeset: `minor`

The public `Result` / `AsyncResult` surface is unchanged — 2.0's types are a **superset** of 1.x's, so consumer code still compiles. (The 1.0 migration was `major` because of the real `ok`→`Ok` rename; this one has no breaking change.) If you import `unthrown` directly alongside amqp-contract, bump your own dep to `^2.0.0` so a single copy is shared.

## Verification

`pnpm build` (14/14), `pnpm typecheck` (16/16), `pnpm test` (client 4 / core 19 / worker 48 / contract 120 / asyncapi 14), `pnpm lint`, `pnpm knip` — all green with **zero source changes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
