### PR TITLE
feat(docs): add the hero background glyph

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -4,3 +4,35 @@
 :root {
   --accent: #ff6600;
 }
+
+/* Home-hero background glyph — the project's motif behind the hero (a message
+ * fanning out to bound queues). Painted in --accent through a mask, so it
+ * always tracks the accent token; the SVG is base64-encoded so no CSS
+ * minifier can mangle it. `position: relative` gives the glyph its positioning
+ * context (kept here so this file stands alone, even though the shared theme
+ * also sets it). */
+.VPHome {
+  position: relative;
+}
+.VPHome::after {
+  content: "";
+  position: absolute;
+  top: 30px;
+  right: 0;
+  width: 560px;
+  max-width: 56vw;
+  aspect-ratio: 500 / 300;
+  background-color: var(--accent);
+  -webkit-mask: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MDAgMzAwIiBmaWxsPSJub25lIj48cGF0aCBkPSJNMCwxNTAgSDE1MCBNMTUwLDE1MCBDMjIwLDE1MCAyMjAsNzAgMjkwLDcwIEg1MDAgTTE1MCwxNTAgQzIyMCwxNTAgMjIwLDE1MCAyOTAsMTUwIEg1MDAgTTE1MCwxNTAgQzIyMCwxNTAgMjIwLDIzMCAyOTAsMjMwIEg1MDAiIHN0cm9rZT0iI2ZmZiIgc3Ryb2tlLXdpZHRoPSIyIi8+PGNpcmNsZSBjeD0iMTUwIiBjeT0iMTUwIiByPSI3IiBmaWxsPSIjZmZmIi8+PGNpcmNsZSBjeD0iMjkwIiBjeT0iNzAiIHI9IjUiIGZpbGw9IiNmZmYiLz48Y2lyY2xlIGN4PSIyOTAiIGN5PSIxNTAiIHI9IjUiIGZpbGw9IiNmZmYiLz48Y2lyY2xlIGN4PSIyOTAiIGN5PSIyMzAiIHI9IjUiIGZpbGw9IiNmZmYiLz48L3N2Zz4=")
+    no-repeat top right / contain;
+  mask: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MDAgMzAwIiBmaWxsPSJub25lIj48cGF0aCBkPSJNMCwxNTAgSDE1MCBNMTUwLDE1MCBDMjIwLDE1MCAyMjAsNzAgMjkwLDcwIEg1MDAgTTE1MCwxNTAgQzIyMCwxNTAgMjIwLDE1MCAyOTAsMTUwIEg1MDAgTTE1MCwxNTAgQzIyMCwxNTAgMjIwLDIzMCAyOTAsMjMwIEg1MDAiIHN0cm9rZT0iI2ZmZiIgc3Ryb2tlLXdpZHRoPSIyIi8+PGNpcmNsZSBjeD0iMTUwIiBjeT0iMTUwIiByPSI3IiBmaWxsPSIjZmZmIi8+PGNpcmNsZSBjeD0iMjkwIiBjeT0iNzAiIHI9IjUiIGZpbGw9IiNmZmYiLz48Y2lyY2xlIGN4PSIyOTAiIGN5PSIxNTAiIHI9IjUiIGZpbGw9IiNmZmYiLz48Y2lyY2xlIGN4PSIyOTAiIGN5PSIyMzAiIHI9IjUiIGZpbGw9IiNmZmYiLz48L3N2Zz4=")
+    no-repeat top right / contain;
+  opacity: 0.14;
+  pointer-events: none;
+  z-index: 0;
+}
+@media (max-width: 768px) {
+  .VPHome::after {
+    display: none;
+  }
+}


### PR DESCRIPTION
Adds the project-specific line-art motif behind the home hero from the Claude Design docs mockup, in the site accent (self-contained data-URI in `custom.css`, hidden on mobile).

Note: this was meant to ride along with the 1.5.0 PR but got stranded when that merged first — hence this follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)