### PR TITLE
docs: add Changelog nav link

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -89,6 +89,7 @@ export default withMermaid(
         { text: "Guides", link: "/guide/getting-started" },
         { text: "API", link: "/api/" },
         { text: "Examples", link: "/examples/" },
+        { text: "Changelog", link: "https://github.com/btravstack/amqp-contract/releases" },
         // Back to the btravstack hub (links the docs up to the landing page).
         { text: "btravstack", link: "https://btravstack.github.io/" },
       ],


### PR DESCRIPTION
Adds a **Changelog** nav item → `https://github.com/btravstack/amqp-contract/releases` (the changesets-generated release notes), so every project docs site links its changelog — matching the unthrown docs, which already do.

(This was meant to land with the earlier nav PR but stranded when that PR merged with only the hub back-link commit; re-doing it off current main.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)