### PR TITLE
docs: add logo to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <div align="center">
 
+<img src="docs/public/logo.svg" alt="amqp-contract" width="128" height="128" />
+
 # amqp-contract
 
 **Type-safe contracts for [AMQP](https://www.amqp.org/)/[RabbitMQ](https://www.rabbitmq.com/) messaging with [TypeScript](https://www.typescriptlang.org/)**


### PR DESCRIPTION
Aligns the README header with the other btravstack projects (matching [unthrown](https://github.com/btravstack/unthrown)'s header): a centered logo above the title.

## Change

Adds one line to the centered header block:

```md
<img src="docs/public/logo.svg" alt="amqp-contract" width="128" height="128" />
```

The rest of the header (title, tagline, the five CI/npm/TypeScript/License badges, and the docs links row) already matched unthrown's format — the logo was the only missing piece.

## Notes

- Uses the existing tracked `docs/public/logo.svg`, which is **theme-adaptive** — it carries an internal `@media (prefers-color-scheme: dark)` with light/dark variants, so a single `<img>` renders correctly on both GitHub light and dark backgrounds (same technique unthrown's logo uses).
- Relative path resolves at the repo root where GitHub renders the README. Scoped to the root README only (the per-package npm READMEs live in subdirectories where that relative path wouldn't resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)