### PR TITLE
fix: DX audit — correct onboarding docs, add type tests, actionable errors

### DIFF
--- a/.changeset/actionable-error-messages.md
+++ b/.changeset/actionable-error-messages.md
@@ -1,0 +1,5 @@
+---
+"@amqp-contract/core": patch
+---
+
+Make `AmqpClient`'s `TechnicalError` messages actionable: connection failures now hint at verifying the broker is reachable at the configured `urls`, and publish failures include the target exchange and routing key (or queue name) instead of a generic "Failed to publish message".

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+# Description
+
+<!-- What does this PR change, and why? -->
+
+## Checklist
+
+- [ ] Tests added/updated for new functionality
+- [ ] `pnpm test` passes
+- [ ] `pnpm typecheck` passes (not covered by the pre-commit hook!)
+- [ ] **Changeset added** (`pnpm changeset`) if this changes anything published — without one, the change will not be released. Not needed for docs/tests/tooling-only changes.
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,14 @@ Thank you for your interest in contributing to amqp-contract!
 
 ## Development Setup
 
+### Prerequisites
+
+- **Node.js >= 22.19** (enforced via `engines`; `.node-version` pins the version used in CI)
+- **pnpm 11.7.0** — the repo pins it via the `packageManager` field, so `corepack enable` gives you the right version automatically
+- **Docker running** (not just installed) — required only for `pnpm test:integration`, which spins up RabbitMQ via testcontainers
+
+### Setup
+
 1. Install dependencies:
 
 ```bash
@@ -25,6 +33,28 @@ pnpm test
 # Run integration tests (requires Docker)
 pnpm test:integration
 ```
+
+### Development Loop
+
+```bash
+# Rebuild packages on change (tsdown --watch)
+pnpm dev
+
+# Run one package's unit tests
+pnpm --filter @amqp-contract/worker test
+
+# Run a single test file (from the package directory)
+cd packages/worker && pnpm vitest run --project unit src/retry.spec.ts
+
+# Type check everything
+pnpm typecheck
+```
+
+> [!IMPORTANT]
+> Two gotchas worth knowing up front:
+>
+> - **`pnpm typecheck` is not in the pre-commit hook.** Lefthook only runs `oxfmt` and `oxlint` on commit, so run `pnpm typecheck` (and `pnpm test`) yourself before pushing.
+> - **Packages typecheck against each other's `dist/` output**, not `src/`. If you change a public type in package A, rebuild it (`pnpm --filter @amqp-contract/<a> build`) before typechecking a package that depends on it — otherwise you'll see stale, confusing type errors.
 
 ## Testing Strategy
 

--- a/README.md
+++ b/README.md
@@ -72,20 +72,7 @@ const contract = defineContract({
   },
 });
 
