### PR TITLE
Adopt @btravstack/theme 1.4.0 — RabbitMQ-orange accent + feature icons

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,6 @@
+/* amqp-contract accent — RabbitMQ orange.
+ * @btravstack/theme 1.4.0 derives every accent shade from this one token
+ * (deep/hover/soft/washes/hero glow/feature-icon chip/light-mode AA text). */
+:root:root {
+  --accent: #FF6600;
+}

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,6 +1,6 @@
-/* amqp-contract accent — RabbitMQ orange.
- * @btravstack/theme 1.4.0 derives every accent shade from this one token
- * (deep/hover/soft/washes/hero glow/feature-icon chip/light-mode AA text). */
-:root:root {
-  --accent: #FF6600;
+/* amqp-contract accent — RabbitMQ orange. The shared @btravstack/theme
+ * derives every accent shade (deep/hover/soft/washes/hero glow/feature
+ * icons/AA text) from this single token. */
+:root {
+  --accent: #ff6600;
 }

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,3 +1,4 @@
 import Theme from "@btravstack/theme";
+import "./custom.css";
 
 export default Theme;

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,15 +22,15 @@ hero:
       link: https://github.com/btravstack/amqp-contract
 
 features:
-  - icon: 🔒
+  - icon: { src: /icons/shield-check.svg }
     title: Type Safety & Validation
     details: End-to-end TypeScript inference with automatic runtime validation using Zod, Valibot, or ArkType.
 
-  - icon: 🔄
+  - icon: { src: /icons/retry.svg }
     title: Reliable Retry
     details: Built-in immediate or exponential backoff retry mechanisms.
 
-  - icon: 📄
+  - icon: { src: /icons/spec.svg }
     title: AsyncAPI Compatible
     details: Generate AsyncAPI 3.0 specs for documentation, visualization, and breaking change detection.
 ---

--- a/docs/public/icons/retry.svg
+++ b/docs/public/icons/retry.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="#FF7A26" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20 12a8 8 0 1 1-2.3-5.6"></path><path d="M20 3v4h-4"></path></svg>

--- a/docs/public/icons/shield-check.svg
+++ b/docs/public/icons/shield-check.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="#FF7A26" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l8 3.5v5.2c0 5-3.4 8.6-8 11.3-4.6-2.7-8-6.3-8-11.3V5.5L12 2z"></path><path d="M8.5 12l2.4 2.4 4.6-4.8"></path></svg>

--- a/docs/public/icons/spec.svg
+++ b/docs/public/icons/spec.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="#FF7A26" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6 2h9l4 4v16H6z"></path><path d="M15 2v4h4"></path><path d="M9 12h7M9 16h7"></path></svg>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: 3.6.0
       version: 3.6.0
     '@btravstack/theme':
-      specifier: 1.3.0
-      version: 1.3.0
+      specifier: 1.4.0
+      version: 1.4.0
     '@changesets/cli':
       specifier: 2.31.0
       version: 2.31.0
@@ -182,7 +182,7 @@ importers:
         version: link:../tools/tsconfig
       '@btravstack/theme':
         specifier: 'catalog:'
-        version: 1.3.0(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3))
+        version: 1.4.0(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3))
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
@@ -815,8 +815,8 @@ packages:
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
-  '@btravstack/theme@1.3.0':
-    resolution: {integrity: sha512-7lyrA0XjH8Fm1BDPOVWji3iIVYTYFYBpeAdITenaV0KXdvImZSMPDhUr/XQRV8LHCMfo8E9FVxRMDRhNCHEdKg==}
+  '@btravstack/theme@1.4.0':
+    resolution: {integrity: sha512-K6s6gxBkRRQG51gf13CMS+lu6QX+mH4DFhR8v75+v0UYDmAL/hCBbkuc0ydRcPMQ1NcBvHpkbj34Tukl4LCtSQ==}
     peerDependencies:
       vitepress: ^1.6.0
 
@@ -5609,7 +5609,7 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
-  '@btravstack/theme@1.3.0(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3))':
+  '@btravstack/theme@1.4.0(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3))':
     dependencies:
       vitepress: 1.6.4(@algolia/client-search@5.53.0)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.15)(typescript@6.0.3)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ packages:
 
 catalog:
   "@asyncapi/parser": 3.6.0
-  "@btravstack/theme": 1.3.0
+  "@btravstack/theme": 1.4.0
   "@changesets/cli": 2.31.0
   "@commitlint/cli": 21.1.0
   "@commitlint/config-conventional": 21.1.0


### PR DESCRIPTION
Adopts the accent-driven **@btravstack/theme@1.4.0** and gives the docs their own brand color.

- **Catalog** pin `@btravstack/theme` → **1.4.0**.
- **Accent**: a small `docs/.vitepress/theme/custom.css` sets `:root { --accent: #FF6600 }` (RabbitMQ orange). The 1.4.0 theme derives links, buttons, hero glow, brand shades, feature-icon chips and light-mode AA text from that single token.
- **Feature icons**: the home page emoji are replaced with the design's stroke icons — shield-check (Type Safety & Validation) · retry (Reliable Retry) · spec (AsyncAPI Compatible).

Logos were already the refined marks on `main`, so they're unchanged. Docs build passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)