### PR TITLE
chore: audit housekeeping — ignore .claude, fix stale doc API references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,6 +161,9 @@ vite.config.ts.timestamp-*
 .vscode/
 .idea/
 
+# AI agents
+.claude/
+
 # macOS
 .DS_Store
 .AppleDouble

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ describe("Feature Integration", () => {
 
     // WHEN
     const client = new AmqpClient(contract, { urls: [amqpConnectionUrl] });
-    await client.channel.waitForConnect();
+    (await client.waitForConnect()).unwrap();
 
     // THEN
     await expect(amqpChannel.checkExchange("test")).resolves.toBeDefined();

--- a/docs/guide/channel-configuration.md
+++ b/docs/guide/channel-configuration.md
@@ -324,10 +324,10 @@ describe("Channel Configuration", () => {
       },
     });
 
-    const connected = await client.waitForConnect();
-    expect(connected.isOk()).toBe(true);
+    const connectResult = await client.waitForConnect();
+    expect(connectResult.isOk()).toBe(true);
 
-    await client.close();
+    (await client.close()).unwrap();
   });
 });
 ```
@@ -414,7 +414,7 @@ const client = new AmqpClient(contract, {
 
 **Solutions:**
 
-1. Ensure channel is connected: `await client.waitForConnect()`
+1. Ensure channel is connected: `(await client.waitForConnect()).unwrap()` — `await` alone returns a `Result` and does not throw on failure
 2. Check for errors in setup function (they may cause silent failures)
 3. Verify setup function signature is correct
 

--- a/docs/guide/channel-configuration.md
+++ b/docs/guide/channel-configuration.md
@@ -324,8 +324,8 @@ describe("Channel Configuration", () => {
       },
     });
 
-    await client.channel.waitForConnect();
-    expect(client.channel).toBeDefined();
+    const connected = await client.waitForConnect();
+    expect(connected.isOk()).toBe(true);
 
     await client.close();
   });
@@ -414,7 +414,7 @@ const client = new AmqpClient(contract, {
 
 **Solutions:**
 
-1. Ensure channel is connected: `await client.channel.waitForConnect()`
+1. Ensure channel is connected: `await client.waitForConnect()`
 2. Check for errors in setup function (they may cause silent failures)
 3. Verify setup function signature is correct
 


### PR DESCRIPTION
Two small fixes surfaced by a project audit:

- **chore: ignore `.claude/`** — stale agent worktrees under `.claude/worktrees` were scanned by knip, producing 268 false-positive unused files and a failing `pnpm knip` run. The stale worktrees have been removed locally; ignoring the directory prevents recurrence.
- **fix(docs): `client.channel.waitForConnect()` → `client.waitForConnect()`** — `AmqpClient` keeps its channel wrapper private and exposes `waitForConnect()` directly (returning `AsyncResult<void, TechnicalError>`). Fixed in `docs/guide/channel-configuration.md` (3 places) and `CONTRIBUTING.md`, using the same `(await ...).unwrap()` idiom as the integration tests.

No public API changes, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)