-// 6. Type-safe publishing with validation
-const client = (
-  await TypedAmqpClient.create({
-    contract,
-    urls: ["amqp://localhost"],
-  })
-).unwrap();
-
-await client.publish("orderCreated", {
-  orderId: "ORD-123", // ✅ TypeScript knows!
-  amount: 99.99,
-});
-
-// 7. Type-safe consuming with automatic retry (configured at queue level)
+// 5. Type-safe consuming with automatic retry (configured at queue level)
 const worker = (
   await TypedAmqpWorker.create({
     contract,
@@ -98,15 +85,46 @@ const worker = (
     urls: ["amqp://localhost"],
   })
 ).unwrap();
+
+// 6. Type-safe publishing with validation
+const client = (
+  await TypedAmqpClient.create({
+    contract,
+    urls: ["amqp://localhost"],
+  })
+).unwrap();
+
+// publish() returns a Result instead of throwing — unwrap() it (or use
+// .match()) so failures surface. See the error model guide for details.
+(
+  await client.publish("orderCreated", {
+    orderId: "ORD-123", // ✅ TypeScript knows!
+    amount: 99.99,
+  })
+).unwrap();
+
+// 7. Clean up
+(await client.close()).unwrap();
+(await worker.close()).unwrap();
 ```
+
+▶ For the full runnable version (including the RabbitMQ Docker command), follow the [5-minute quick start](https://btravstack.github.io/amqp-contract/guide/getting-started).
 
 ## Installation
 
+Requires **Node.js 22.19+**.
+
 ```bash
-pnpm add @amqp-contract/contract @amqp-contract/client @amqp-contract/worker unthrown
+pnpm add @amqp-contract/contract @amqp-contract/client @amqp-contract/worker unthrown zod
 ```
 
-[`unthrown`](https://github.com/btravstack/unthrown) is exposed in the public types (`AsyncResult<void, HandlerError>`), so consumers need it directly to construct handler results.
+[`unthrown`](https://github.com/btravstack/unthrown) is exposed in the public types (`AsyncResult<void, HandlerError>`), so consumers need it directly to construct handler results. `zod` can be swapped for any [Standard Schema](https://standardschema.dev/) library ([Valibot](https://valibot.dev/), [ArkType](https://arktype.io/), …).
+
+Need a local RabbitMQ to try it against?
+
+```bash
+docker run -d --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:4-management
+```
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -94,8 +94,9 @@ const client = (
   })
 ).unwrap();
 
-// publish() returns a Result instead of throwing — unwrap() it (or use
-// .match()) so failures surface. See the error model guide for details.
+// publish() returns an AsyncResult instead of throwing — awaiting it yields
+// a Result to unwrap() (or .match()) so failures surface. See the error
+// model guide for details.
 (
   await client.publish("orderCreated", {
     orderId: "ORD-123", // ✅ TypeScript knows!

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -141,7 +141,11 @@ export default withMermaid(
           },
           {
             text: "Help",
-            items: [{ text: "Troubleshooting", link: "/guide/troubleshooting" }],
+            items: [
+              { text: "Troubleshooting", link: "/guide/troubleshooting" },
+              { text: "FAQ", link: "/guide/faq" },
+              { text: "Upgrading", link: "/guide/upgrading" },
+            ],
           },
         ],
         "/api/": [

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -1,0 +1,38 @@
+---
+title: FAQ - amqp-contract
+description: Frequently asked questions about amqp-contract, type-safe AMQP/RabbitMQ messaging for TypeScript.
+---
+
+# FAQ
+
+## Why doesn't `client.publish()` throw on failure?
+
+Every fallible operation returns a `Result` / `AsyncResult` (from [`unthrown`](https://github.com/btravstack/unthrown)) instead of throwing — `await client.publish(...)` gives you a `Result` that you `.unwrap()`, `.match()`, or chain. This makes failure handling explicit and type-checked rather than an invisible `try`/`catch` obligation. The [Error Model guide](/guide/error-model) explains the full `Ok` / `Err` / `Defect` model.
+
+## Which schema libraries can I use?
+
+Any library implementing [Standard Schema v1](https://standardschema.dev/) — [Zod](https://zod.dev/), [Valibot](https://valibot.dev/), and [ArkType](https://arktype.io/) are all tested. See [Schema Libraries](/guide/schema-libraries).
+
+## Do I need to install `amqplib` myself?
+
+No. `amqplib` (and `amqp-connection-manager`) ship as regular dependencies of the amqp-contract packages. Installing them yourself only risks version drift. You do need to install [`unthrown`](https://github.com/btravstack/unthrown) and your schema library directly, since both appear in the types you write against.
+
+## Why are queues quorum by default?
+
+Quorum queues are RabbitMQ's recommended replicated queue type for data safety. amqp-contract defaults to them and only uses classic queues for features quorum queues don't support (`exclusive`, `autoDelete`, `maxPriority`, non-durable). See [Defining Contracts](/guide/defining-contracts).
+
+## Does it work with NestJS (or other frameworks)?
+
+amqp-contract is framework-agnostic — it runs anywhere Node.js does, and you can wire the client/worker into any framework's lifecycle. There is no dedicated NestJS module today; if that would unblock you, [open an issue](https://github.com/btravstack/amqp-contract/issues).
+
+## Does it support Kafka, NATS, or SQS?
+
+No — amqp-contract targets AMQP 0-9-1 (RabbitMQ) specifically, which is what allows it to model exchanges, queues, bindings, and routing keys in the type system.
+
+## Does it support request/reply (RPC)?
+
+Yes — define an RPC in the contract and both the caller and the responder are typed, with timeout and cancellation handling. See [Client Usage](/guide/client-usage) and [Worker Usage](/guide/worker-usage).
+
+## How do I test my contracts?
+
+`@amqp-contract/testing` provides Vitest fixtures that spin up a real RabbitMQ via [testcontainers](https://testcontainers.com/) with per-test vhost isolation. See the [Testing guide](/guide/testing).

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -13,7 +13,7 @@ amqp-contract brings end-to-end type safety to [AMQP](https://www.amqp.org/)/[Ra
 
 ## Prerequisites
 
-- **Node.js 18+** - [Download Node.js](https://nodejs.org/)
+- **Node.js 22.19+** - [Download Node.js](https://nodejs.org/)
 - **RabbitMQ running locally** - We'll use Docker (see below)
 - **Basic TypeScript knowledge** - Understanding of TypeScript syntax
 
@@ -54,8 +54,8 @@ mkdir amqp-demo && cd amqp-demo
 npm init -y
 
 # Install dependencies
-pnpm add @amqp-contract/contract @amqp-contract/client @amqp-contract/worker amqplib zod
-pnpm add -D @types/amqplib typescript tsx
+pnpm add @amqp-contract/contract @amqp-contract/client @amqp-contract/worker unthrown zod
+pnpm add -D typescript tsx
 
 # Initialize TypeScript
 npx tsc --init --target ES2022 --module NodeNext --moduleResolution NodeNext
@@ -67,8 +67,8 @@ mkdir amqp-demo && cd amqp-demo
 npm init -y
 
 # Install dependencies
-npm install @amqp-contract/contract @amqp-contract/client @amqp-contract/worker amqplib zod
-npm install -D @types/amqplib typescript tsx
+npm install @amqp-contract/contract @amqp-contract/client @amqp-contract/worker unthrown zod
+npm install -D typescript tsx
 
 # Initialize TypeScript
 npx tsc --init --target ES2022 --module NodeNext --moduleResolution NodeNext
@@ -80,13 +80,17 @@ mkdir amqp-demo && cd amqp-demo
 npm init -y
 
 # Install dependencies
-yarn add @amqp-contract/contract @amqp-contract/client @amqp-contract/worker amqplib zod
-yarn add -D @types/amqplib typescript tsx
+yarn add @amqp-contract/contract @amqp-contract/client @amqp-contract/worker unthrown zod
+yarn add -D typescript tsx
 
 # Initialize TypeScript
 npx tsc --init --target ES2022 --module NodeNext --moduleResolution NodeNext
 ```
 
+:::
+
+::: info Why these packages?
+[`unthrown`](https://github.com/btravstack/unthrown) appears in the public types (handlers return `AsyncResult<void, HandlerError>`), so you need it directly to construct handler results. `zod` can be any [Standard Schema](https://standardschema.dev/) library — see [Alternative Schema Libraries](#alternative-schema-libraries) below. You do **not** need to install `amqplib` yourself; it ships as a dependency of the amqp-contract packages.
 :::
 
 ### Optional Packages
@@ -223,7 +227,7 @@ Create `consumer.ts` - processes messages:
 ```typescript
 // consumer.ts
 import { TypedAmqpWorker } from "@amqp-contract/worker";
-import { fromSafePromise } from "unthrown";
+import { Ok } from "unthrown";
 import { contract } from "./contract.js";
 
 async function main() {
@@ -241,11 +245,8 @@ async function main() {
           console.log(`  Subject: ${payload.subject}`);
           console.log(`  Body: ${payload.body}`);
 
-          // Simulate sending email (the promise never rejects, so fromSafePromise)
-          return fromSafePromise(new Promise((resolve) => setTimeout(resolve, 1000))).map(() => {
-            console.log("✅ Email sent successfully!");
-            return undefined;
-          });
+          // Report success — handlers return a Result, they don't throw
+          return Ok(undefined).toAsync();
         },
       },
       urls: ["amqp://localhost"],
@@ -265,6 +266,10 @@ async function main() {
 
 main().catch(console.error);
 ```
+
+::: tip Doing real async work in a handler?
+Wrap the promise with `fromPromise(promise, qualify)` (or `fromSafePromise` if it can never reject) instead of `async`/`await` — handlers return an `AsyncResult`, not a bare promise. See the [Error Model guide](/guide/error-model) and [Worker Usage](/guide/worker-usage).
+:::
 
 ## Step 6: Run It
 
@@ -309,7 +314,6 @@ npx tsx publisher.ts
   To: user@example.com
   Subject: Welcome to amqp-contract!
   Body: This is a type-safe message from amqp-contract.
-✅ Email sent successfully!
 ```
 
 **🎉 Success!** You've just sent and received your first type-safe AMQP message!

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -245,7 +245,7 @@ async function main() {
           console.log(`  Subject: ${payload.subject}`);
           console.log(`  Body: ${payload.body}`);
 
-          // Report success — handlers return a Result, they don't throw
+          // Report success — handlers return an AsyncResult, they don't throw
           return Ok(undefined).toAsync();
         },
       },

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -46,7 +46,7 @@ The `.match({ ok, err, defect })` handler keys stay lowercase — those are case
 
 Replaces `neverthrow` with [`unthrown`](https://github.com/btravstack/unthrown) across all packages. unthrown keeps the errors-as-values model but adds a third **`Defect`** channel for unexpected failures. If you consume the `Result` / `AsyncResult` values returned by the client, worker, or core, update your call sites:
 
-| neverthrow (0.x)                           | unthrown (1.0+)                                              |
+| neverthrow (amqp-contract 0.x)             | unthrown (amqp-contract 1.x)                                 |
 | ------------------------------------------ | ------------------------------------------------------------ |
 | `ResultAsync<T, E>`                        | `AsyncResult<T, E>`                                          |
 | `result.match(okFn, errFn)`                | `result.match({ ok, err, defect })`                          |
@@ -55,6 +55,8 @@ Replaces `neverthrow` with [`unthrown`](https://github.com/btravstack/unthrown) 
 | `ResultAsync.fromPromise(p, mapper)`       | `fromPromise(p, qualify)` (free function, mapper required)   |
 | `._unsafeUnwrap()` / `._unsafeUnwrapErr()` | `.unwrap()` / `.unwrapErr()`                                 |
 | `error instanceof HandlerError`            | `isHandlerError(error)` (`HandlerError` is now a union type) |
+
+The table shows the constructors as they were on amqp-contract 1.x (lowercase `ok` / `err`); if you're upgrading straight to 2.0+, use the capitalized `Ok` / `Err` forms from the [1.x → 2.0](#_1-x-→-2-0) section instead.
 
 Error classes (`TechnicalError`, `RetryableError`, …) became `TaggedError`s with namespaced tags (e.g. `"@amqp-contract/TechnicalError"`) for exhaustive dispatch via `matchTags`; their `Error.name` and constructors are unchanged.
 

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -1,0 +1,61 @@
+---
+title: Upgrading - amqp-contract
+description: Migration notes for major versions of amqp-contract, including the neverthrow to unthrown transition and the Ok/Err constructor rename.
+---
+
+# Upgrading
+
+All six `@amqp-contract/*` packages version together, so upgrade them in lockstep. This page summarizes the changes that require action; the full history lives in the [GitHub Releases](https://github.com/btravstack/amqp-contract/releases) and each package's `CHANGELOG.md`.
+
+## 2.1.x → 2.2.x
+
+Upgrades [`unthrown`](https://github.com/btravstack/unthrown) to `3.0.0`. amqp-contract's own public surface is unchanged. Action is only needed if you author `qualify` mappers that intentionally route unexpected failures to the `Defect` channel:
+
+- The standalone `Defect` constructor is no longer exported.
+- `qualify` now receives a `defect` callback as its second argument: `(cause, defect) => E | defect(cause)`.
+
+```diff
+- import { fromPromise, Defect } from "unthrown";
+- fromPromise(work(), (cause) => isExpected(cause) ? new MyError(cause) : Defect(cause));
++ import { fromPromise } from "unthrown";
++ fromPromise(work(), (cause, defect) => isExpected(cause) ? new MyError(cause) : defect(cause));
+```
+
+Mappers that only return a modeled error (the common case) are unaffected. If you depend on `unthrown` directly, bump it to `^3.0.0` so a single copy is shared.
+
+## 2.0.x → 2.1.x
+
+Upgrades `unthrown` to `2.0.0`, which is additive (adds the `AsyncResult` value namespace, `flatTapErr`, `isResult`). No code changes required.
+
+## 1.x → 2.0
+
+Upgrades `unthrown` to `1.0.0`, which renames the value constructors — **`ok` → `Ok`, `err` → `Err`, `defect` → `Defect`** (the lowercase forms are removed). Update every call site that constructs results directly:
+
+```diff
+- import { ok, err } from "unthrown";
+- return ok(undefined).toAsync();
+- return err(new RetryableError("...")).toAsync();
++ import { Ok, Err } from "unthrown";
++ return Ok(undefined).toAsync();
++ return Err(new RetryableError("...")).toAsync();
+```
+
+The `.match({ ok, err, defect })` handler keys stay lowercase — those are case branches, not constructors. Everything else (`fromPromise`, `fromSafePromise`, `.unwrap()`, `.isOk()`, …) is unchanged.
+
+## 0.x → 1.0
+
+Replaces `neverthrow` with [`unthrown`](https://github.com/btravstack/unthrown) across all packages. unthrown keeps the errors-as-values model but adds a third **`Defect`** channel for unexpected failures. If you consume the `Result` / `AsyncResult` values returned by the client, worker, or core, update your call sites:
+
+| neverthrow (0.x)                           | unthrown (1.0+)                                              |
+| ------------------------------------------ | ------------------------------------------------------------ |
+| `ResultAsync<T, E>`                        | `AsyncResult<T, E>`                                          |
+| `result.match(okFn, errFn)`                | `result.match({ ok, err, defect })`                          |
+| `.andThen` / `.andTee` / `.orTee`          | `.flatMap` / `.tap` / `.tapErr`                              |
+| `okAsync(v)` / `errAsync(e)`               | `ok(v).toAsync()` / `err(e).toAsync()`                       |
+| `ResultAsync.fromPromise(p, mapper)`       | `fromPromise(p, qualify)` (free function, mapper required)   |
+| `._unsafeUnwrap()` / `._unsafeUnwrapErr()` | `.unwrap()` / `.unwrapErr()`                                 |
+| `error instanceof HandlerError`            | `isHandlerError(error)` (`HandlerError` is now a union type) |
+
+Error classes (`TechnicalError`, `RetryableError`, …) became `TaggedError`s with namespaced tags (e.g. `"@amqp-contract/TechnicalError"`) for exhaustive dispatch via `matchTags`; their `Error.name` and constructors are unchanged.
+
+See the [Error Model guide](/guide/error-model) for the full picture of how results flow through the API.

--- a/packages/client/src/client.test-d.ts
+++ b/packages/client/src/client.test-d.ts
@@ -1,0 +1,75 @@
+/**
+ * Type tests for message-payload inference on the typed client.
+ * These guard the flagship DX promise: `client.publish` payloads are fully
+ * inferred from the contract, and wrong shapes are compile errors.
+ */
+
+import {
+  defineContract,
+  defineEventConsumer,
+  defineEventPublisher,
+  defineExchange,
+  defineMessage,
+  defineQueue,
+} from "@amqp-contract/contract";
+import type { TechnicalError } from "@amqp-contract/core";
+import type { AsyncResult } from "unthrown";
+import { describe, expectTypeOf, test } from "vitest";
+import { z } from "zod";
+import type { TypedAmqpClient } from "./client.js";
+import type { MessageValidationError } from "./errors.js";
+import type { ClientInferPublisherInput } from "./types.js";
+
+const ordersExchange = defineExchange("orders");
+const orderProcessingQueue = defineQueue("order-processing");
+const orderMessage = defineMessage(
+  z.object({
+    orderId: z.string(),
+    amount: z.number(),
+  }),
+);
+const orderCreatedEvent = defineEventPublisher(ordersExchange, orderMessage, {
+  routingKey: "order.created",
+});
+
+const contract = defineContract({
+  publishers: {
+    orderCreated: orderCreatedEvent,
+  },
+  consumers: {
+    processOrder: defineEventConsumer(orderCreatedEvent, orderProcessingQueue),
+  },
+});
+
+declare const client: TypedAmqpClient<typeof contract>;
+
+describe("publish payload inference", () => {
+  test("should infer the publisher input type from the contract", () => {
+    expectTypeOf<ClientInferPublisherInput<typeof contract, "orderCreated">>().toEqualTypeOf<{
+      orderId: string;
+      amount: number;
+    }>();
+  });
+
+  test("should accept a valid payload and return a typed AsyncResult", () => {
+    expectTypeOf(
+      client.publish("orderCreated", { orderId: "ORD-123", amount: 99.99 }),
+    ).toEqualTypeOf<AsyncResult<void, TechnicalError | MessageValidationError>>();
+  });
+
+  test("should reject invalid payloads at compile time", () => {
+    // @ts-expect-error — missing required field `amount`
+    client.publish("orderCreated", { orderId: "ORD-123" });
+
+    // @ts-expect-error — `orderId` must be a string
+    client.publish("orderCreated", { orderId: 123, amount: 99.99 });
+
+    // @ts-expect-error — excess property not in the schema
+    client.publish("orderCreated", { orderId: "ORD-123", amount: 99.99, extra: true });
+  });
+
+  test("should reject unknown publisher names at compile time", () => {
+    // @ts-expect-error — `unknownPublisher` is not defined in the contract
+    client.publish("unknownPublisher", { orderId: "ORD-123", amount: 99.99 });
+  });
+});

--- a/packages/client/vitest.config.ts
+++ b/packages/client/vitest.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
           setupFiles: ["./src/vitest.setup.ts"],
           include: ["src/**/*.spec.ts"],
           exclude: ["src/**/__tests__/*.spec.ts"],
+          typecheck: {
+            enabled: true,
+            include: ["src/**/*.test-d.ts"],
+          },
         },
       },
       {

--- a/packages/core/src/amqp-client.ts
+++ b/packages/core/src/amqp-client.ts
@@ -264,7 +264,11 @@ export class AmqpClient {
 
     return fromPromise(
       racedPromise,
-      (error: unknown) => new TechnicalError("Failed to connect to AMQP broker", error),
+      (error: unknown) =>
+        new TechnicalError(
+          "Failed to connect to AMQP broker — verify the broker is running and reachable at the configured `urls`",
+          error,
+        ),
     );
   }
 
@@ -281,7 +285,11 @@ export class AmqpClient {
   ): AsyncResult<boolean, TechnicalError> {
     return fromPromise(
       this.channelWrapper.publish(exchange, routingKey, content, options),
-      (error: unknown) => new TechnicalError("Failed to publish message", error),
+      (error: unknown) =>
+        new TechnicalError(
+          `Failed to publish message to exchange "${exchange}" (routing key "${routingKey}")`,
+          error,
+        ),
     );
   }
 
@@ -297,7 +305,8 @@ export class AmqpClient {
   ): AsyncResult<boolean, TechnicalError> {
     return fromPromise(
       this.channelWrapper.sendToQueue(queue, content, options),
-      (error: unknown) => new TechnicalError("Failed to publish message to queue", error),
+      (error: unknown) =>
+        new TechnicalError(`Failed to publish message to queue "${queue}"`, error),
     );
   }
 

--- a/packages/worker/src/handlers.test-d.ts
+++ b/packages/worker/src/handlers.test-d.ts
@@ -1,0 +1,79 @@
+/**
+ * Type tests for handler payload inference on the typed worker.
+ * These guard the flagship DX promise: handler payloads are fully inferred
+ * from the contract, and wrong handler maps are compile errors.
+ */
+
+import {
+  defineContract,
+  defineEventConsumer,
+  defineEventPublisher,
+  defineExchange,
+  defineMessage,
+  defineQueue,
+} from "@amqp-contract/contract";
+import { Ok } from "unthrown";
+import { describe, expectTypeOf, test } from "vitest";
+import { z } from "zod";
+import { defineHandlers } from "./handlers.js";
+import type { WorkerInferConsumedMessage } from "./types.js";
+
+const ordersExchange = defineExchange("orders");
+const orderProcessingQueue = defineQueue("order-processing");
+const orderMessage = defineMessage(
+  z.object({
+    orderId: z.string(),
+    amount: z.number(),
+  }),
+);
+const orderCreatedEvent = defineEventPublisher(ordersExchange, orderMessage, {
+  routingKey: "order.created",
+});
+
+const contract = defineContract({
+  publishers: {
+    orderCreated: orderCreatedEvent,
+  },
+  consumers: {
+    processOrder: defineEventConsumer(orderCreatedEvent, orderProcessingQueue),
+  },
+});
+
+describe("handler payload inference", () => {
+  test("should infer the consumed message payload type from the contract", () => {
+    expectTypeOf<
+      WorkerInferConsumedMessage<typeof contract, "processOrder">["payload"]
+    >().toEqualTypeOf<{
+      orderId: string;
+      amount: number;
+    }>();
+  });
+
+  test("should infer the payload inside a handler", () => {
+    defineHandlers(contract, {
+      processOrder: ({ payload }) => {
+        expectTypeOf(payload).toEqualTypeOf<{ orderId: string; amount: number }>();
+        return Ok(undefined).toAsync();
+      },
+    });
+  });
+
+  test("should reject access to properties not in the schema", () => {
+    defineHandlers(contract, {
+      processOrder: ({ payload }) => {
+        expectTypeOf(payload).not.toHaveProperty("nonExistent");
+        return Ok(undefined).toAsync();
+      },
+    });
+  });
+
+  test("should reject handler maps that don't match the contract", () => {
+    defineHandlers(contract, {
+      // @ts-expect-error — `unknownConsumer` is not defined in the contract
+      unknownConsumer: () => Ok(undefined).toAsync(),
+    });
+
+    // @ts-expect-error — missing handler for `processOrder`
+    defineHandlers(contract, {});
+  });
+});

--- a/packages/worker/vitest.config.ts
+++ b/packages/worker/vitest.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
           setupFiles: ["./src/vitest.setup.ts"],
           include: ["src/**/*.spec.ts"],
           exclude: ["src/**/__tests__/*.spec.ts"],
+          typecheck: {
+            enabled: true,
+            include: ["src/**/*.test-d.ts"],
+          },
         },
       },
       {


### PR DESCRIPTION
Fixes all findings from a developer-experience audit of the onboarding funnel and contributor docs.

## Consumer DX
- **Install lists corrected everywhere.** getting-started was missing `unthrown` (imported by its own consumer example) and told users to install `amqplib`/`@types/amqplib` (which ship as dependencies); the README was missing `zod`. Both now share one correct list.
- **Node requirement aligned** to the actual `engines` constraint (22.19+) — docs previously claimed 18+.
- **README example is now trustworthy**: publish `Result` handled with an explanatory note instead of silently discarded, step numbering fixed, client/worker closed, RabbitMQ docker command added, link to the runnable quick start.
- **One canonical hello-world handler idiom** (`Ok(undefined).toAsync()`) across README and getting-started, with a tip pointing at `fromPromise` for real async work.
- **New docs pages**: FAQ and an Upgrading guide condensing the breaking changes from the changelogs (neverthrow→unthrown, `Ok`/`Err` rename, unthrown 3.0 `qualify` signature).

## Contributor DX
- CONTRIBUTING now states prerequisites (Node/pnpm/Docker), documents the dev loop (watch mode, single-package and single-file test runs), and calls out two gotchas: typecheck is not in the pre-commit hook, and packages typecheck against `dist/`.
- PR template with a changeset reminder.

## Code
- **Payload-inference type tests** for client and worker (`client.test-d.ts`, `handlers.test-d.ts`) — the flagship inference had zero type-test coverage; includes `@ts-expect-error` negatives. Vitest typecheck enabled in both packages' unit projects.
- **fix(core)**: `AmqpClient` error messages now name the exchange/routing key or queue and hint at checking `urls` on connection failure. Changeset included (patch).

## Verification
- `pnpm build`, `pnpm typecheck`, `pnpm test` all pass (new type tests run in client/worker: "Type Errors: no errors").
- Docs site builds cleanly (`pnpm --filter @amqp-contract/docs build`), so the new pages and sidebar links are valid.
- Integration tests not run locally (Docker); CI will cover them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)