### PR TITLE
chore: make unthrown a peer dependency of core, client, worker

### DIFF
--- a/.changeset/unthrown-peer-dependency.md
+++ b/.changeset/unthrown-peer-dependency.md
@@ -1,0 +1,15 @@
+---
+"@amqp-contract/client": minor
+"@amqp-contract/worker": minor
+"@amqp-contract/core": minor
+---
+
+Move `unthrown` from a regular dependency to a **peer dependency** (`^3.0.0`) in `@amqp-contract/core`, `@amqp-contract/client`, and `@amqp-contract/worker`.
+
+`unthrown`'s types are part of the public API (`AsyncResult`, `Result`, `HandlerError`), and unthrown types are nominal — they key on a `unique symbol`, so two copies at different versions (or even the same version, in a non-deduped install) do not unify. As a peer dependency, a single copy is shared between your app and amqp-contract, preventing "two different types with this name exist but are unrelated" errors.
+
+**Action required:** ensure `unthrown` is a direct dependency of your project (the docs already recommend this). Package managers that auto-install peer dependencies (npm 7+, pnpm 8+) handle this for you; stricter setups should add `unthrown` explicitly:
+
+```bash
+pnpm add unthrown
+```

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -61,8 +61,7 @@
     "@amqp-contract/contract": "workspace:*",
     "@amqp-contract/core": "workspace:*",
     "@standard-schema/spec": "catalog:",
-    "ts-pattern": "catalog:",
-    "unthrown": "catalog:"
+    "ts-pattern": "catalog:"
   },
   "devDependencies": {
     "@amqp-contract/testing": "workspace:*",
@@ -77,8 +76,12 @@
     "typedoc": "catalog:",
     "typedoc-plugin-markdown": "catalog:",
     "typescript": "catalog:",
+    "unthrown": "catalog:",
     "vitest": "catalog:",
     "zod": "catalog:"
+  },
+  "peerDependencies": {
+    "unthrown": "^3.0.0"
   },
   "engines": {
     "node": ">=22.19"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,8 +60,7 @@
   "dependencies": {
     "@amqp-contract/contract": "workspace:*",
     "amqp-connection-manager": "catalog:",
-    "amqplib": "catalog:",
-    "unthrown": "catalog:"
+    "amqplib": "catalog:"
   },
   "devDependencies": {
     "@amqp-contract/testing": "workspace:*",
@@ -74,11 +73,13 @@
     "tsdown": "catalog:",
     "typedoc": "catalog:",
     "typescript": "catalog:",
+    "unthrown": "catalog:",
     "vitest": "catalog:",
     "zod": "catalog:"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.0"
+    "@opentelemetry/api": "^1.0.0",
+    "unthrown": "^3.0.0"
   },
   "peerDependenciesMeta": {
     "@opentelemetry/api": {

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -60,8 +60,7 @@
   "dependencies": {
     "@amqp-contract/contract": "workspace:*",
     "@amqp-contract/core": "workspace:*",
-    "@standard-schema/spec": "catalog:",
-    "unthrown": "catalog:"
+    "@standard-schema/spec": "catalog:"
   },
   "devDependencies": {
     "@amqp-contract/testing": "workspace:*",
@@ -76,8 +75,12 @@
     "typedoc": "catalog:",
     "typedoc-plugin-markdown": "catalog:",
     "typescript": "catalog:",
+    "unthrown": "catalog:",
     "vitest": "catalog:",
     "zod": "catalog:"
+  },
+  "peerDependencies": {
+    "unthrown": "^3.0.0"
   },
   "engines": {
     "node": ">=22.19"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -394,9 +394,6 @@ importers:
       ts-pattern:
         specifier: 'catalog:'
         version: 5.9.0
-      unthrown:
-        specifier: 'catalog:'
-        version: 3.0.0
     devDependencies:
       '@amqp-contract/testing':
         specifier: workspace:*
@@ -434,6 +431,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      unthrown:
+        specifier: 'catalog:'
+        version: 3.0.0
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -489,9 +489,6 @@ importers:
       amqplib:
         specifier: 'catalog:'
         version: 2.0.1
-      unthrown:
-        specifier: 'catalog:'
-        version: 3.0.0
     devDependencies:
       '@amqp-contract/testing':
         specifier: workspace:*
@@ -523,6 +520,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      unthrown:
+        specifier: 'catalog:'
+        version: 3.0.0
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -575,9 +575,6 @@ importers:
       '@standard-schema/spec':
         specifier: 'catalog:'
         version: 1.1.0
-      unthrown:
-        specifier: 'catalog:'
-        version: 3.0.0
     devDependencies:
       '@amqp-contract/testing':
         specifier: workspace:*
@@ -615,6 +612,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      unthrown:
+        specifier: 'catalog:'
+        version: 3.0.0
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)


### PR DESCRIPTION
Moves `unthrown` from a regular dependency to a **peer dependency** (`^3.0.0`) in `@amqp-contract/core`, `@amqp-contract/client`, and `@amqp-contract/worker`.

## Why
- `unthrown`'s types are part of the public API (`AsyncResult`, `Result`, `HandlerError`) — all three packages' built `.d.mts` import from `unthrown`.
- unthrown types are **nominal**: `Result`/`Defect` key on a `declare const DEFECT: unique symbol`. Two copies at different versions — or even the same version in a non-deduped install — produce distinct symbols and do **not** unify, surfacing as `Type 'AsyncResult<…>' is not assignable… two different types with this name exist but are unrelated`.
- The README already instructs consumers to install `unthrown` directly, which is the definitional signature of a peer dependency. There's in-repo precedent: `@opentelemetry/api` is peer-dep'd in core for the same shared-singleton reason.

A peer dep forces a single shared copy the consumer controls.

## Change
Per package (core, client, worker):
- Remove `unthrown` from `dependencies`.
- Add `"unthrown": "^3.0.0"` to `peerDependencies` (range, matching the existing `@opentelemetry/api` peer-dep style).
- Keep `"unthrown": "catalog:"` in `devDependencies` so each package still builds and tests against it.

Semver: shipped as **minor**. npm 7+/pnpm 8+ auto-install peers, and the docs already tell people to install `unthrown`, so in practice adopters are unaffected; the changeset notes the action for stricter setups.

## Verification
- `pnpm install` succeeds; `unthrown@3.0.0` still resolves for all three packages.
- `pnpm build`, `pnpm typecheck`, `pnpm test` all pass.
- Changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)