### PR TITLE
feat: upgrade unthrown to v3.0.0

### DIFF
--- a/.agents/rules/handlers.md
+++ b/.agents/rules/handlers.md
@@ -159,17 +159,17 @@ For the authoritative API read unthrown's type definitions; the subset this proj
 
 `AsyncResult<T, E>` (async; `await` resolves to a `Result<T, E>`):
 
-| Method                          | Description                                                                       |
-| ------------------------------- | --------------------------------------------------------------------------------- |
-| `Ok(value).toAsync()`           | Lift a successful sync `Result` into an `AsyncResult`                             |
-| `Err(error).toAsync()`          | Lift a failed sync `Result` into an `AsyncResult`                                 |
-| `fromPromise(promise, qualify)` | Wrap a `Promise`; `qualify` maps the rejection to `E \| Defect(cause)`. Required. |
-| `fromSafePromise(promise)`      | Wrap a `Promise` asserted not to fail in a modeled way (rejection → `Defect`).    |
-| `.map(f)` / `.mapErr(f)`        | Transform the OK value / the error                                                |
-| `.flatMap(f)`                   | Chain another `Result` / `AsyncResult` (was `.andThen` in neverthrow)             |
-| `.orElse(f)`                    | Recover from an error with another `Result` / `AsyncResult`                       |
-| `.tap(f)` / `.tapErr(f)`        | Side effect on OK / error without changing the value (was `.andTee` / `.orTee`)   |
-| `await asyncResult`             | Resolves to a `Result<T, E>` — no exception, even on `Err`                        |
+| Method                          | Description                                                                                                                                           |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Ok(value).toAsync()`           | Lift a successful sync `Result` into an `AsyncResult`                                                                                                 |
+| `Err(error).toAsync()`          | Lift a failed sync `Result` into an `AsyncResult`                                                                                                     |
+| `fromPromise(promise, qualify)` | Wrap a `Promise`; `qualify(cause, defect)` maps the rejection to `E \| defect(cause)` (call the `defect` callback for unexpected failures). Required. |
+| `fromSafePromise(promise)`      | Wrap a `Promise` asserted not to fail in a modeled way (rejection → `Defect`).                                                                        |
+| `.map(f)` / `.mapErr(f)`        | Transform the OK value / the error                                                                                                                    |
+| `.flatMap(f)`                   | Chain another `Result` / `AsyncResult` (was `.andThen` in neverthrow)                                                                                 |
+| `.orElse(f)`                    | Recover from an error with another `Result` / `AsyncResult`                                                                                           |
+| `.tap(f)` / `.tapErr(f)`        | Side effect on OK / error without changing the value (was `.andTee` / `.orTee`)                                                                       |
+| `await asyncResult`             | Resolves to a `Result<T, E>` — no exception, even on `Err`                                                                                            |
 
 `Result<T, E>` (sync; a union of `Ok` / `Err` / `Defect`):
 

--- a/.changeset/unthrown-v3.md
+++ b/.changeset/unthrown-v3.md
@@ -1,0 +1,21 @@
+---
+"@amqp-contract/contract": minor
+---
+
+Upgrade [`unthrown`](https://github.com/btravstack/unthrown) (and `@unthrown/vitest`) to `3.0.0`.
+
+amqp-contract's own public surface is unchanged — the `Result` / `AsyncResult` you receive from the client and worker keep the same shape and methods, and no source changes were needed.
+
+unthrown 3.0 does change how a **defect** is produced inside a `qualify` mapper, which matters only if you author handlers that intentionally route an unexpected failure to the `Defect` channel:
+
+- The standalone `Defect` constructor is no longer exported.
+- `qualify` now receives a second argument — a `defect` callback — so its signature is `(cause, defect) => E | defect(cause)`.
+
+```diff
+- import { fromPromise, Defect } from "unthrown";
+- fromPromise(work(), (cause) => isExpected(cause) ? new MyError(cause) : Defect(cause));
++ import { fromPromise } from "unthrown";
++ fromPromise(work(), (cause, defect) => isExpected(cause) ? new MyError(cause) : defect(cause));
+```
+
+Mappers that only return a modeled error (the common case — e.g. `(cause) => new RetryableError("…", cause)`) are unaffected.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ This is the canonical list — sub-files reference these rather than restating t
 - `await asyncResult` resolves to a `Result<T, E>` — it does **not** throw on `Err`.
 - `result.match({ ok, err, defect })` is **boxed and has three branches**. Positional `match(okFn, errFn)` is the old neverthrow shape and is not supported.
 - Build async results with `Ok(value).toAsync()` / `Err(error).toAsync()` — there is no `okAsync` / `errAsync`.
-- Wrap promises with the free function `fromPromise(promise, qualify)` (not a static `ResultAsync.fromPromise`); `qualify` maps the rejection reason to `E | Defect(cause)` and is required.
+- Wrap promises with the free function `fromPromise(promise, qualify)` (not a static `ResultAsync.fromPromise`); `qualify(cause, defect)` maps the rejection reason to `E` (or, for an unexpected failure, a defect via the `defect` callback it receives — `defect(cause)`) and is required. There is no standalone `Defect` import in unthrown 3.x.
 - `.isOk()` / `.isErr()` / `.isDefect()` are type guards that **narrow `this`** (since unthrown 0.2.0), so `if (result.isErr()) result.error` works. **Prefer the method form** — the standalone `isOk(result)` / `isErr(result)` / `isDefect(result)` functions narrow identically but are not used in this codebase.
 
 ### Topology and contract authoring
@@ -72,7 +72,7 @@ These have been re-introduced more than once across recent migrations / reviews 
 
 - **Treating `await TypedAmqp(Client|Worker).create(...)` as a client/worker.** It returns `AsyncResult<Client, TechnicalError>`; `await` gives you a `Result`. Unwrap with `.unwrap()` (or pattern-match) before calling instance methods.
 - **Wrapping `client.publish(...)` in `fromPromise(...)`.** `publish` already returns an `AsyncResult` — wrap it again and you get `AsyncResult<AsyncResult<...>>`. Chain `.map` / `.mapErr` / `.flatMap` directly.
-- **Calling `fromPromise(p)` without the `qualify` mapper.** The mapper is a required second argument and must return `E | Defect(cause)`. The fix to the opaque "expected 2 arguments, got 1" error is always: pass the mapper.
+- **Calling `fromPromise(p)` without the `qualify` mapper.** The mapper is a required second argument with signature `(cause, defect) => E | defect(cause)` — return a modeled error, or call the `defect` callback for an unexpected failure. The fix to the opaque "expected 2 arguments, got 1" error is always: pass the mapper.
 - **Using positional `result.match(okFn, errFn)`.** That's the old neverthrow shape. unthrown's `match` is boxed with three branches: `result.match({ ok, err, defect })`.
 - **Reaching for `okAsync` / `errAsync` or `ResultAsync` / `_unsafeUnwrap`.** Those are neverthrow. Use `Ok(v).toAsync()` / `Err(e).toAsync()`, the `AsyncResult` type, and `.unwrap()`.
 - **Using lowercase `ok` / `err` / `defect` constructors.** unthrown 1.0 renamed them to **`Ok` / `Err` / `Defect`** (the lowercase forms are removed). The `.match({ ok, err, defect })` handler keys stay lowercase, though — those are case branches, not constructors.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ catalogs:
       specifier: 1.1.0
       version: 1.1.0
     '@unthrown/vitest':
-      specifier: 2.0.0
-      version: 2.0.0
+      specifier: 3.0.0
+      version: 3.0.0
     '@vitest/coverage-v8':
       specifier: 4.1.9
       version: 4.1.9
@@ -100,8 +100,8 @@ catalogs:
       specifier: 6.0.3
       version: 6.0.3
     unthrown:
-      specifier: 2.0.0
-      version: 2.0.0
+      specifier: 3.0.0
+      version: 3.0.0
     valibot:
       specifier: 1.4.1
       version: 1.4.1
@@ -237,7 +237,7 @@ importers:
         version: 6.0.3
       unthrown:
         specifier: 'catalog:'
-        version: 2.0.0
+        version: 3.0.0
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -292,7 +292,7 @@ importers:
         version: 13.1.3
       unthrown:
         specifier: 'catalog:'
-        version: 2.0.0
+        version: 3.0.0
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -396,7 +396,7 @@ importers:
         version: 5.9.0
       unthrown:
         specifier: 'catalog:'
-        version: 2.0.0
+        version: 3.0.0
     devDependencies:
       '@amqp-contract/testing':
         specifier: workspace:*
@@ -412,7 +412,7 @@ importers:
         version: 24.13.2
       '@unthrown/vitest':
         specifier: 'catalog:'
-        version: 2.0.0(vitest@4.1.9)
+        version: 3.0.0(vitest@4.1.9)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.9(vitest@4.1.9)
@@ -491,7 +491,7 @@ importers:
         version: 2.0.1
       unthrown:
         specifier: 'catalog:'
-        version: 2.0.0
+        version: 3.0.0
     devDependencies:
       '@amqp-contract/testing':
         specifier: workspace:*
@@ -510,7 +510,7 @@ importers:
         version: 24.13.2
       '@unthrown/vitest':
         specifier: 'catalog:'
-        version: 2.0.0(vitest@4.1.9)
+        version: 3.0.0(vitest@4.1.9)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.9(vitest@4.1.9)
@@ -577,7 +577,7 @@ importers:
         version: 1.1.0
       unthrown:
         specifier: 'catalog:'
-        version: 2.0.0
+        version: 3.0.0
     devDependencies:
       '@amqp-contract/testing':
         specifier: workspace:*
@@ -593,7 +593,7 @@ importers:
         version: 24.13.2
       '@unthrown/vitest':
         specifier: 'catalog:'
-        version: 2.0.0(vitest@4.1.9)
+        version: 3.0.0(vitest@4.1.9)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.9(vitest@4.1.9)
@@ -641,7 +641,7 @@ importers:
         version: link:../packages/worker
       unthrown:
         specifier: 'catalog:'
-        version: 2.0.0
+        version: 3.0.0
     devDependencies:
       '@types/node':
         specifier: 24.13.2
@@ -2662,8 +2662,8 @@ packages:
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
-  '@unthrown/vitest@2.0.0':
-    resolution: {integrity: sha512-ZnpksMED7VX/aOSb1dinVU34SgrQ7BHbmX3iSeYGRXhryZ1YdcsKF4Zb4T8dZQWURshxoog2Thy9cD336V/McQ==}
+  '@unthrown/vitest@3.0.0':
+    resolution: {integrity: sha512-imKT5Wo8Kd+DwDa4XcPYzxTc4gXd+7wkPmObIVy5X9pJ67i5SYeS5IHfdRiT/k7Rs6B7K2c/siRRYE+ckfgH9g==}
     engines: {node: '>=22.19'}
     peerDependencies:
       vitest: ^4
@@ -5153,8 +5153,8 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
-  unthrown@2.0.0:
-    resolution: {integrity: sha512-Pu2Zu7rvA5CajF9oxw0Ft/Y00PPc0Q+TWZqA6jWzEzoWPCqvB7xEhetJhr+3azBcItTIuUgIchMqb5zz+MexJA==}
+  unthrown@3.0.0:
+    resolution: {integrity: sha512-UXIjZTRgbq3ANGYoH1s1jgK85XDmO2HICllG0wtCSBLBPl+Y+prx36Nk17r2JWdnSeTh8pB1fnzDzNpKTgiPzw==}
     engines: {node: '>=22.19'}
 
   urijs@1.19.11:
@@ -7308,9 +7308,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@unthrown/vitest@2.0.0(vitest@4.1.9)':
+  '@unthrown/vitest@3.0.0(vitest@4.1.9)':
     dependencies:
-      unthrown: 2.0.0
+      unthrown: 3.0.0
       vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@upsetjs/venn.js@2.0.0':
@@ -10110,7 +10110,7 @@ snapshots:
 
   universalify@0.1.2: {}
 
-  unthrown@2.0.0: {}
+  unthrown@3.0.0: {}
 
   urijs@1.19.11: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,7 +32,7 @@ catalog:
   "@orpc/zod": 1.14.6
   "@standard-schema/spec": 1.1.0
   "@types/node": 24.13.2
-  "@unthrown/vitest": 2.0.0
+  "@unthrown/vitest": 3.0.0
   "@vitest/coverage-v8": 4.1.9
   amqp-connection-manager: 5.0.0
   amqplib: 2.0.1
@@ -52,7 +52,7 @@ catalog:
   typedoc: 0.28.19
   typedoc-plugin-markdown: 4.12.0
   typescript: 6.0.3
-  unthrown: 2.0.0
+  unthrown: 3.0.0
   valibot: 1.4.1
   vitepress: 1.6.4
   vitepress-plugin-mermaid: 2.0.17


### PR DESCRIPTION
## What

Upgrades [`unthrown`](https://github.com/btravstack/unthrown) and `@unthrown/vitest` from `2.0.0` to **`3.0.0`**.

## Breaking changes in 3.0 — and why they don't touch our code

I diffed the 2.0 → 3.0 `.d.ts`. Two breaking changes, both around producing a **defect** inside a `qualify` mapper:

1. The standalone `Defect` constructor is no longer exported.
2. `qualify` now receives a second arg — a `defect` callback: `(cause, defect) => E | defect(cause)`.

amqp-contract's `qualify` mappers all return **modeled errors** (`new TechnicalError(...)`, `new RetryableError(...)`) and never construct a defect, so a single-param `(cause) => …` mapper is still assignable to the new signature. **No source changes were required** — only the catalog bump, lockfile, and the qualify-mapper docs (AGENTS.md, handlers rule).

The `Result` / `AsyncResult` types you receive from the client and worker are unchanged.

## Changeset: `minor`

amqp-contract's own public surface is unchanged (same reasoning as the 2.0 bump). The defect/qualify change only matters for consumers who **author handlers that intentionally route to the Defect channel** — the changeset documents the `(cause, defect) => defect(cause)` migration for that case.

## Verification

`pnpm build` (14/14), `pnpm typecheck` (16/16), `pnpm test` (client 4 / core 19 / worker 48 / contract 120 / asyncapi 14), `pnpm lint`, `pnpm knip` — all green with zero source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
