### PR TITLE
docs(examples): demonstrate the command pattern alongside events

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -175,6 +175,31 @@ export const contract = defineContract({
 });
 ```
 
+### Event or command?
+
+This tutorial uses the **event** pattern — one publisher broadcasts, and any number of consumers subscribe. It's the right default for notifications and domain events like "an email was requested".
+
+When the work has a single owner (a task queue — many producers, one consumer), reach for the **command** pattern instead. You define the consumer first with `defineCommandConsumer`, and `defineCommandPublisher` derives the publisher's message type from it so callers can't drift:
+
+```typescript
+import { defineCommandConsumer, defineCommandPublisher } from "@amqp-contract/contract";
+
+// The worker owns the queue and declares the one command it accepts
+const processPayment = defineCommandConsumer(paymentQueue, paymentsExchange, paymentMessage, {
+  routingKey: "payment.charge",
+});
+
+// Any service can send the command; its payload type comes from the consumer
+const chargeCustomer = defineCommandPublisher(processPayment);
+```
+
+| Pattern     | Shape                          | Define with                                        |
+| ----------- | ------------------------------ | -------------------------------------------------- |
+| **Event**   | one publisher → many consumers | `defineEventPublisher` → `defineEventConsumer`     |
+| **Command** | many publishers → one consumer | `defineCommandConsumer` → `defineCommandPublisher` |
+
+Both register the same way in `defineContract`, and both stay fully typed end to end. See [Defining Contracts](/guide/defining-contracts) for the full comparison and the [Command Pattern example](/examples/command-pattern) for a complete walkthrough.
+
 ## Step 4: Publisher
 
 Create `publisher.ts` - publishes a message:

--- a/examples/basic-order-processing-client/src/index.ts
+++ b/examples/basic-order-processing-client/src/index.ts
@@ -114,6 +114,20 @@ async function main() {
   await publishWithLog("orderUrgentUpdate", urgentUpdate);
   logger.info(`   ✓ Published urgent update for ${urgentUpdate.orderId}`);
   logger.info(`   → Will be received by: notifications & urgent queues`);
+  await new Promise((resolve) => setTimeout(resolve, 1500));
+
+  // 6. Send a FULFILLMENT COMMAND (routing key: order.fulfill)
+  //    This is a command, not an event: it is addressed to the single
+  //    fulfillment worker (a task queue), not broadcast to subscribers.
+  logger.info("6️⃣ Sending FULFILLMENT COMMAND (order.fulfill)");
+  const fulfillment = {
+    orderId: "ORD-001",
+    warehouseId: "WH-EU-1",
+    priority: "express" as const,
+  };
+  await publishWithLog("requestFulfillment", fulfillment);
+  logger.info(`   ✓ Sent fulfillment command for ${fulfillment.orderId}`);
+  logger.info(`   → Will be received by: the single fulfillment worker (task queue)`);
 
   logger.info("=".repeat(60));
   logger.info("All orders published!");

--- a/examples/basic-order-processing-contract/src/index.ts
+++ b/examples/basic-order-processing-contract/src/index.ts
@@ -1,4 +1,6 @@
 import {
+  defineCommandConsumer,
+  defineCommandPublisher,
   defineContract,
   defineEventConsumer,
   defineEventPublisher,
@@ -42,6 +44,18 @@ const orderStatusSchema = z.object({
 });
 
 /**
+ * Message schema for the fulfillment command.
+ *
+ * A command is an instruction to do work ("fulfill this order"), not a fact
+ * that happened ("this order was created"). It is addressed to one owner.
+ */
+const fulfillmentSchema = z.object({
+  orderId: z.string(),
+  warehouseId: z.string(),
+  priority: z.enum(["standard", "express"]).default("standard"),
+});
+
+/**
  * Message headers schema for order events
  */
 const orderHeadersSchema = z.object({
@@ -54,6 +68,10 @@ const ordersExchange = defineExchange("orders");
 
 // Define dead letter exchange for failed messages
 const ordersDlx = defineExchange("orders-dlx");
+
+// Direct exchange dedicated to the fulfillment command (task queue). A command
+// targets a single owner, so a direct exchange routing on an exact key fits.
+const fulfillmentExchange = defineExchange("fulfillment", { type: "direct" });
 
 // Define queues
 const orderProcessingQueue = defineQueue("order-processing", {
@@ -68,6 +86,10 @@ const orderProcessingQueue = defineQueue("order-processing", {
 const orderNotificationsQueue = defineQueue("order-notifications");
 const orderShippingQueue = defineQueue("order-shipping");
 const orderUrgentQueue = defineQueue("order-urgent");
+
+// The fulfillment worker owns this queue — commands sent to it are processed
+// by exactly one consumer (a task queue), not broadcast.
+const orderFulfillmentQueue = defineQueue("order-fulfillment");
 
 // Dead letter queue to collect failed messages
 const ordersDlxQueue = defineQueue("orders-dlx-queue");
@@ -85,6 +107,11 @@ const orderStatusMessage = defineMessage(orderStatusSchema, {
 });
 
 const orderUnionMessage = defineMessage(z.union([orderSchema, orderStatusSchema]));
+
+const fulfillmentMessage = defineMessage(fulfillmentSchema, {
+  summary: "Order fulfillment command",
+  description: "Instructs the fulfillment service to pick, pack, and ship an order",
+});
 
 /**
  * Event publishers for each event type.
@@ -130,12 +157,33 @@ const failedOrderEvent = defineEventPublisher(ordersDlx, orderMessage, {
 });
 
 /**
- * Order processing contract demonstrating the event pattern.
+ * Command consumer for the fulfillment task queue.
+ *
+ * The command pattern is the inverse of the event pattern: instead of one
+ * publisher broadcasting to many consumers, many publishers send commands to a
+ * single consumer that owns the queue. Here the fulfillment worker owns
+ * `order-fulfillment` and exposes one command.
+ *
+ * `defineCommandPublisher` derives the publisher's message type and routing key
+ * from this consumer, so callers cannot drift from the owner's contract.
+ */
+const fulfillOrder = defineCommandConsumer(
+  orderFulfillmentQueue,
+  fulfillmentExchange,
+  fulfillmentMessage,
+  { routingKey: "order.fulfill" },
+);
+
+const requestFulfillment = defineCommandPublisher(fulfillOrder);
+
+/**
+ * Order processing contract demonstrating both the event and command patterns.
  *
  * This contract demonstrates:
  * 1. Event Pattern: publishers broadcast events, consumers subscribe with routing key overrides
- * 2. Dead Letter Exchange: Failed messages from orderProcessingQueue are routed to DLX
- * 3. Topic Exchange Wildcards: Consumers use patterns like order.# and order.*.urgent
+ * 2. Command Pattern: many publishers send a command to one owner (the fulfillment task queue)
+ * 3. Dead Letter Exchange: Failed messages from orderProcessingQueue are routed to DLX
+ * 4. Topic Exchange Wildcards: Consumers use patterns like order.# and order.*.urgent
  *
  * Exchanges, queues, and bindings are automatically extracted from publishers and consumers.
  */
@@ -149,6 +197,10 @@ export const orderContract = defineContract({
     orderUrgentUpdate: definePublisher(ordersExchange, orderStatusMessage, {
       routingKey: "order.updated.urgent",
     }),
+
+    // Command publisher: sends a fulfillment command to the single owner.
+    // Its message type is derived from `fulfillOrder`, not restated here.
+    requestFulfillment,
   },
   consumers: {
     // Event consumer: subscribes to order.created events
@@ -169,5 +221,8 @@ export const orderContract = defineContract({
 
     // DLX consumer: receives failed messages
     handleFailedOrders: defineEventConsumer(failedOrderEvent, ordersDlxQueue),
+
+    // Command consumer: the fulfillment worker owns this task queue
+    fulfillOrder,
   },
 });

--- a/examples/basic-order-processing-worker/src/index.spec.ts
+++ b/examples/basic-order-processing-worker/src/index.spec.ts
@@ -24,6 +24,7 @@ describe("Basic Order Processing Worker Integration", () => {
           handleUrgentOrder: () => Ok(undefined).toAsync(),
 
           handleFailedOrders: () => Ok(undefined).toAsync(),
+          fulfillOrder: () => Ok(undefined).toAsync(),
         }),
         urls: [amqpConnectionUrl],
       })
@@ -75,6 +76,7 @@ describe("Basic Order Processing Worker Integration", () => {
         handleUrgentOrder: () => Ok(undefined).toAsync(),
 
         handleFailedOrders: () => Ok(undefined).toAsync(),
+        fulfillOrder: () => Ok(undefined).toAsync(),
       }),
       urls: [amqpConnectionUrl],
     });
@@ -141,6 +143,7 @@ describe("Basic Order Processing Worker Integration", () => {
         handleUrgentOrder: () => Ok(undefined).toAsync(),
 
         handleFailedOrders: () => Ok(undefined).toAsync(),
+        fulfillOrder: () => Ok(undefined).toAsync(),
       }),
       urls: [amqpConnectionUrl],
     });
@@ -170,6 +173,56 @@ describe("Basic Order Processing Worker Integration", () => {
       });
       expect(processedOrders.length).toBeGreaterThanOrEqual(1);
       expect(notifications.length).toBeGreaterThan(0); // Receives all events
+    } finally {
+      (await worker.close()).unwrap();
+    }
+  });
+
+  it("should deliver a fulfillment command to the single owning consumer", async ({
+    amqpConnectionUrl,
+    publishMessage,
+  }) => {
+    // GIVEN
+    const fulfilled: Array<unknown> = [];
+    const worker = (
+      await TypedAmqpWorker.create({
+        contract: orderContract,
+        handlers: defineHandlers(orderContract, {
+          processOrder: () => Ok(undefined).toAsync(),
+          notifyOrder: () => Ok(undefined).toAsync(),
+          shipOrder: () => Ok(undefined).toAsync(),
+          handleUrgentOrder: () => Ok(undefined).toAsync(),
+          handleFailedOrders: () => Ok(undefined).toAsync(),
+          fulfillOrder: ({ payload }) => {
+            fulfilled.push(payload);
+            return Ok(undefined).toAsync();
+          },
+        }),
+        urls: [amqpConnectionUrl],
+      })
+    ).unwrap();
+
+    try {
+      const command = {
+        orderId: "TEST-004",
+        warehouseId: "WH-EU-1",
+        priority: "express" as const,
+      };
+
+      // WHEN — the command is addressed to the fulfillment queue's exchange + key
+      publishMessage(
+        orderContract.publishers.requestFulfillment.exchange.name,
+        orderContract.publishers.requestFulfillment.routingKey,
+        command,
+      );
+
+      // THEN
+      await vi.waitFor(() => {
+        if (fulfilled.length < 1) {
+          throw new Error("Fulfillment command not yet handled");
+        }
+      });
+      expect(fulfilled).toEqual([command]);
     } finally {
       (await worker.close()).unwrap();
     }

--- a/examples/basic-order-processing-worker/src/index.ts
+++ b/examples/basic-order-processing-worker/src/index.ts
@@ -124,6 +124,26 @@ async function main() {
         });
       },
 
+      // Command handler (task queue): the fulfillment worker owns this queue.
+      // Unlike the event handlers above, this command reaches exactly one worker.
+      fulfillOrder: ({ payload }) => {
+        logger.info(
+          {
+            orderId: payload.orderId,
+            warehouseId: payload.warehouseId,
+            priority: payload.priority,
+          },
+          "[FULFILLMENT] Fulfillment command received",
+        );
+
+        return fromPromise(
+          new Promise<void>((resolve) => setTimeout(resolve, 400)),
+          (e) => new RetryableError("Fulfillment failed", e),
+        ).map(() => {
+          logger.info({ orderId: payload.orderId }, "Order handed to the warehouse");
+        });
+      },
+
       // Handler for FAILED orders (from dead letter exchange)
       handleFailedOrders: ({ payload }) => {
         logger.error(
@@ -151,10 +171,11 @@ async function main() {
   logger.info("Worker ready, waiting for messages...");
   logger.info("=".repeat(60));
   logger.info("Subscribed to:");
-  logger.info("  • order.created     → processOrder handler");
+  logger.info("  • order.created     → processOrder handler (event)");
   logger.info("  • order.#           → notifyOrder handler (all events)");
-  logger.info("  • order.shipped     → shipOrder handler");
-  logger.info("  • order.*.urgent    → handleUrgentOrder handler");
+  logger.info("  • order.shipped     → shipOrder handler (event)");
+  logger.info("  • order.*.urgent    → handleUrgentOrder handler (event)");
+  logger.info("  • order.fulfill     → fulfillOrder handler (command / task queue)");
   logger.info("  • order.failed (via DLX) → handleFailedOrders handler");
   logger.info("=".repeat(60));
   logger.info("Dead Letter Exchange:");


### PR DESCRIPTION
The command variants (`defineCommandConsumer` / `defineCommandPublisher`) were unit-tested but unused in any runnable example or entry doc — so newcomers only ever saw the event pattern despite commands being a first-class part of the API. This adds a real command flow.

## Example (basic-order-processing)
Adds a **fulfillment task queue** wired end to end:
- **Contract**: a `fulfillment` direct exchange + `order-fulfillment` queue owned by one worker; `fulfillOrder = defineCommandConsumer(...)` and `requestFulfillment = defineCommandPublisher(fulfillOrder)`. The publisher's payload type is derived from the consumer.
- **Worker**: a `fulfillOrder` handler. Because the contract now has this consumer, the type system *required* adding it across the example's handler maps — a nice demonstration that the inference is real.
- **Client**: dispatches a `requestFulfillment` command, with log lines contrasting "task queue" vs the events' "broadcast".
- **Integration test**: asserts the command reaches its single owning consumer.

## Entry doc (getting-started)
Adds an **"Event or command?"** section after the contract step: a short explanation, a code sketch of the command variant, and a comparison table, linking to the existing `defining-contracts` guide and `command-pattern` example.

## Verification
- `pnpm build`, `pnpm typecheck`, docs build all pass.
- Example integration tests run against real RabbitMQ (Docker): **4/4 pass**, including the new command-delivery test.

No public API changed (examples are private, rest is docs), so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)