### PR TITLE
chore(deps): downgrade knip and valibot to satisfy release-age policy

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ catalogs:
       specifier: 2.2.1
       version: 2.2.1
     knip:
-      specifier: 6.23.0
-      version: 6.23.0
+      specifier: 6.20.0
+      version: 6.20.0
     lefthook:
       specifier: 2.1.9
       version: 2.1.9
@@ -103,8 +103,8 @@ catalogs:
       specifier: 3.0.0
       version: 3.0.0
     valibot:
-      specifier: 1.4.2
-      version: 1.4.2
+      specifier: 1.4.1
+      version: 1.4.1
     vitepress:
       specifier: 1.6.4
       version: 1.6.4
@@ -142,7 +142,7 @@ importers:
         version: 21.1.0
       knip:
         specifier: 'catalog:'
-        version: 6.23.0
+        version: 6.20.0
       lefthook:
         specifier: 'catalog:'
         version: 2.1.9
@@ -345,7 +345,7 @@ importers:
         version: 1.14.6(@ark/schema@0.56.0)(@opentelemetry/api@1.9.1)(@orpc/contract@1.14.6(@opentelemetry/api@1.9.1))(arktype@2.2.1)
       '@orpc/valibot':
         specifier: 'catalog:'
-        version: 1.14.6(@opentelemetry/api@1.9.1)(@orpc/contract@1.14.6(@opentelemetry/api@1.9.1))(@orpc/server@1.14.6(@opentelemetry/api@1.9.1))(valibot@1.4.2(typescript@6.0.3))
+        version: 1.14.6(@opentelemetry/api@1.9.1)(@orpc/contract@1.14.6(@opentelemetry/api@1.9.1))(@orpc/server@1.14.6(@opentelemetry/api@1.9.1))(valibot@1.4.1(typescript@6.0.3))
       '@orpc/zod':
         specifier: 'catalog:'
         version: 1.14.6(@opentelemetry/api@1.9.1)(@orpc/contract@1.14.6(@opentelemetry/api@1.9.1))(@orpc/server@1.14.6(@opentelemetry/api@1.9.1))(zod@4.4.3)
@@ -372,7 +372,7 @@ importers:
         version: 6.0.3
       valibot:
         specifier: 'catalog:'
-        version: 1.4.2(typescript@6.0.3)
+        version: 1.4.1(typescript@6.0.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -4044,8 +4044,8 @@ packages:
   khroma@2.1.0:
     resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
 
-  knip@6.23.0:
-    resolution: {integrity: sha512-2DvAOX2pZWiG4SLvRRxOAU0aWGEn1ZoVblI541xIoXFdHqq2THMZXy66/qcY5WGuW3TXhb9T1x1zd/Hd1u+yqg==}
+  knip@6.20.0:
+    resolution: {integrity: sha512-q+HYrS7FOERk32GM7g43IdTG7TurN7+YMLZrNpCxubZPYZyQwliBgd18yH4oYQL7YgGtOxP2fCqess3K2XaK2Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -5162,8 +5162,8 @@ packages:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
-  valibot@1.4.2:
-    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+  valibot@1.4.1:
+    resolution: {integrity: sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -6387,13 +6387,13 @@ snapshots:
     transitivePeerDependencies:
       - '@opentelemetry/api'
 
-  '@orpc/valibot@1.14.6(@opentelemetry/api@1.9.1)(@orpc/contract@1.14.6(@opentelemetry/api@1.9.1))(@orpc/server@1.14.6(@opentelemetry/api@1.9.1))(valibot@1.4.2(typescript@6.0.3))':
+  '@orpc/valibot@1.14.6(@opentelemetry/api@1.9.1)(@orpc/contract@1.14.6(@opentelemetry/api@1.9.1))(@orpc/server@1.14.6(@opentelemetry/api@1.9.1))(valibot@1.4.1(typescript@6.0.3))':
     dependencies:
       '@orpc/contract': 1.14.6(@opentelemetry/api@1.9.1)
       '@orpc/openapi': 1.14.6(@opentelemetry/api@1.9.1)
       '@orpc/server': 1.14.6(@opentelemetry/api@1.9.1)
-      '@valibot/to-json-schema': 1.7.1(valibot@1.4.2(typescript@6.0.3))
-      valibot: 1.4.2(typescript@6.0.3)
+      '@valibot/to-json-schema': 1.7.1(valibot@1.4.1(typescript@6.0.3))
+      valibot: 1.4.1(typescript@6.0.3)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - crossws
@@ -7297,9 +7297,9 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3))':
+  '@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3))':
     dependencies:
-      valibot: 1.4.2(typescript@6.0.3)
+      valibot: 1.4.1(typescript@6.0.3)
 
   '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@24.13.2)(lightningcss@1.32.0))(vue@3.5.35(typescript@6.0.3))':
     dependencies:
@@ -8800,7 +8800,7 @@ snapshots:
 
   khroma@2.1.0: {}
 
-  knip@6.23.0:
+  knip@6.20.0:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       formatly: 0.3.0
@@ -10099,7 +10099,7 @@ snapshots:
 
   uuid@14.0.0: {}
 
-  valibot@1.4.2(typescript@6.0.3):
+  valibot@1.4.1(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,7 +37,7 @@ catalog:
   amqp-connection-manager: 5.0.0
   amqplib: 2.0.1
   arktype: 2.2.1
-  knip: 6.23.0
+  knip: 6.20.0
   lefthook: 2.1.9
   mermaid: 11.16.0
   oxfmt: 0.56.0
@@ -53,7 +53,7 @@ catalog:
   typedoc-plugin-markdown: 4.12.0
   typescript: 6.0.3
   unthrown: 3.0.0
-  valibot: 1.4.2
+  valibot: 1.4.1
   vitepress: 1.6.4
   vitepress-plugin-mermaid: 2.0.17
   vitest: 4.1.9


### PR DESCRIPTION
## Problem

CI on `main` is red: the `Build` (and other install) jobs fail the strict `minimumReleaseAge` supply-chain check. Two Dependabot bumps landed on 2026-06-28 — **within** the 7-day cutoff — so the committed lockfile is rejected:

```
knip@6.23.0    published 2026-06-28, within cutoff (2026-06-25)
valibot@1.4.2  published 2026-06-28, within cutoff (2026-06-25)
```

(The Dependabot `cooldown` added in #505 prevents this going forward, but these two merged before it took effect.)

## Fix

Downgrade both to the newest versions that have aged past 7 days, per the policy:

| Package | From | To | Published |
| --- | --- | --- | --- |
| knip | 6.23.0 | **6.20.0** | 2026-06-24 |
| valibot | 1.4.2 | **1.4.1** | 2026-05-24 |

Only the catalog pins + lockfile change; the `minimumReleaseAge` policy itself is untouched. (Regenerating the lockfile required temporarily relaxing the age gate locally, since the strict check blocks `pnpm install` from even re-resolving — the policy is fully restored in the committed diff.)

Dependabot will re-propose these bumps once the versions age past 7 days, and they'll pass then.

## Verification

Lockfile passes the supply-chain policy; `pnpm build` (14/14), `typecheck` (16/16), `test`, `lint`, and `knip` (now 6.20.0) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
