### PR TITLE
feat: migrate to unthrown 4 (peer dependency)

### DIFF
--- a/.changeset/unthrown-4-peer-dependency.md
+++ b/.changeset/unthrown-4-peer-dependency.md
@@ -1,0 +1,22 @@
+---
+"@amqp-contract/client": minor
+"@amqp-contract/worker": minor
+"@amqp-contract/core": minor
+---
+
+Adopt [`unthrown`](https://github.com/btravstack/unthrown) 4, and make it a **peer dependency** (`^4.0.0`) of `@amqp-contract/core`, `@amqp-contract/client`, and `@amqp-contract/worker`.
+
+`unthrown`'s types (`AsyncResult`, `Result`, `HandlerError`) are part of the public API and are nominal (keyed on a `unique symbol`), so two copies do not unify — as a peer dependency a single copy is shared between your app and amqp-contract.
+
+**Action required:** ensure `unthrown@^4` is a direct dependency of your project. Package managers that auto-install peers (npm 7+, pnpm 8+) handle this; otherwise:
+
+```bash
+pnpm add unthrown@^4
+```
+
+unthrown 4 also changes two things you may rely on when consuming results:
+
+- **`.unwrap()` is type-gated** — it compiles only on an infallible result (`E = never`). `(await client.publish(...)).unwrap()` and `(await TypedAmqpClient.create(...)).unwrap()` no longer compile. Use `.match()`, or clear the error channel first with `.recover((e) => { throw e })` before `.unwrap()`.
+- **`TaggedError` reserves `message`** — only relevant if you subclass `TaggedError` yourself; move the message out of the payload into `override message = "…"`.
+
+See the [Upgrading guide](https://btravstack.github.io/amqp-contract/guide/upgrading) for details. amqp-contract's own public API shape is unchanged.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ const worker = (
       },
     },
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -91,22 +93,36 @@ const client = (
   await TypedAmqpClient.create({
     contract,
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
-// publish() returns an AsyncResult instead of throwing — awaiting it yields
-// a Result to unwrap() (or .match()) so failures surface. See the error
-// model guide for details.
+// publish() returns an AsyncResult instead of throwing — awaiting it yields a
+// Result. unthrown 4 gates unwrap() to infallible results, so clear the error
+// channel with recover() first (or use .match()). See the error model guide.
 (
-  await client.publish("orderCreated", {
-    orderId: "ORD-123", // ✅ TypeScript knows!
-    amount: 99.99,
-  })
+  await client
+    .publish("orderCreated", {
+      orderId: "ORD-123", // ✅ TypeScript knows!
+      amount: 99.99,
+    })
+    .recover((e) => {
+      throw e;
+    })
 ).unwrap();
 
 // 7. Clean up
-(await client.close()).unwrap();
-(await worker.close()).unwrap();
+(
+  await client.close().recover((e) => {
+    throw e;
+  })
+).unwrap();
+(
+  await worker.close().recover((e) => {
+    throw e;
+  })
+).unwrap();
 ```
 
 ▶ For the full runnable version (including the RabbitMQ Docker command), follow the [5-minute quick start](https://btravstack.github.io/amqp-contract/guide/getting-started).

--- a/README.md
+++ b/README.md
@@ -73,56 +73,46 @@ const contract = defineContract({
 });
 
 // 5. Type-safe consuming with automatic retry (configured at queue level)
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    handlers: {
-      processOrder: ({ payload }) => {
-        console.log(payload.orderId); // ✅ TypeScript knows!
-        return Ok(undefined).toAsync();
-      },
+const worker = await TypedAmqpWorker.create({
+  contract,
+  handlers: {
+    processOrder: ({ payload }) => {
+      console.log(payload.orderId); // ✅ TypeScript knows!
+      return Ok(undefined).toAsync();
     },
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+  },
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
 // 6. Type-safe publishing with validation
-const client = (
-  await TypedAmqpClient.create({
-    contract,
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const client = await TypedAmqpClient.create({
+  contract,
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
 // publish() returns an AsyncResult instead of throwing — awaiting it yields a
 // Result. unthrown 4 gates unwrap() to infallible results, so clear the error
 // channel with recover() first (or use .match()). See the error model guide.
-(
-  await client
-    .publish("orderCreated", {
-      orderId: "ORD-123", // ✅ TypeScript knows!
-      amount: 99.99,
-    })
-    .recover((e) => {
-      throw e;
-    })
-).unwrap();
+await client
+  .publish("orderCreated", {
+    orderId: "ORD-123", // ✅ TypeScript knows!
+    amount: 99.99,
+  })
+  .unwrapOrElse((e) => {
+    throw e;
+  });
 
 // 7. Clean up
-(
-  await client.close().recover((e) => {
-    throw e;
-  })
-).unwrap();
-(
-  await worker.close().recover((e) => {
-    throw e;
-  })
-).unwrap();
+await client.close().unwrapOrElse((e) => {
+  throw e;
+});
+await worker.close().unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 ▶ For the full runnable version (including the RabbitMQ Docker command), follow the [5-minute quick start](https://btravstack.github.io/amqp-contract/guide/getting-started).

--- a/docs/TERMINOLOGY.md
+++ b/docs/TERMINOLOGY.md
@@ -82,23 +82,27 @@ When implementing the contract, we use our terms:
 import { Ok } from "unthrown";
 
 // Client = runtime publisher
-const client = (await TypedAmqpClient.create({ contract, urls })).unwrap();
+const client = await TypedAmqpClient.create({ contract, urls }).unwrapOrElse((e) => {
+  throw e;
+});
 
-await client.publish("orderCreated", message);
+await client.publish("orderCreated", message).unwrapOrElse((e) => {
+  throw e;
+});
 
 // Worker = runtime consumer
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    handlers: {
-      processOrder: ({ payload }) => {
-        // Handle message
-        return Ok(undefined).toAsync();
-      },
+const worker = await TypedAmqpWorker.create({
+  contract,
+  handlers: {
+    processOrder: ({ payload }) => {
+      // Handle message
+      return Ok(undefined).toAsync();
     },
-    urls,
-  })
-).unwrap();
+  },
+  urls,
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 These terms (`TypedAmqpClient`, `TypedAmqpWorker`) describe the **runtime components** that implement the contract.
@@ -154,17 +158,21 @@ await publisher.publish(exchange, routingKey, message);
 const consumer = await createConsumer(queue, handler);
 
 // amqp-contract uses:
-const client = (await TypedAmqpClient.create({ contract, urls })).unwrap();
+const client = await TypedAmqpClient.create({ contract, urls }).unwrapOrElse((e) => {
+  throw e;
+});
 
-await client.publish("orderCreated", message);
+await client.publish("orderCreated", message).unwrapOrElse((e) => {
+  throw e;
+});
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    handlers: { processOrder: handler },
-    urls,
-  })
-).unwrap();
+const worker = await TypedAmqpWorker.create({
+  contract,
+  handlers: { processOrder: handler },
+  urls,
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 The functionality is identical; only the naming differs.

--- a/docs/examples/basic-order-processing.md
+++ b/docs/examples/basic-order-processing.md
@@ -310,6 +310,8 @@ const client = (
   await TypedAmqpClient.create({
     contract: orderContract,
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -387,6 +389,8 @@ const worker = (
       },
     },
     connection,
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```

--- a/docs/examples/basic-order-processing.md
+++ b/docs/examples/basic-order-processing.md
@@ -306,14 +306,12 @@ The client is in a separate package (`@amqp-contract-examples/basic-order-proces
 import { TypedAmqpClient } from "@amqp-contract/client";
 import { orderContract } from "@amqp-contract-examples/basic-order-processing-contract";
 
-const client = (
-  await TypedAmqpClient.create({
-    contract: orderContract,
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const client = await TypedAmqpClient.create({
+  contract: orderContract,
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
 // Publish new order with explicit error handling
 const result = await client.publish("orderCreated", {
@@ -362,37 +360,35 @@ import { orderContract } from "@amqp-contract-examples/basic-order-processing-co
 
 const connection = await connect("amqp://localhost");
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract: orderContract,
-    handlers: {
-      processOrder: ({ payload }) => {
-        console.log(`[PROCESSING] Order ${payload.orderId}`);
-        console.log(`  Customer: ${payload.customerId}`);
-        console.log(`  Total: $${payload.totalAmount}`);
-        return Ok(undefined).toAsync();
-      },
-
-      notifyOrder: ({ payload }) => {
-        console.log(`[NOTIFICATION] Order ${payload.orderId} event`);
-        return Ok(undefined).toAsync();
-      },
-
-      shipOrder: ({ payload }) => {
-        console.log(`[SHIPPING] Order ${payload.orderId} - ${payload.status}`);
-        return Ok(undefined).toAsync();
-      },
-
-      handleUrgentOrder: ({ payload }) => {
-        console.log(`[URGENT] Order ${payload.orderId} - ${payload.status}`);
-        return Ok(undefined).toAsync();
-      },
+const worker = await TypedAmqpWorker.create({
+  contract: orderContract,
+  handlers: {
+    processOrder: ({ payload }) => {
+      console.log(`[PROCESSING] Order ${payload.orderId}`);
+      console.log(`  Customer: ${payload.customerId}`);
+      console.log(`  Total: $${payload.totalAmount}`);
+      return Ok(undefined).toAsync();
     },
-    connection,
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+
+    notifyOrder: ({ payload }) => {
+      console.log(`[NOTIFICATION] Order ${payload.orderId} event`);
+      return Ok(undefined).toAsync();
+    },
+
+    shipOrder: ({ payload }) => {
+      console.log(`[SHIPPING] Order ${payload.orderId} - ${payload.status}`);
+      return Ok(undefined).toAsync();
+    },
+
+    handleUrgentOrder: ({ payload }) => {
+      console.log(`[URGENT] Order ${payload.orderId} - ${payload.status}`);
+      return Ok(undefined).toAsync();
+    },
+  },
+  connection,
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 ## Message Routing Table

--- a/docs/examples/command-pattern.md
+++ b/docs/examples/command-pattern.md
@@ -68,27 +68,23 @@ import { TypedAmqpClient } from "@amqp-contract/client";
 import { contract } from "@org/payment-contract";
 import { randomUUID } from "node:crypto";
 
-const client = (
-  await TypedAmqpClient.create({
-    contract,
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const client = await TypedAmqpClient.create({
+  contract,
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
-(
-  await client
-    .publish("chargeCustomer", {
-      customerId: "cust_123",
-      amountCents: 4_999,
-      currency: "USD",
-      idempotencyKey: randomUUID(),
-    })
-    .recover((e) => {
-      throw e;
-    })
-).unwrap();
+await client
+  .publish("chargeCustomer", {
+    customerId: "cust_123",
+    amountCents: 4_999,
+    currency: "USD",
+    idempotencyKey: randomUUID(),
+  })
+  .unwrapOrElse((e) => {
+    throw e;
+  });
 ```
 
 A `subscriptions-service`, `refunds-service`, or any other publisher does the same — they all use `chargeCustomer`. Routing-key dispatch is handled by the contract; callers never name `payments.charge` themselves.
@@ -127,17 +123,15 @@ const chargeHandler = defineHandler(contract, "chargeCustomer", ({ payload }) =>
   ).map(() => undefined),
 );
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    handlers: {
-      chargeCustomer: [chargeHandler, { prefetch: 5 }],
-    },
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const worker = await TypedAmqpWorker.create({
+  contract,
+  handlers: {
+    chargeCustomer: [chargeHandler, { prefetch: 5 }],
+  },
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
 process.on("SIGINT", async () => {
   await worker.close();

--- a/docs/examples/command-pattern.md
+++ b/docs/examples/command-pattern.md
@@ -72,6 +72,8 @@ const client = (
   await TypedAmqpClient.create({
     contract,
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -126,6 +128,8 @@ const worker = (
       chargeCustomer: [chargeHandler, { prefetch: 5 }],
     },
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 

--- a/docs/examples/command-pattern.md
+++ b/docs/examples/command-pattern.md
@@ -77,12 +77,18 @@ const client = (
   })
 ).unwrap();
 
-await client.publish("chargeCustomer", {
-  customerId: "cust_123",
-  amountCents: 4_999,
-  currency: "USD",
-  idempotencyKey: randomUUID(),
-});
+(
+  await client
+    .publish("chargeCustomer", {
+      customerId: "cust_123",
+      amountCents: 4_999,
+      currency: "USD",
+      idempotencyKey: randomUUID(),
+    })
+    .recover((e) => {
+      throw e;
+    })
+).unwrap();
 ```
 
 A `subscriptions-service`, `refunds-service`, or any other publisher does the same — they all use `chargeCustomer`. Routing-key dispatch is handled by the contract; callers never name `payments.charge` themselves.

--- a/docs/guide/channel-configuration.md
+++ b/docs/guide/channel-configuration.md
@@ -327,7 +327,11 @@ describe("Channel Configuration", () => {
     const connectResult = await client.waitForConnect();
     expect(connectResult.isOk()).toBe(true);
 
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 });
 ```
@@ -414,7 +418,7 @@ const client = new AmqpClient(contract, {
 
 **Solutions:**
 
-1. Ensure channel is connected: `(await client.waitForConnect()).unwrap()` — `await` alone returns a `Result` and does not throw on failure
+1. Ensure channel is connected: check `(await client.waitForConnect()).isOk()` — `await` alone returns a `Result` and does not throw on failure
 2. Check for errors in setup function (they may cause silent failures)
 3. Verify setup function signature is correct
 

--- a/docs/guide/channel-configuration.md
+++ b/docs/guide/channel-configuration.md
@@ -327,11 +327,9 @@ describe("Channel Configuration", () => {
     const connectResult = await client.waitForConnect();
     expect(connectResult.isOk()).toBe(true);
 
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 });
 ```

--- a/docs/guide/client-usage.md
+++ b/docs/guide/client-usage.md
@@ -4,20 +4,18 @@ Learn how to use the type-safe AMQP client to publish messages.
 
 ## Creating a Client
 
-Create a type-safe client from your contract. `TypedAmqpClient.create(...)` returns `AsyncResult<TypedAmqpClient, TechnicalError>` — `await` yields a `Result` you pattern-match with `.match()`, or (to throw on failure) clear the error channel with `.recover((e) => { throw e })` before `.unwrap()`, since [unthrown 4 gates `.unwrap()`](./error-model.md#getting-the-value-out) to infallible results:
+Create a type-safe client from your contract. `TypedAmqpClient.create(...)` returns `AsyncResult<TypedAmqpClient, TechnicalError>` — `await` yields a `Result` you pattern-match with `.match()`, or (to throw on failure) unwrap with `.unwrapOrElse((e) => { throw e })`, since [unthrown 4 gates `.unwrap()`](./error-model.md#getting-the-value-out) to infallible results:
 
 ```typescript
 import { TypedAmqpClient } from "@amqp-contract/client";
 import { contract } from "./contract";
 
-const client = (
-  await TypedAmqpClient.create({
-    contract,
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const client = await TypedAmqpClient.create({
+  contract,
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 ### Default Publish Options
@@ -25,18 +23,16 @@ const client = (
 Configure default publish options that apply to all messages published by the client:
 
 ```typescript
-const client = (
-  await TypedAmqpClient.create({
-    contract,
-    urls: ["amqp://localhost"],
-    defaultPublishOptions: {
-      priority: 5,
-      headers: { "x-app-version": "1.0.0" },
-    },
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const client = await TypedAmqpClient.create({
+  contract,
+  urls: ["amqp://localhost"],
+  defaultPublishOptions: {
+    priority: 5,
+    headers: { "x-app-version": "1.0.0" },
+  },
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 Default publish options can be overridden by options passed to individual `publish` calls.
@@ -205,14 +201,12 @@ async function main() {
   let client;
 
   try {
-    client = (
-      await TypedAmqpClient.create({
-        contract,
-        urls: ["amqp://localhost"],
-      }).recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    client = await TypedAmqpClient.create({
+      contract,
+      urls: ["amqp://localhost"],
+    }).unwrapOrElse((e) => {
+      throw e;
+    });
 
     const result = await client.publish("orderCreated", {
       orderId: "ORD-123",

--- a/docs/guide/client-usage.md
+++ b/docs/guide/client-usage.md
@@ -4,7 +4,7 @@ Learn how to use the type-safe AMQP client to publish messages.
 
 ## Creating a Client
 
-Create a type-safe client from your contract. `TypedAmqpClient.create(...)` returns `AsyncResult<TypedAmqpClient, TechnicalError>` — `await` yields a `Result`, which you unwrap (`.unwrap()`) or pattern-match before using:
+Create a type-safe client from your contract. `TypedAmqpClient.create(...)` returns `AsyncResult<TypedAmqpClient, TechnicalError>` — `await` yields a `Result` you pattern-match with `.match()`, or (to throw on failure) clear the error channel with `.recover((e) => { throw e })` before `.unwrap()`, since [unthrown 4 gates `.unwrap()`](./error-model.md#getting-the-value-out) to infallible results:
 
 ```typescript
 import { TypedAmqpClient } from "@amqp-contract/client";
@@ -14,6 +14,8 @@ const client = (
   await TypedAmqpClient.create({
     contract,
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```
@@ -31,6 +33,8 @@ const client = (
       priority: 5,
       headers: { "x-app-version": "1.0.0" },
     },
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```
@@ -205,6 +209,8 @@ async function main() {
       await TypedAmqpClient.create({
         contract,
         urls: ["amqp://localhost"],
+      }).recover((e) => {
+        throw e;
       })
     ).unwrap();
 

--- a/docs/guide/comparison.md
+++ b/docs/guide/comparison.md
@@ -66,14 +66,12 @@ import { TypedAmqpClient } from "@amqp-contract/client";
 import { contract } from "./contract.js";
 
 // Create client once
-const client = (
-  await TypedAmqpClient.create({
-    contract, // Resources declared automatically!
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const client = await TypedAmqpClient.create({
+  contract, // Resources declared automatically!
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
 // Publish - fully typed and validated!
 const result = await client.publish("orderCreated", {
@@ -126,23 +124,21 @@ import { TypedAmqpWorker } from "@amqp-contract/worker";
 import { fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 import { contract } from "./contract.js";
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    handlers: {
-      processOrder: ({ payload }) => {
-        // ✅ Payload is fully typed!
-        console.log(payload.orderId); // ✅ Full autocomplete!
-        console.log(payload.amount); // ✅ Type-safe!
-        // ✅ Automatic validation - invalid messages rejected!
-        return Ok(undefined).toAsync();
-      }, // ✅ Auto-acknowledgment on success!
-    },
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const worker = await TypedAmqpWorker.create({
+  contract,
+  handlers: {
+    processOrder: ({ payload }) => {
+      // ✅ Payload is fully typed!
+      console.log(payload.orderId); // ✅ Full autocomplete!
+      console.log(payload.amount); // ✅ Type-safe!
+      // ✅ Automatic validation - invalid messages rejected!
+      return Ok(undefined).toAsync();
+    }, // ✅ Auto-acknowledgment on success!
+  },
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 :::

--- a/docs/guide/comparison.md
+++ b/docs/guide/comparison.md
@@ -70,6 +70,8 @@ const client = (
   await TypedAmqpClient.create({
     contract, // Resources declared automatically!
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -137,6 +139,8 @@ const worker = (
       }, // ✅ Auto-acknowledgment on success!
     },
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```

--- a/docs/guide/connection-sharing.md
+++ b/docs/guide/connection-sharing.md
@@ -31,47 +31,43 @@ import { TypedAmqpWorker } from "@amqp-contract/worker";
 import { contract } from "./contract";
 
 // 1. Create client - automatically creates connection
-const client = (
-  await TypedAmqpClient.create({
-    contract,
-    urls: ["amqp://localhost"], // ← Just provide URLs
-    connectionOptions: {
-      heartbeatIntervalInSeconds: 30,
-    },
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const client = await TypedAmqpClient.create({
+  contract,
+  urls: ["amqp://localhost"], // ← Just provide URLs
+  connectionOptions: {
+    heartbeatIntervalInSeconds: 30,
+  },
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
 // 2. Create worker - automatically reuses the same connection!
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    urls: ["amqp://localhost"], // ← Same URLs = automatic sharing
-    handlers: {
-      processOrder: ({ payload }) => {
-        console.log("Processing order:", payload.orderId);
+const worker = await TypedAmqpWorker.create({
+  contract,
+  urls: ["amqp://localhost"], // ← Same URLs = automatic sharing
+  handlers: {
+    processOrder: ({ payload }) => {
+      console.log("Processing order:", payload.orderId);
 
-        // Can publish from within consumer — `publish` already returns a
-        // AsyncResult, so we chain its combinators directly.
-        return client
-          .publish("orderProcessed", {
-            orderId: payload.orderId,
-            status: "completed",
-          })
-          .map(() => {
-            console.log("Order processed event published");
-          })
-          .mapErr((error) => {
-            console.error("Failed to publish:", error);
-            return new RetryableError("Failed to publish", error);
-          });
-      },
+      // Can publish from within consumer — `publish` already returns a
+      // AsyncResult, so we chain its combinators directly.
+      return client
+        .publish("orderProcessed", {
+          orderId: payload.orderId,
+          status: "completed",
+        })
+        .map(() => {
+          console.log("Order processed event published");
+        })
+        .mapErr((error) => {
+          console.error("Failed to publish:", error);
+          return new RetryableError("Failed to publish", error);
+        });
     },
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+  },
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
 // Both client and worker automatically share a single connection! ✅
 // Result: 1 connection, 2 channels
@@ -119,26 +115,22 @@ When you create multiple clients or workers with the same URLs and connection op
 
 ```typescript
 // ✅ Automatically shares a single connection
-const client = (
-  await TypedAmqpClient.create({
-    contract,
-    urls: ["amqp://localhost"], // ← URLs match
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const client = await TypedAmqpClient.create({
+  contract,
+  urls: ["amqp://localhost"], // ← URLs match
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    urls: ["amqp://localhost"], // ← URLs match = shared connection
-    handlers: {
-      /* ... */
-    },
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const worker = await TypedAmqpWorker.create({
+  contract,
+  urls: ["amqp://localhost"], // ← URLs match = shared connection
+  handlers: {
+    /* ... */
+  },
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
 // Result: 1 connection, 2 channels ✅
 // - Less resource usage
@@ -157,47 +149,39 @@ You can create multiple clients and workers - they automatically share connectio
 
 ```typescript
 // All automatically share the same connection
-const orderClient = (
-  await TypedAmqpClient.create({
-    contract: orderContract,
-    urls: ["amqp://localhost"], // ← Same URLs
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const orderClient = await TypedAmqpClient.create({
+  contract: orderContract,
+  urls: ["amqp://localhost"], // ← Same URLs
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
-const notificationClient = (
-  await TypedAmqpClient.create({
-    contract: notificationContract,
-    urls: ["amqp://localhost"], // ← Same URLs
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const notificationClient = await TypedAmqpClient.create({
+  contract: notificationContract,
+  urls: ["amqp://localhost"], // ← Same URLs
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
-const orderWorker = (
-  await TypedAmqpWorker.create({
-    contract: orderContract,
-    urls: ["amqp://localhost"], // ← Same URLs
-    handlers: {
-      /* ... */
-    },
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const orderWorker = await TypedAmqpWorker.create({
+  contract: orderContract,
+  urls: ["amqp://localhost"], // ← Same URLs
+  handlers: {
+    /* ... */
+  },
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
-const notificationWorker = (
-  await TypedAmqpWorker.create({
-    contract: notificationContract,
-    urls: ["amqp://localhost"], // ← Same URLs
-    handlers: {
-      /* ... */
-    },
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const notificationWorker = await TypedAmqpWorker.create({
+  contract: notificationContract,
+  urls: ["amqp://localhost"], // ← Same URLs
+  handlers: {
+    /* ... */
+  },
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
 // All automatically share one connection with 4 separate channels
 ```
@@ -208,23 +192,19 @@ If you need separate connections (e.g., for different RabbitMQ clusters), just u
 
 ```typescript
 // These will have separate connections
-const mainClient = (
-  await TypedAmqpClient.create({
-    contract,
-    urls: ["amqp://main-cluster"], // ← Different URLs
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const mainClient = await TypedAmqpClient.create({
+  contract,
+  urls: ["amqp://main-cluster"], // ← Different URLs
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
-const analyticsClient = (
-  await TypedAmqpClient.create({
-    contract,
-    urls: ["amqp://analytics-cluster"], // ← Different URLs
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const analyticsClient = await TypedAmqpClient.create({
+  contract,
+  urls: ["amqp://analytics-cluster"], // ← Different URLs
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
 // Result: 2 separate connections (one per cluster)
 ```
@@ -243,50 +223,42 @@ For maximum sharing benefits, use the same `connectionOptions` across all client
 // ✅ Best: Use consistent options (or omit for defaults)
 const connectionOptions = { heartbeatIntervalInSeconds: 30 };
 
-const client = (
-  await TypedAmqpClient.create({
-    contract,
-    urls: ["amqp://localhost"],
-    connectionOptions, // ← Same options
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const client = await TypedAmqpClient.create({
+  contract,
+  urls: ["amqp://localhost"],
+  connectionOptions, // ← Same options
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    urls: ["amqp://localhost"],
-    connectionOptions, // ← Same options = connection shared
-    handlers: {
-      /* ... */
-    },
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const worker = await TypedAmqpWorker.create({
+  contract,
+  urls: ["amqp://localhost"],
+  connectionOptions, // ← Same options = connection shared
+  handlers: {
+    /* ... */
+  },
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
 // ✅ Also good: Omit options to use defaults
-const client = (
-  await TypedAmqpClient.create({
-    contract,
-    urls: ["amqp://localhost"], // ← No options
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const client = await TypedAmqpClient.create({
+  contract,
+  urls: ["amqp://localhost"], // ← No options
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    urls: ["amqp://localhost"], // ← No options = connection shared
-    handlers: {
-      /* ... */
-    },
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const worker = await TypedAmqpWorker.create({
+  contract,
+  urls: ["amqp://localhost"], // ← No options = connection shared
+  handlers: {
+    /* ... */
+  },
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 #### 2. **Extract Shared Configuration**
@@ -304,26 +276,22 @@ const AMQP_CONFIG = {
 } as const;
 
 // All components use the same configuration
-const client = (
-  await TypedAmqpClient.create({
-    contract: orderContract,
-    ...AMQP_CONFIG,
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const client = await TypedAmqpClient.create({
+  contract: orderContract,
+  ...AMQP_CONFIG,
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract: orderContract,
-    ...AMQP_CONFIG,
-    handlers: {
-      /* ... */
-    },
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const worker = await TypedAmqpWorker.create({
+  contract: orderContract,
+  ...AMQP_CONFIG,
+  handlers: {
+    /* ... */
+  },
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 #### 3. **Understand Configuration Conflicts**
@@ -332,28 +300,24 @@ Different `connectionOptions` create separate connections:
 
 ```typescript
 // ⚠️ Warning: Different options = separate connections (may be intentional)
-const client = (
-  await TypedAmqpClient.create({
-    contract,
-    urls: ["amqp://localhost"],
-    connectionOptions: { heartbeatIntervalInSeconds: 30 }, // ← Options A
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const client = await TypedAmqpClient.create({
+  contract,
+  urls: ["amqp://localhost"],
+  connectionOptions: { heartbeatIntervalInSeconds: 30 }, // ← Options A
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    urls: ["amqp://localhost"],
-    connectionOptions: { heartbeatIntervalInSeconds: 60 }, // ← Options B (different)
-    handlers: {
-      /* ... */
-    },
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const worker = await TypedAmqpWorker.create({
+  contract,
+  urls: ["amqp://localhost"],
+  connectionOptions: { heartbeatIntervalInSeconds: 60 }, // ← Options B (different)
+  handlers: {
+    /* ... */
+  },
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
 // Result: 2 separate connections (different configurations)
 // This may be intentional if you need different heartbeat settings
@@ -425,26 +389,22 @@ Connection sharing is **completely backward compatible** and happens automatical
 
 ```typescript
 // Existing code automatically benefits from connection sharing
-const client = (
-  await TypedAmqpClient.create({
-    contract,
-    urls: ["amqp://localhost"], // ← Connection automatically created
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const client = await TypedAmqpClient.create({
+  contract,
+  urls: ["amqp://localhost"], // ← Connection automatically created
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    urls: ["amqp://localhost"], // ← Same URLs = connection automatically shared
-    handlers: {
-      /* ... */
-    },
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const worker = await TypedAmqpWorker.create({
+  contract,
+  urls: ["amqp://localhost"], // ← Same URLs = connection automatically shared
+  handlers: {
+    /* ... */
+  },
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
 // No code changes needed - connection sharing just works!
 // Result: 1 connection, 2 channels (automatically managed)
@@ -460,98 +420,82 @@ Connection sharing is automatic when URLs and connection options match. If you s
 
    ```typescript
    // ❌ Different URLs = different connections
-   const client = (
-     await TypedAmqpClient.create({
-       contract,
-       urls: ["amqp://localhost:5672"],
-     }).recover((e) => {
-       throw e;
-     })
-   ).unwrap();
-   const worker = (
-     await TypedAmqpWorker.create({
-       contract,
-       urls: ["amqp://localhost"], // Different URL!
-       handlers: {
-         /* ... */
-       },
-     }).recover((e) => {
-       throw e;
-     })
-   ).unwrap();
+   const client = await TypedAmqpClient.create({
+     contract,
+     urls: ["amqp://localhost:5672"],
+   }).unwrapOrElse((e) => {
+     throw e;
+   });
+   const worker = await TypedAmqpWorker.create({
+     contract,
+     urls: ["amqp://localhost"], // Different URL!
+     handlers: {
+       /* ... */
+     },
+   }).unwrapOrElse((e) => {
+     throw e;
+   });
 
    // ✅ Same URLs = shared connection
    const urls = ["amqp://localhost"];
-   const client = (
-     await TypedAmqpClient.create({
-       contract,
-       urls,
-     }).recover((e) => {
-       throw e;
-     })
-   ).unwrap();
-   const worker = (
-     await TypedAmqpWorker.create({
-       contract,
-       urls, // Same URL reference
-       handlers: {
-         /* ... */
-       },
-     }).recover((e) => {
-       throw e;
-     })
-   ).unwrap();
+   const client = await TypedAmqpClient.create({
+     contract,
+     urls,
+   }).unwrapOrElse((e) => {
+     throw e;
+   });
+   const worker = await TypedAmqpWorker.create({
+     contract,
+     urls, // Same URL reference
+     handlers: {
+       /* ... */
+     },
+   }).unwrapOrElse((e) => {
+     throw e;
+   });
    ```
 
 2. **Check connection options match**:
 
    ```typescript
    // ❌ Different options = different connections
-   const client = (
-     await TypedAmqpClient.create({
-       contract,
-       urls: ["amqp://localhost"],
-       connectionOptions: { heartbeatIntervalInSeconds: 30 },
-     }).recover((e) => {
-       throw e;
-     })
-   ).unwrap();
-   const worker = (
-     await TypedAmqpWorker.create({
-       contract,
-       urls: ["amqp://localhost"],
-       connectionOptions: { heartbeatIntervalInSeconds: 60 }, // Different!
-       handlers: {
-         /* ... */
-       },
-     }).recover((e) => {
-       throw e;
-     })
-   ).unwrap();
+   const client = await TypedAmqpClient.create({
+     contract,
+     urls: ["amqp://localhost"],
+     connectionOptions: { heartbeatIntervalInSeconds: 30 },
+   }).unwrapOrElse((e) => {
+     throw e;
+   });
+   const worker = await TypedAmqpWorker.create({
+     contract,
+     urls: ["amqp://localhost"],
+     connectionOptions: { heartbeatIntervalInSeconds: 60 }, // Different!
+     handlers: {
+       /* ... */
+     },
+   }).unwrapOrElse((e) => {
+     throw e;
+   });
 
    // ✅ Same options = shared connection
    const connectionOptions = { heartbeatIntervalInSeconds: 30 };
-   const client = (
-     await TypedAmqpClient.create({
-       contract,
-       urls: ["amqp://localhost"],
-       connectionOptions,
-     }).recover((e) => {
-       throw e;
-     })
-   ).unwrap();
-   const worker = (
-     await TypedAmqpWorker.create({
-       contract,
-       urls: ["amqp://localhost"],
-       connectionOptions, // Same options reference
-       handlers: {
-         /* ... */
-       },
-     }).recover((e) => {
-       throw e;
-     })
-   ).unwrap();
+   const client = await TypedAmqpClient.create({
+     contract,
+     urls: ["amqp://localhost"],
+     connectionOptions,
+   }).unwrapOrElse((e) => {
+     throw e;
+   });
+   const worker = await TypedAmqpWorker.create({
+     contract,
+     urls: ["amqp://localhost"],
+     connectionOptions, // Same options reference
+     handlers: {
+       /* ... */
+     },
+   }).unwrapOrElse((e) => {
+     throw e;
+   });
    ```
 
 ### Cleanup in tests

--- a/docs/guide/connection-sharing.md
+++ b/docs/guide/connection-sharing.md
@@ -38,6 +38,8 @@ const client = (
     connectionOptions: {
       heartbeatIntervalInSeconds: 30,
     },
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -66,6 +68,8 @@ const worker = (
           });
       },
     },
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -119,6 +123,8 @@ const client = (
   await TypedAmqpClient.create({
     contract,
     urls: ["amqp://localhost"], // ← URLs match
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -129,6 +135,8 @@ const worker = (
     handlers: {
       /* ... */
     },
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -153,6 +161,8 @@ const orderClient = (
   await TypedAmqpClient.create({
     contract: orderContract,
     urls: ["amqp://localhost"], // ← Same URLs
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -160,6 +170,8 @@ const notificationClient = (
   await TypedAmqpClient.create({
     contract: notificationContract,
     urls: ["amqp://localhost"], // ← Same URLs
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -170,6 +182,8 @@ const orderWorker = (
     handlers: {
       /* ... */
     },
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -180,6 +194,8 @@ const notificationWorker = (
     handlers: {
       /* ... */
     },
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -196,6 +212,8 @@ const mainClient = (
   await TypedAmqpClient.create({
     contract,
     urls: ["amqp://main-cluster"], // ← Different URLs
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -203,6 +221,8 @@ const analyticsClient = (
   await TypedAmqpClient.create({
     contract,
     urls: ["amqp://analytics-cluster"], // ← Different URLs
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -228,6 +248,8 @@ const client = (
     contract,
     urls: ["amqp://localhost"],
     connectionOptions, // ← Same options
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -239,6 +261,8 @@ const worker = (
     handlers: {
       /* ... */
     },
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -247,6 +271,8 @@ const client = (
   await TypedAmqpClient.create({
     contract,
     urls: ["amqp://localhost"], // ← No options
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -257,6 +283,8 @@ const worker = (
     handlers: {
       /* ... */
     },
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```
@@ -280,6 +308,8 @@ const client = (
   await TypedAmqpClient.create({
     contract: orderContract,
     ...AMQP_CONFIG,
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -290,6 +320,8 @@ const worker = (
     handlers: {
       /* ... */
     },
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```
@@ -305,6 +337,8 @@ const client = (
     contract,
     urls: ["amqp://localhost"],
     connectionOptions: { heartbeatIntervalInSeconds: 30 }, // ← Options A
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -316,6 +350,8 @@ const worker = (
     handlers: {
       /* ... */
     },
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -393,6 +429,8 @@ const client = (
   await TypedAmqpClient.create({
     contract,
     urls: ["amqp://localhost"], // ← Connection automatically created
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -403,6 +441,8 @@ const worker = (
     handlers: {
       /* ... */
     },
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -424,6 +464,8 @@ Connection sharing is automatic when URLs and connection options match. If you s
      await TypedAmqpClient.create({
        contract,
        urls: ["amqp://localhost:5672"],
+     }).recover((e) => {
+       throw e;
      })
    ).unwrap();
    const worker = (
@@ -433,6 +475,8 @@ Connection sharing is automatic when URLs and connection options match. If you s
        handlers: {
          /* ... */
        },
+     }).recover((e) => {
+       throw e;
      })
    ).unwrap();
 
@@ -442,6 +486,8 @@ Connection sharing is automatic when URLs and connection options match. If you s
      await TypedAmqpClient.create({
        contract,
        urls,
+     }).recover((e) => {
+       throw e;
      })
    ).unwrap();
    const worker = (
@@ -451,6 +497,8 @@ Connection sharing is automatic when URLs and connection options match. If you s
        handlers: {
          /* ... */
        },
+     }).recover((e) => {
+       throw e;
      })
    ).unwrap();
    ```
@@ -464,6 +512,8 @@ Connection sharing is automatic when URLs and connection options match. If you s
        contract,
        urls: ["amqp://localhost"],
        connectionOptions: { heartbeatIntervalInSeconds: 30 },
+     }).recover((e) => {
+       throw e;
      })
    ).unwrap();
    const worker = (
@@ -474,6 +524,8 @@ Connection sharing is automatic when URLs and connection options match. If you s
        handlers: {
          /* ... */
        },
+     }).recover((e) => {
+       throw e;
      })
    ).unwrap();
 
@@ -484,6 +536,8 @@ Connection sharing is automatic when URLs and connection options match. If you s
        contract,
        urls: ["amqp://localhost"],
        connectionOptions,
+     }).recover((e) => {
+       throw e;
      })
    ).unwrap();
    const worker = (
@@ -494,6 +548,8 @@ Connection sharing is automatic when URLs and connection options match. If you s
        handlers: {
          /* ... */
        },
+     }).recover((e) => {
+       throw e;
      })
    ).unwrap();
    ```

--- a/docs/guide/core-concepts.md
+++ b/docs/guide/core-concepts.md
@@ -55,14 +55,12 @@ const contract = defineContract({
 });
 
 // 5. Client knows exact types
-const client = (
-  await TypedAmqpClient.create({
-    contract,
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const client = await TypedAmqpClient.create({
+  contract,
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
 const result = await client.publish("orderCreated", {
   orderId: "ORD-123", // ✅ TypeScript knows!

--- a/docs/guide/core-concepts.md
+++ b/docs/guide/core-concepts.md
@@ -59,6 +59,8 @@ const client = (
   await TypedAmqpClient.create({
     contract,
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 

--- a/docs/guide/error-model.md
+++ b/docs/guide/error-model.md
@@ -4,6 +4,23 @@ amqp-contract uses [`unthrown`](https://github.com/btravstack/unthrown)'s `Async
 
 This page lists every error type the library can produce, where it surfaces, and what you should do with it.
 
+## Getting the value out
+
+The safe way to consume a result is `.match({ ok, err, defect })` — it forces you to handle every channel.
+
+`unthrown` 4 makes `.unwrap()` **type-gated**: it compiles only on a result whose error channel is empty (`E = never`), so `Ok(x).unwrap()` works but `(await client.publish(...)).unwrap()` on a fallible result is a compile error. When you genuinely want to throw on failure (a script, a test, an example), clear the error channel first with `recover` and then `unwrap`:
+
+```ts
+// throws on Err (and rethrows a Defect) — the escape hatch, not the default
+const client = (
+  await TypedAmqpClient.create({ contract, urls: ["amqp://localhost"] }).recover((e) => {
+    throw e;
+  })
+).unwrap();
+```
+
+Prefer `.match()` / `.recover()` / `.orElse()` in real code; reach for the `recover`-then-`unwrap` form only where throwing is acceptable.
+
 ## Error hierarchy
 
 ```

--- a/docs/guide/error-model.md
+++ b/docs/guide/error-model.md
@@ -8,18 +8,18 @@ This page lists every error type the library can produce, where it surfaces, and
 
 The safe way to consume a result is `.match({ ok, err, defect })` — it forces you to handle every channel.
 
-`unthrown` 4 makes `.unwrap()` **type-gated**: it compiles only on a result whose error channel is empty (`E = never`), so `Ok(x).unwrap()` works but `(await client.publish(...)).unwrap()` on a fallible result is a compile error. When you genuinely want to throw on failure (a script, a test, an example), clear the error channel first with `recover` and then `unwrap`:
+`unthrown` 4 makes `.unwrap()` **type-gated**: it compiles only on a result whose error channel is empty (`E = never`), so `Ok(x).unwrap()` works but `(await client.publish(...)).unwrap()` on a fallible result is a compile error. When you genuinely want to throw on failure (a script, a test, an example), use `.unwrapOrElse()` — it returns the value on `Ok`, runs your callback on `Err` (throw to surface it), and rethrows a `Defect`'s cause:
 
 ```ts
 // throws on Err (and rethrows a Defect) — the escape hatch, not the default
-const client = (
-  await TypedAmqpClient.create({ contract, urls: ["amqp://localhost"] }).recover((e) => {
+const client = await TypedAmqpClient.create({ contract, urls: ["amqp://localhost"] }).unwrapOrElse(
+  (e) => {
     throw e;
-  })
-).unwrap();
+  },
+);
 ```
 
-Prefer `.match()` / `.recover()` / `.orElse()` in real code; reach for the `recover`-then-`unwrap` form only where throwing is acceptable.
+Prefer `.match()` / `.recover()` / `.orElse()` in real code; reach for the `.unwrapOrElse((e) => { throw e })` form only where throwing is acceptable.
 
 ## Error hierarchy
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -7,7 +7,7 @@ description: Frequently asked questions about amqp-contract, type-safe AMQP/Rabb
 
 ## Why doesn't `client.publish()` throw on failure?
 
-Every fallible operation returns a `Result` / `AsyncResult` (from [`unthrown`](https://github.com/btravstack/unthrown)) instead of throwing — `await client.publish(...)` gives you a `Result` that you `.match()` or chain. (`unthrown` 4 gates `.unwrap()` to infallible results, so to throw on failure you clear the error channel with `.recover((e) => { throw e })` first — see [Getting the value out](/guide/error-model#getting-the-value-out).) This makes failure handling explicit and type-checked rather than an invisible `try`/`catch` obligation. The [Error Model guide](/guide/error-model) explains the full `Ok` / `Err` / `Defect` model.
+Every fallible operation returns a `Result` / `AsyncResult` (from [`unthrown`](https://github.com/btravstack/unthrown)) instead of throwing — `await client.publish(...)` gives you a `Result` that you `.match()` or chain. (`unthrown` 4 gates `.unwrap()` to infallible results, so to throw on failure you unwrap with `.unwrapOrElse((e) => { throw e })` — see [Getting the value out](/guide/error-model#getting-the-value-out).) This makes failure handling explicit and type-checked rather than an invisible `try`/`catch` obligation. The [Error Model guide](/guide/error-model) explains the full `Ok` / `Err` / `Defect` model.
 
 ## Which schema libraries can I use?
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -7,7 +7,7 @@ description: Frequently asked questions about amqp-contract, type-safe AMQP/Rabb
 
 ## Why doesn't `client.publish()` throw on failure?
 
-Every fallible operation returns a `Result` / `AsyncResult` (from [`unthrown`](https://github.com/btravstack/unthrown)) instead of throwing — `await client.publish(...)` gives you a `Result` that you `.unwrap()`, `.match()`, or chain. This makes failure handling explicit and type-checked rather than an invisible `try`/`catch` obligation. The [Error Model guide](/guide/error-model) explains the full `Ok` / `Err` / `Defect` model.
+Every fallible operation returns a `Result` / `AsyncResult` (from [`unthrown`](https://github.com/btravstack/unthrown)) instead of throwing — `await client.publish(...)` gives you a `Result` that you `.match()` or chain. (`unthrown` 4 gates `.unwrap()` to infallible results, so to throw on failure you clear the error channel with `.recover((e) => { throw e })` first — see [Getting the value out](/guide/error-model#getting-the-value-out).) This makes failure handling explicit and type-checked rather than an invisible `try`/`catch` obligation. The [Error Model guide](/guide/error-model) explains the full `Ok` / `Err` / `Defect` model.
 
 ## Which schema libraries can I use?
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -217,6 +217,8 @@ async function main() {
     await TypedAmqpClient.create({
       contract,
       urls: ["amqp://localhost"],
+    }).recover((e) => {
+      throw e;
     })
   ).unwrap();
 
@@ -275,6 +277,8 @@ async function main() {
         },
       },
       urls: ["amqp://localhost"],
+    }).recover((e) => {
+      throw e;
     })
   ).unwrap();
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -213,14 +213,12 @@ async function main() {
   console.log("🚀 Starting publisher...");
 
   // Create client
-  const client = (
-    await TypedAmqpClient.create({
-      contract,
-      urls: ["amqp://localhost"],
-    }).recover((e) => {
-      throw e;
-    })
-  ).unwrap();
+  const client = await TypedAmqpClient.create({
+    contract,
+    urls: ["amqp://localhost"],
+  }).unwrapOrElse((e) => {
+    throw e;
+  });
 
   console.log("✅ Connected to RabbitMQ");
 
@@ -261,26 +259,24 @@ async function main() {
   console.log("⚙️ Starting worker...");
 
   // Create worker with handlers
-  const worker = (
-    await TypedAmqpWorker.create({
-      contract,
-      handlers: {
-        processEmail: ({ payload }) => {
-          // Payload is fully typed!
-          console.log("\n📬 Received email:");
-          console.log(`  To: ${payload.to}`);
-          console.log(`  Subject: ${payload.subject}`);
-          console.log(`  Body: ${payload.body}`);
+  const worker = await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+      processEmail: ({ payload }) => {
+        // Payload is fully typed!
+        console.log("\n📬 Received email:");
+        console.log(`  To: ${payload.to}`);
+        console.log(`  Subject: ${payload.subject}`);
+        console.log(`  Body: ${payload.body}`);
 
-          // Report success — handlers return an AsyncResult, they don't throw
-          return Ok(undefined).toAsync();
-        },
+        // Report success — handlers return an AsyncResult, they don't throw
+        return Ok(undefined).toAsync();
       },
-      urls: ["amqp://localhost"],
-    }).recover((e) => {
-      throw e;
-    })
-  ).unwrap();
+    },
+    urls: ["amqp://localhost"],
+  }).unwrapOrElse((e) => {
+    throw e;
+  });
 
   console.log("✅ Worker ready, waiting for messages...\n");
   console.log("Press Ctrl+C to stop\n");

--- a/docs/guide/logging.md
+++ b/docs/guide/logging.md
@@ -32,15 +32,13 @@ Pass a `logger` to `TypedAmqpClient.create()`:
 ```typescript
 import { TypedAmqpClient } from "@amqp-contract/client";
 
-const client = (
-  await TypedAmqpClient.create({
-    contract,
-    urls: ["amqp://localhost"],
-    logger, // [!code highlight]
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const client = await TypedAmqpClient.create({
+  contract,
+  urls: ["amqp://localhost"],
+  logger, // [!code highlight]
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 ## Usage with Worker
@@ -50,16 +48,14 @@ Pass a `logger` to `TypedAmqpWorker.create()`:
 ```typescript
 import { TypedAmqpWorker } from "@amqp-contract/worker";
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    urls: ["amqp://localhost"],
-    handlers,
-    logger, // [!code highlight]
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const worker = await TypedAmqpWorker.create({
+  contract,
+  urls: ["amqp://localhost"],
+  handlers,
+  logger, // [!code highlight]
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 ## What Gets Logged

--- a/docs/guide/logging.md
+++ b/docs/guide/logging.md
@@ -37,6 +37,8 @@ const client = (
     contract,
     urls: ["amqp://localhost"],
     logger, // [!code highlight]
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```
@@ -54,6 +56,8 @@ const worker = (
     urls: ["amqp://localhost"],
     handlers,
     logger, // [!code highlight]
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```

--- a/docs/guide/message-compression.md
+++ b/docs/guide/message-compression.md
@@ -42,7 +42,7 @@ import { contract } from "./contract";
 const client = (await TypedAmqpClient.create({
   contract,
   urls: ["amqp://localhost"],
-})).unwrap();
+}).recover((e) => { throw e })).unwrap();
 
 // Publish with gzip compression
 await client
@@ -98,6 +98,8 @@ const worker = (
       },
     },
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```

--- a/docs/guide/message-compression.md
+++ b/docs/guide/message-compression.md
@@ -39,10 +39,10 @@ Compression is specified in the publish options:
 import { TypedAmqpClient } from "@amqp-contract/client";
 import { contract } from "./contract";
 
-const client = (await TypedAmqpClient.create({
+const client = await TypedAmqpClient.create({
   contract,
   urls: ["amqp://localhost"],
-}).recover((e) => { throw e })).unwrap();
+}).unwrapOrElse((e) => { throw e; });
 
 // Publish with gzip compression
 await client
@@ -86,22 +86,20 @@ await client
 import { TypedAmqpWorker } from "@amqp-contract/worker";
 import { contract } from "./contract";
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    handlers: {
-      processOrder: ({ payload }) => {
-        // Message is automatically decompressed
-        console.log("Processing order:", payload.orderId);
-        console.log("Items:", payload.items); // Already decompressed
-        return Ok(undefined).toAsync();
-      },
+const worker = await TypedAmqpWorker.create({
+  contract,
+  handlers: {
+    processOrder: ({ payload }) => {
+      // Message is automatically decompressed
+      console.log("Processing order:", payload.orderId);
+      console.log("Items:", payload.items); // Already decompressed
+      return Ok(undefined).toAsync();
     },
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+  },
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 The worker automatically:

--- a/docs/guide/opentelemetry-observability.md
+++ b/docs/guide/opentelemetry-observability.md
@@ -155,27 +155,23 @@ const customTelemetryProvider: TelemetryProvider = {
 };
 
 // Use in client
-const client = (
-  await TypedAmqpClient.create({
-    contract,
-    connection,
-    telemetry: customTelemetryProvider,
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const client = await TypedAmqpClient.create({
+  contract,
+  connection,
+  telemetry: customTelemetryProvider,
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
 // Use in worker
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    connection,
-    handlers,
-    telemetry: customTelemetryProvider,
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const worker = await TypedAmqpWorker.create({
+  contract,
+  connection,
+  handlers,
+  telemetry: customTelemetryProvider,
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 ## Best Practices

--- a/docs/guide/opentelemetry-observability.md
+++ b/docs/guide/opentelemetry-observability.md
@@ -160,6 +160,8 @@ const client = (
     contract,
     connection,
     telemetry: customTelemetryProvider,
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -170,6 +172,8 @@ const worker = (
     connection,
     handlers,
     telemetry: customTelemetryProvider,
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -82,8 +82,16 @@ amqp-contract automatically shares connections across clients and workers with t
 
 ```typescript
 // These share the same underlying connection
-const client = (await TypedAmqpClient.create({ contract, urls })).unwrap();
-const worker = (await TypedAmqpWorker.create({ contract, handlers, urls })).unwrap();
+const client = (
+  await TypedAmqpClient.create({ contract, urls }).recover((e) => {
+    throw e;
+  })
+).unwrap();
+const worker = (
+  await TypedAmqpWorker.create({ contract, handlers, urls }).recover((e) => {
+    throw e;
+  })
+).unwrap();
 ```
 
 ### Connection Pool Sizing
@@ -101,6 +109,8 @@ const client = (
         clientProperties: { connection_name: "publisher" },
       },
     },
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -115,6 +125,8 @@ const worker = (
         clientProperties: { connection_name: "consumer" },
       },
     },
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```
@@ -131,6 +143,8 @@ const client = (
     connectionOptions: {
       heartbeatIntervalInSeconds: 60, // Default: 0 (disabled)
     },
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -82,16 +82,12 @@ amqp-contract automatically shares connections across clients and workers with t
 
 ```typescript
 // These share the same underlying connection
-const client = (
-  await TypedAmqpClient.create({ contract, urls }).recover((e) => {
-    throw e;
-  })
-).unwrap();
-const worker = (
-  await TypedAmqpWorker.create({ contract, handlers, urls }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const client = await TypedAmqpClient.create({ contract, urls }).unwrapOrElse((e) => {
+  throw e;
+});
+const worker = await TypedAmqpWorker.create({ contract, handlers, urls }).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 ### Connection Pool Sizing
@@ -100,35 +96,31 @@ For high-throughput scenarios, you may want separate connections:
 
 ```typescript
 // Separate connection for publishing
-const client = (
-  await TypedAmqpClient.create({
-    contract,
-    urls,
+const client = await TypedAmqpClient.create({
+  contract,
+  urls,
+  connectionOptions: {
     connectionOptions: {
-      connectionOptions: {
-        clientProperties: { connection_name: "publisher" },
-      },
+      clientProperties: { connection_name: "publisher" },
     },
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+  },
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
 // Separate connection for consuming
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    handlers,
-    urls,
+const worker = await TypedAmqpWorker.create({
+  contract,
+  handlers,
+  urls,
+  connectionOptions: {
     connectionOptions: {
-      connectionOptions: {
-        clientProperties: { connection_name: "consumer" },
-      },
+      clientProperties: { connection_name: "consumer" },
     },
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+  },
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 ### Heartbeat Configuration
@@ -136,17 +128,15 @@ const worker = (
 Heartbeats detect dead connections but add overhead:
 
 ```typescript
-const client = (
-  await TypedAmqpClient.create({
-    contract,
-    urls,
-    connectionOptions: {
-      heartbeatIntervalInSeconds: 60, // Default: 0 (disabled)
-    },
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const client = await TypedAmqpClient.create({
+  contract,
+  urls,
+  connectionOptions: {
+    heartbeatIntervalInSeconds: 60, // Default: 0 (disabled)
+  },
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 **Recommendations:**

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -124,6 +124,8 @@ describe("Order Processing Contract", () => {
       await TypedAmqpClient.create({
         contract,
         urls: [amqpConnectionUrl],
+      }).recover((e) => {
+        throw e;
       })
     ).unwrap();
 
@@ -139,6 +141,8 @@ describe("Order Processing Contract", () => {
           },
         },
         urls: [amqpConnectionUrl],
+      }).recover((e) => {
+        throw e;
       })
     ).unwrap();
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -120,31 +120,27 @@ describe("Order Processing Contract", () => {
     amqpConnectionUrl,
   }) => {
     // Create client
-    const client = (
-      await TypedAmqpClient.create({
-        contract,
-        urls: [amqpConnectionUrl],
-      }).recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    const client = await TypedAmqpClient.create({
+      contract,
+      urls: [amqpConnectionUrl],
+    }).unwrapOrElse((e) => {
+      throw e;
+    });
 
     // Create worker with handler
     const receivedPayloads: unknown[] = [];
-    const worker = (
-      await TypedAmqpWorker.create({
-        contract,
-        handlers: {
-          processOrder: ({ payload }) => {
-            receivedPayloads.push(payload);
-            return Ok(undefined).toAsync();
-          },
+    const worker = await TypedAmqpWorker.create({
+      contract,
+      handlers: {
+        processOrder: ({ payload }) => {
+          receivedPayloads.push(payload);
+          return Ok(undefined).toAsync();
         },
-        urls: [amqpConnectionUrl],
-      }).recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+      },
+      urls: [amqpConnectionUrl],
+    }).unwrapOrElse((e) => {
+      throw e;
+    });
 
     // Publish message
     const result = await client.publish("orderCreated", {

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -415,6 +415,8 @@ const orderMessage = defineMessage(
        await TypedAmqpClient.create({
          contract,
          urls: ["amqp://localhost"],
+       }).recover((e) => {
+         throw e;
        })
      ).unwrap();
      await client.publish("sendEmail", message);
@@ -426,6 +428,8 @@ const orderMessage = defineMessage(
      await TypedAmqpClient.create({
        contract,
        urls: ["amqp://localhost"],
+     }).recover((e) => {
+       throw e;
      })
    ).unwrap();
 
@@ -483,7 +487,7 @@ const orderMessage = defineMessage(
          { prefetch: 10 }, // Process up to 10 messages concurrently
        ],
      },
-   })).unwrap();
+   }).recover((e) => { throw e })).unwrap();
    ```
 
 2. **Heavy computation in handlers:**
@@ -553,6 +557,8 @@ Error: Connection timeout
            timeout: 10000, // 10 seconds
          },
        },
+     }).recover((e) => {
+       throw e;
      })
    ).unwrap();
    ```
@@ -602,6 +608,8 @@ Error: Queue 'order-processing' not found
      await TypedAmqpClient.create({
        contract,
        urls: ["amqp://localhost"],
+     }).recover((e) => {
+       throw e;
      })
    ).unwrap();
    ```

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -144,16 +144,12 @@ Error: Connection closed: 320 (CONNECTION-FORCED)
 4. **Graceful shutdown:**
    ```typescript
    process.on("SIGINT", async () => {
-     (
-       await worker.close().recover((e) => {
-         throw e;
-       })
-     ).unwrap();
-     (
-       await client.close().recover((e) => {
-         throw e;
-       })
-     ).unwrap();
+     await worker.close().unwrapOrElse((e) => {
+       throw e;
+     });
+     await client.close().unwrapOrElse((e) => {
+       throw e;
+     });
      process.exit(0);
    });
    ```
@@ -419,42 +415,32 @@ const orderMessage = defineMessage(
    ```typescript
    // ❌ Creating new connection for each operation
    async function publishMessage() {
-     const client = (
-       await TypedAmqpClient.create({
-         contract,
-         urls: ["amqp://localhost"],
-       }).recover((e) => {
-         throw e;
-       })
-     ).unwrap();
-     (
-       await client.publish("sendEmail", message).recover((e) => {
-         throw e;
-       })
-     ).unwrap();
-     (
-       await client.close().recover((e) => {
-         throw e;
-       })
-     ).unwrap();
+     const client = await TypedAmqpClient.create({
+       contract,
+       urls: ["amqp://localhost"],
+     }).unwrapOrElse((e) => {
+       throw e;
+     });
+     await client.publish("sendEmail", message).unwrapOrElse((e) => {
+       throw e;
+     });
+     await client.close().unwrapOrElse((e) => {
+       throw e;
+     });
    }
 
    // ✅ Reuse connection
-   const client = (
-     await TypedAmqpClient.create({
-       contract,
-       urls: ["amqp://localhost"],
-     }).recover((e) => {
-       throw e;
-     })
-   ).unwrap();
+   const client = await TypedAmqpClient.create({
+     contract,
+     urls: ["amqp://localhost"],
+   }).unwrapOrElse((e) => {
+     throw e;
+   });
 
    async function publishMessage() {
-     (
-       await client.publish("sendEmail", message).recover((e) => {
-         throw e;
-       })
-     ).unwrap();
+     await client.publish("sendEmail", message).unwrapOrElse((e) => {
+       throw e;
+     });
    }
    ```
 
@@ -463,16 +449,12 @@ const orderMessage = defineMessage(
    ```typescript
    // ✅ Always close connections
    process.on("SIGINT", async () => {
-     (
-       await worker.close().recover((e) => {
-         throw e;
-       })
-     ).unwrap();
-     (
-       await client.close().recover((e) => {
-         throw e;
-       })
-     ).unwrap();
+     await worker.close().unwrapOrElse((e) => {
+       throw e;
+     });
+     await client.close().unwrapOrElse((e) => {
+       throw e;
+     });
      process.exit(0);
    });
    ```
@@ -507,7 +489,7 @@ const orderMessage = defineMessage(
    }
 
    // ✅ Use prefetch to control concurrency
-   const worker = (await TypedAmqpWorker.create({
+   const worker = await TypedAmqpWorker.create({
      contract,
      handlers: {
        processOrder: [
@@ -515,7 +497,7 @@ const orderMessage = defineMessage(
          { prefetch: 10 }, // Process up to 10 messages concurrently
        ],
      },
-   }).recover((e) => { throw e })).unwrap();
+   }).unwrapOrElse((e) => { throw e; });
    ```
 
 2. **Heavy computation in handlers:**
@@ -576,19 +558,17 @@ Error: Connection timeout
 1. **Increase timeout:**
 
    ```typescript
-   const client = (
-     await TypedAmqpClient.create({
-       contract,
-       urls: ["amqp://localhost"],
+   const client = await TypedAmqpClient.create({
+     contract,
+     urls: ["amqp://localhost"],
+     connectionOptions: {
        connectionOptions: {
-         connectionOptions: {
-           timeout: 10000, // 10 seconds
-         },
+         timeout: 10000, // 10 seconds
        },
-     }).recover((e) => {
-       throw e;
-     })
-   ).unwrap();
+     },
+   }).unwrapOrElse((e) => {
+     throw e;
+   });
    ```
 
 2. **Use connection pooling:**
@@ -632,14 +612,12 @@ Error: Queue 'order-processing' not found
 3. **Let amqp-contract create resources:**
    ```typescript
    // Resources are automatically created when client/worker starts
-   const client = (
-     await TypedAmqpClient.create({
-       contract,
-       urls: ["amqp://localhost"],
-     }).recover((e) => {
-       throw e;
-     })
-   ).unwrap();
+   const client = await TypedAmqpClient.create({
+     contract,
+     urls: ["amqp://localhost"],
+   }).unwrapOrElse((e) => {
+     throw e;
+   });
    ```
 
 ### Messages not routing

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -144,8 +144,16 @@ Error: Connection closed: 320 (CONNECTION-FORCED)
 4. **Graceful shutdown:**
    ```typescript
    process.on("SIGINT", async () => {
-     await worker.close();
-     await client.close();
+     (
+       await worker.close().recover((e) => {
+         throw e;
+       })
+     ).unwrap();
+     (
+       await client.close().recover((e) => {
+         throw e;
+       })
+     ).unwrap();
      process.exit(0);
    });
    ```
@@ -419,8 +427,16 @@ const orderMessage = defineMessage(
          throw e;
        })
      ).unwrap();
-     await client.publish("sendEmail", message);
-     await client.close();
+     (
+       await client.publish("sendEmail", message).recover((e) => {
+         throw e;
+       })
+     ).unwrap();
+     (
+       await client.close().recover((e) => {
+         throw e;
+       })
+     ).unwrap();
    }
 
    // ✅ Reuse connection
@@ -434,7 +450,11 @@ const orderMessage = defineMessage(
    ).unwrap();
 
    async function publishMessage() {
-     await client.publish("sendEmail", message);
+     (
+       await client.publish("sendEmail", message).recover((e) => {
+         throw e;
+       })
+     ).unwrap();
    }
    ```
 
@@ -443,8 +463,16 @@ const orderMessage = defineMessage(
    ```typescript
    // ✅ Always close connections
    process.on("SIGINT", async () => {
-     await worker.close();
-     await client.close();
+     (
+       await worker.close().recover((e) => {
+         throw e;
+       })
+     ).unwrap();
+     (
+       await client.close().recover((e) => {
+         throw e;
+       })
+     ).unwrap();
      process.exit(0);
    });
    ```

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -17,15 +17,13 @@ pnpm add unthrown@^4
 
 amqp-contract's own API shape is unchanged, but unthrown 4 changes two things you may rely on:
 
-**1. `.unwrap()` is type-gated.** It now compiles only on a result whose error channel is empty (`E = never`). Calling `.unwrap()` on a fallible result — e.g. `(await client.publish(...)).unwrap()` or `(await TypedAmqpClient.create(...)).unwrap()` — is now a **compile error**. Prefer `.match()`; to keep "throw on failure", clear the error channel with `recover` first:
+**1. `.unwrap()` is type-gated.** It now compiles only on a result whose error channel is empty (`E = never`). Calling `.unwrap()` on a fallible result — e.g. `(await client.publish(...)).unwrap()` or `(await TypedAmqpClient.create(...)).unwrap()` — is now a **compile error**. Prefer `.match()`; to keep "throw on failure", unwrap with `.unwrapOrElse()`:
 
 ```diff
 - const client = (await TypedAmqpClient.create({ contract, urls })).unwrap();
-+ const client = (
-+   await TypedAmqpClient.create({ contract, urls }).recover((e) => {
-+     throw e;
-+   })
-+ ).unwrap();
++ const client = await TypedAmqpClient.create({ contract, urls }).unwrapOrElse((e) => {
++   throw e;
++ });
 ```
 
 See [Getting the value out](./error-model.md#getting-the-value-out).

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -7,6 +7,31 @@ description: Migration notes for major versions of amqp-contract, including the 
 
 All six `@amqp-contract/*` packages version together, so upgrade them in lockstep. This page summarizes the changes that require action; the full history lives in the [GitHub Releases](https://github.com/btravstack/amqp-contract/releases) and each package's `CHANGELOG.md`.
 
+## 2.2.x → 2.3.x
+
+Upgrades [`unthrown`](https://github.com/btravstack/unthrown) to `4.0.0`. Since `unthrown` is a **peer dependency**, bump your own copy to `^4.0.0`:
+
+```bash
+pnpm add unthrown@^4
+```
+
+amqp-contract's own API shape is unchanged, but unthrown 4 changes two things you may rely on:
+
+**1. `.unwrap()` is type-gated.** It now compiles only on a result whose error channel is empty (`E = never`). Calling `.unwrap()` on a fallible result — e.g. `(await client.publish(...)).unwrap()` or `(await TypedAmqpClient.create(...)).unwrap()` — is now a **compile error**. Prefer `.match()`; to keep "throw on failure", clear the error channel with `recover` first:
+
+```diff
+- const client = (await TypedAmqpClient.create({ contract, urls })).unwrap();
++ const client = (
++   await TypedAmqpClient.create({ contract, urls }).recover((e) => {
++     throw e;
++   })
++ ).unwrap();
+```
+
+See [Getting the value out](./error-model.md#getting-the-value-out).
+
+**2. `TaggedError` reserves `message`.** Only relevant if you define your own `TaggedError` subclasses: a `message` field in the payload is now rejected. Move it to `override message = "…"` (or assign `this.message` in the constructor) and keep the payload for structured fields. amqp-contract's own error classes already do this.
+
 ## 2.1.x → 2.2.x
 
 Upgrades [`unthrown`](https://github.com/btravstack/unthrown) to `3.0.0`. amqp-contract's own public surface is unchanged. Action is only needed if you author `qualify` mappers that intentionally route unexpected failures to the `Defect` channel:

--- a/docs/guide/why-amqp-contract.md
+++ b/docs/guide/why-amqp-contract.md
@@ -145,14 +145,12 @@ const contract = defineContract({
 });
 
 // 4. Publisher gets full type safety
-const client = (
-  await TypedAmqpClient.create({
-    contract,
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const client = await TypedAmqpClient.create({
+  contract,
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
 await client.publish("orderCreated", {
   orderId: "ORD-123", // ✅ TypeScript knows these fields!
@@ -161,22 +159,20 @@ await client.publish("orderCreated", {
 });
 
 // 5. Consumer gets fully typed payloads
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    handlers: {
-      processOrder: ({ payload }) => {
-        console.log(payload.orderId); // ✅ Fully typed!
-        console.log(payload.customerId); // ✅ Autocomplete!
-        console.log(payload.amount); // ✅ Type safe!
-        return Ok(undefined).toAsync();
-      },
+const worker = await TypedAmqpWorker.create({
+  contract,
+  handlers: {
+    processOrder: ({ payload }) => {
+      console.log(payload.orderId); // ✅ Fully typed!
+      console.log(payload.customerId); // ✅ Autocomplete!
+      console.log(payload.amount); // ✅ Type safe!
+      return Ok(undefined).toAsync();
     },
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+  },
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 ### 2. Automatic Validation

--- a/docs/guide/why-amqp-contract.md
+++ b/docs/guide/why-amqp-contract.md
@@ -149,6 +149,8 @@ const client = (
   await TypedAmqpClient.create({
     contract,
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -171,6 +173,8 @@ const worker = (
       },
     },
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```

--- a/docs/guide/worker-usage.md
+++ b/docs/guide/worker-usage.md
@@ -27,6 +27,8 @@ const worker = (
     contract,
     handlers: { processOrder },
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -60,6 +62,8 @@ const worker = (
       },
     },
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```
@@ -90,6 +94,8 @@ const worker = (
       },
     },
     connection,
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```
@@ -111,7 +117,7 @@ const workerResult = (await TypedAmqpWorker.create({
     // Missing processOrder handler!
   },
   urls: ['amqp://localhost'],
-})).unwrap();
+}).recover((e) => { throw e })).unwrap();
 
 // ✅ All handlers present
 const worker = (await TypedAmqpWorker.create({
@@ -121,7 +127,7 @@ const worker = (await TypedAmqpWorker.create({
     notifyOrder: ({ payload }) => { ... },
   },
   urls: ['amqp://localhost'],
-})).unwrap();
+}).recover((e) => { throw e })).unwrap();
 
 console.log('✅ All handlers present');
 ```
@@ -179,6 +185,8 @@ const worker = (
     contract,
     handlers,
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```
@@ -236,6 +244,8 @@ const worker = (
     contract: orderContract,
     handlers: orderHandlers,
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```
@@ -254,7 +264,7 @@ const worker = (await TypedAmqpWorker.create({
     notifyOrder: ({ payload }) => { ... },
   },
   connection,
-})).unwrap();
+}).recover((e) => { throw e })).unwrap();
 // Worker is already consuming messages from all queues
 console.log('Worker ready, waiting for messages...');
 ```
@@ -279,6 +289,8 @@ const worker = (
       },
     },
     connection,
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```
@@ -306,6 +318,8 @@ const worker = (
       }),
     },
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```
@@ -365,6 +379,8 @@ async function main() {
         },
       }),
       urls: ["amqp://localhost"],
+    }).recover((e) => {
+      throw e;
     })
   ).unwrap();
 
@@ -413,6 +429,8 @@ const worker = (
       ],
     },
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```
@@ -439,6 +457,8 @@ const worker = (
     defaultConsumerOptions: {
       prefetch: 10,
     },
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```
@@ -523,6 +543,8 @@ const worker = (
         ).map(() => undefined),
     },
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```
@@ -592,6 +614,8 @@ const worker = (
         ).map(() => undefined),
     },
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```
@@ -727,6 +751,8 @@ const worker = (
       ],
     },
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```
@@ -755,6 +781,8 @@ const worker = (
       }),
     },
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```
@@ -796,6 +824,8 @@ const worker = (
       }),
     },
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```
@@ -916,6 +946,8 @@ const worker = (
       },
     },
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 

--- a/docs/guide/worker-usage.md
+++ b/docs/guide/worker-usage.md
@@ -22,15 +22,13 @@ const processOrder = defineHandler(contract, "processOrder", ({ payload }) =>
   ),
 );
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    handlers: { processOrder },
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const worker = await TypedAmqpWorker.create({
+  contract,
+  handlers: { processOrder },
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
 console.log("✅ Worker ready!");
 ```
@@ -48,24 +46,22 @@ import { TypedAmqpWorker } from "@amqp-contract/worker";
 import { fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 import { contract } from "./contract";
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    handlers: {
-      processOrder: ({ payload }) => {
-        console.log("Processing:", payload.orderId);
-        return Ok(undefined).toAsync();
-      },
-      notifyOrder: ({ payload }) => {
-        console.log("Notifying:", payload.orderId);
-        return Ok(undefined).toAsync();
-      },
+const worker = await TypedAmqpWorker.create({
+  contract,
+  handlers: {
+    processOrder: ({ payload }) => {
+      console.log("Processing:", payload.orderId);
+      return Ok(undefined).toAsync();
     },
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+    notifyOrder: ({ payload }) => {
+      console.log("Notifying:", payload.orderId);
+      return Ok(undefined).toAsync();
+    },
+  },
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 In production code, prefer `defineHandler` so handler logic lives in its own module and can be unit-tested.
@@ -77,27 +73,25 @@ Handlers receive validated, fully-typed messages with `{ payload, headers }`:
 ```typescript
 import { fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    handlers: {
-      processOrder: ({ payload }) => {
-        // Payload is fully typed!
-        console.log(payload.orderId); // ✅ string
-        console.log(payload.amount); // ✅ number
-        console.log(payload.items); // ✅ array
+const worker = await TypedAmqpWorker.create({
+  contract,
+  handlers: {
+    processOrder: ({ payload }) => {
+      // Payload is fully typed!
+      console.log(payload.orderId); // ✅ string
+      console.log(payload.amount); // ✅ number
+      console.log(payload.items); // ✅ array
 
-        for (const item of payload.items) {
-          console.log(`${item.productId}: ${item.quantity}`);
-        }
-        return Ok(undefined).toAsync();
-      },
+      for (const item of payload.items) {
+        console.log(`${item.productId}: ${item.quantity}`);
+      }
+      return Ok(undefined).toAsync();
     },
-    connection,
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+  },
+  connection,
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 ### Type Safety
@@ -110,24 +104,24 @@ The worker enforces:
 
 ```typescript
 // ❌ TypeScript error: missing handler
-const workerResult = (await TypedAmqpWorker.create({
+const workerResult = await TypedAmqpWorker.create({
   contract,
   handlers: {
     notifyOrder: ({ payload }) => { ... },
     // Missing processOrder handler!
   },
   urls: ['amqp://localhost'],
-}).recover((e) => { throw e })).unwrap();
+}).unwrapOrElse((e) => { throw e; });
 
 // ✅ All handlers present
-const worker = (await TypedAmqpWorker.create({
+const worker = await TypedAmqpWorker.create({
   contract,
   handlers: {
     processOrder: ({ payload }) => { ... },
     notifyOrder: ({ payload }) => { ... },
   },
   urls: ['amqp://localhost'],
-}).recover((e) => { throw e })).unwrap();
+}).unwrapOrElse((e) => { throw e; });
 
 console.log('✅ All handlers present');
 ```
@@ -180,15 +174,13 @@ const handlers = defineHandlers(contract, {
     ),
 });
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    handlers,
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const worker = await TypedAmqpWorker.create({
+  contract,
+  handlers,
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 ### Benefits
@@ -239,15 +231,13 @@ import { TypedAmqpWorker } from "@amqp-contract/worker";
 import { orderContract } from "./contract";
 import { orderHandlers } from "./handlers/order-handlers";
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract: orderContract,
-    handlers: orderHandlers,
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const worker = await TypedAmqpWorker.create({
+  contract: orderContract,
+  handlers: orderHandlers,
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 ## Starting Consumers
@@ -257,14 +247,14 @@ const worker = (
 By default, `TypedAmqpWorker.create` automatically starts all consumers defined in the contract:
 
 ```typescript
-const worker = (await TypedAmqpWorker.create({
+const worker = await TypedAmqpWorker.create({
   contract,
   handlers: {
     processOrder: ({ payload }) => { ... },
     notifyOrder: ({ payload }) => { ... },
   },
   connection,
-}).recover((e) => { throw e })).unwrap();
+}).unwrapOrElse((e) => { throw e; });
 // Worker is already consuming messages from all queues
 console.log('Worker ready, waiting for messages...');
 ```
@@ -278,21 +268,19 @@ By default, messages are automatically acknowledged after successful processing:
 ```typescript
 import { fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    handlers: {
-      processOrder: ({ payload }) => {
-        console.log("Processing:", payload.orderId);
-        // Message is automatically acked after this handler completes
-        return Ok(undefined).toAsync();
-      },
+const worker = await TypedAmqpWorker.create({
+  contract,
+  handlers: {
+    processOrder: ({ payload }) => {
+      console.log("Processing:", payload.orderId);
+      // Message is automatically acked after this handler completes
+      return Ok(undefined).toAsync();
     },
-    connection,
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+  },
+  connection,
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 ### Manual Acknowledgment
@@ -303,25 +291,23 @@ For more control over acknowledgment, use the raw message parameter and error ty
 import { defineHandler, RetryableError, NonRetryableError } from "@amqp-contract/worker";
 import { fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    handlers: {
-      processOrder: defineHandler(contract, "processOrder", ({ payload }, rawMessage) => {
-        // Access raw AMQP message properties if needed
-        console.log("Delivery tag:", rawMessage.fields.deliveryTag);
+const worker = await TypedAmqpWorker.create({
+  contract,
+  handlers: {
+    processOrder: defineHandler(contract, "processOrder", ({ payload }, rawMessage) => {
+      // Access raw AMQP message properties if needed
+      console.log("Delivery tag:", rawMessage.fields.deliveryTag);
 
-        return fromPromise(
-          processOrder(payload),
-          (error) => new RetryableError("Processing failed", error), // Failure - will retry
-        ).map(() => undefined); // Success - message will be acked
-      }),
-    },
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+      return fromPromise(
+        processOrder(payload),
+        (error) => new RetryableError("Processing failed", error), // Failure - will retry
+      ).map(() => undefined); // Success - message will be acked
+    }),
+  },
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 **Acknowledgment behavior:**
@@ -353,36 +339,34 @@ import { fromPromise, Ok, type AsyncResult } from "unthrown";
 import { contract } from "./contract";
 
 async function main() {
-  const worker = (
-    await TypedAmqpWorker.create({
-      contract,
-      handlers: defineHandlers(contract, {
-        processOrder: ({ payload }) => {
-          console.log(`Processing order ${payload.orderId}`);
+  const worker = await TypedAmqpWorker.create({
+    contract,
+    handlers: defineHandlers(contract, {
+      processOrder: ({ payload }) => {
+        console.log(`Processing order ${payload.orderId}`);
 
-          return fromPromise(
-            Promise.all([saveToDatabase(payload), sendConfirmation(payload.customerId)]),
-          )
-            .map(() => undefined)
-            .mapErr((error) => {
-              console.error("Processing failed:", error);
-              return new RetryableError("Order processing failed", error);
-            });
-        },
+        return fromPromise(
+          Promise.all([saveToDatabase(payload), sendConfirmation(payload.customerId)]),
+        )
+          .map(() => undefined)
+          .mapErr((error) => {
+            console.error("Processing failed:", error);
+            return new RetryableError("Order processing failed", error);
+          });
+      },
 
-        notifyOrder: ({ payload }) => {
-          console.log(`Sending notification for ${payload.orderId}`);
-          return fromPromise(
-            sendEmail(payload),
-            (error) => new RetryableError("Email failed", error),
-          ).map(() => undefined);
-        },
-      }),
-      urls: ["amqp://localhost"],
-    }).recover((e) => {
-      throw e;
-    })
-  ).unwrap();
+      notifyOrder: ({ payload }) => {
+        console.log(`Sending notification for ${payload.orderId}`);
+        return fromPromise(
+          sendEmail(payload),
+          (error) => new RetryableError("Email failed", error),
+        ).map(() => undefined);
+      },
+    }),
+    urls: ["amqp://localhost"],
+  }).unwrapOrElse((e) => {
+    throw e;
+  });
 
   console.log("✅ Worker ready!");
 
@@ -412,27 +396,25 @@ Use the tuple syntax `[handler, options]` to configure prefetch per-handler:
 import { fromPromise, Ok, type AsyncResult } from "unthrown";
 import { RetryableError } from "@amqp-contract/worker";
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    handlers: {
-      processOrder: [
-        ({ payload }) =>
-          fromPromise(
-            saveToDatabase(payload),
-            (error) => new RetryableError("Failed to save order", error),
-          ).map(() => {
-            console.log("Order:", payload.orderId);
-            return undefined;
-          }),
-        { prefetch: 10 }, // Process up to 10 messages concurrently
-      ],
-    },
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const worker = await TypedAmqpWorker.create({
+  contract,
+  handlers: {
+    processOrder: [
+      ({ payload }) =>
+        fromPromise(
+          saveToDatabase(payload),
+          (error) => new RetryableError("Failed to save order", error),
+        ).map(() => {
+          console.log("Order:", payload.orderId);
+          return undefined;
+        }),
+      { prefetch: 10 }, // Process up to 10 messages concurrently
+    ],
+  },
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 ### Default Consumer Options
@@ -443,24 +425,22 @@ If you want to apply a common consumer configuration across all handlers, use `d
 import { fromPromise, Ok, type AsyncResult } from "unthrown";
 import { RetryableError } from "@amqp-contract/worker";
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    handlers: {
-      processOrder: ({ payload }) =>
-        fromPromise(
-          processOrder(payload),
-          (error) => new RetryableError("Processing failed", error),
-        ).map(() => undefined),
-    },
-    urls: ["amqp://localhost"],
-    defaultConsumerOptions: {
-      prefetch: 10,
-    },
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const worker = await TypedAmqpWorker.create({
+  contract,
+  handlers: {
+    processOrder: ({ payload }) =>
+      fromPromise(
+        processOrder(payload),
+        (error) => new RetryableError("Processing failed", error),
+      ).map(() => undefined),
+  },
+  urls: ["amqp://localhost"],
+  defaultConsumerOptions: {
+    prefetch: 10,
+  },
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 `defaultConsumerOptions` are applied to every consumer handler. When a handler is defined with tuple syntax, per-handler options override these defaults.
@@ -532,21 +512,19 @@ const ordersQueue = defineQueue("orders", {
 });
 
 // 2. Worker automatically uses queue's retry configuration
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    handlers: {
-      processOrder: ({ payload }) =>
-        fromPromise(
-          processPayment(payload),
-          (error) => new RetryableError("Payment failed", error),
-        ).map(() => undefined),
-    },
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const worker = await TypedAmqpWorker.create({
+  contract,
+  handlers: {
+    processOrder: ({ payload }) =>
+      fromPromise(
+        processPayment(payload),
+        (error) => new RetryableError("Payment failed", error),
+      ).map(() => undefined),
+  },
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 **How Immediate-Requeue works:**
@@ -603,21 +581,19 @@ const contract = defineContract({
 });
 
 // 3. Worker automatically uses queue's retry configuration
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    handlers: {
-      processOrder: ({ payload }) =>
-        fromPromise(
-          processPayment(payload),
-          (error) => new RetryableError("Payment failed", error),
-        ).map(() => undefined),
-    },
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const worker = await TypedAmqpWorker.create({
+  contract,
+  handlers: {
+    processOrder: ({ payload }) =>
+      fromPromise(
+        processPayment(payload),
+        (error) => new RetryableError("Payment failed", error),
+      ).map(() => undefined),
+  },
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 **How TTL-Backoff works:**
@@ -729,32 +705,30 @@ Use `RetryableError` for transient failures that may succeed on retry:
 import { RetryableError, defineHandler } from "@amqp-contract/worker";
 import { fromPromise, Ok, type AsyncResult } from "unthrown";
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    handlers: {
-      processOrder: [
-        defineHandler(contract, "processOrder", ({ payload }) =>
-          fromPromise(
-            externalApiCall(payload),
-            (error) =>
-              // Explicitly signal this should be retried
-              new RetryableError("External API temporarily unavailable", error),
-          ).map(() => undefined),
-        ),
-        {
-          retry: {
-            maxRetries: 5,
-            initialDelayMs: 2000,
-          },
+const worker = await TypedAmqpWorker.create({
+  contract,
+  handlers: {
+    processOrder: [
+      defineHandler(contract, "processOrder", ({ payload }) =>
+        fromPromise(
+          externalApiCall(payload),
+          (error) =>
+            // Explicitly signal this should be retried
+            new RetryableError("External API temporarily unavailable", error),
+        ).map(() => undefined),
+      ),
+      {
+        retry: {
+          maxRetries: 5,
+          initialDelayMs: 2000,
         },
-      ],
-    },
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+      },
+    ],
+  },
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 #### NonRetryableError
@@ -765,26 +739,24 @@ Use `NonRetryableError` for permanent failures that should NOT be retried:
 import { NonRetryableError, RetryableError, defineHandler } from "@amqp-contract/worker";
 import { Err, fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    handlers: {
-      processOrder: defineHandler(contract, "processOrder", ({ payload }) => {
-        // Validation errors should not be retried
-        if (payload.amount <= 0) {
-          return Err(new NonRetryableError("Invalid order amount")).toAsync();
-        }
-        return fromPromise(
-          processPayment(payload),
-          (error) => new RetryableError("Payment failed", error),
-        ).map(() => undefined);
-      }),
-    },
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const worker = await TypedAmqpWorker.create({
+  contract,
+  handlers: {
+    processOrder: defineHandler(contract, "processOrder", ({ payload }) => {
+      // Validation errors should not be retried
+      if (payload.amount <= 0) {
+        return Err(new NonRetryableError("Invalid order amount")).toAsync();
+      }
+      return fromPromise(
+        processPayment(payload),
+        (error) => new RetryableError("Payment failed", error),
+      ).map(() => undefined);
+    }),
+  },
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 **NonRetryableError behavior:**
@@ -802,32 +774,30 @@ import { defineHandler, RetryableError, NonRetryableError } from "@amqp-contract
 import { Err, fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 import { match } from "ts-pattern";
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    handlers: {
-      processOrder: defineHandler(contract, "processOrder", ({ payload }) => {
-        // Validation - non-retryable
-        if (payload.amount <= 0) {
-          return Err(new NonRetryableError("Invalid amount")).toAsync();
-        }
+const worker = await TypedAmqpWorker.create({
+  contract,
+  handlers: {
+    processOrder: defineHandler(contract, "processOrder", ({ payload }) => {
+      // Validation - non-retryable
+      if (payload.amount <= 0) {
+        return Err(new NonRetryableError("Invalid amount")).toAsync();
+      }
 
-        // Qualify the rejection at the boundary into a modeled HandlerError.
-        return fromPromise(processPayment(payload), (error) =>
-          match(error)
-            .when(
-              (e) => e instanceof PaymentDeclinedError,
-              () => new NonRetryableError("Payment declined", error),
-            )
-            .otherwise(() => new RetryableError("Payment failed", error)),
-        ).map(() => undefined);
-      }),
-    },
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+      // Qualify the rejection at the boundary into a modeled HandlerError.
+      return fromPromise(processPayment(payload), (error) =>
+        match(error)
+          .when(
+            (e) => e instanceof PaymentDeclinedError,
+            () => new NonRetryableError("Payment declined", error),
+          )
+          .otherwise(() => new RetryableError("Payment failed", error)),
+      ).map(() => undefined);
+    }),
+  },
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 **When to use which error type:**
@@ -923,33 +893,31 @@ const contract = defineContract({
 });
 
 // Worker automatically uses queue's retry configuration
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    handlers: {
-      processOrder: ({ payload }) => {
-        // Validate before processing (don't retry validation errors)
-        if (!payload.amount || payload.amount <= 0) {
-          return Err(new NonRetryableError("Invalid order amount")).toAsync();
-        }
+const worker = await TypedAmqpWorker.create({
+  contract,
+  handlers: {
+    processOrder: ({ payload }) => {
+      // Validate before processing (don't retry validation errors)
+      if (!payload.amount || payload.amount <= 0) {
+        return Err(new NonRetryableError("Invalid order amount")).toAsync();
+      }
 
-        // Process with external service (retry on failure based on queue config)
-        return fromPromise(
-          Promise.all([
-            paymentService.charge(payload),
-            inventoryService.reserve(payload),
-            notificationService.send(payload),
-          ]),
-        )
-          .map(() => undefined)
-          .mapErr((error) => new RetryableError("Order processing failed", error));
-      },
+      // Process with external service (retry on failure based on queue config)
+      return fromPromise(
+        Promise.all([
+          paymentService.charge(payload),
+          inventoryService.reserve(payload),
+          notificationService.send(payload),
+        ]),
+      )
+        .map(() => undefined)
+        .mapErr((error) => new RetryableError("Order processing failed", error));
     },
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+  },
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
 console.log("✅ Worker ready with retry enabled!");
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,25 +88,21 @@ export const contract = defineContract({
 import { TypedAmqpClient } from "@amqp-contract/client";
 import { contract } from "./contract";
 
-const client = (
-  await TypedAmqpClient.create({
-    contract,
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+const client = await TypedAmqpClient.create({
+  contract,
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 
-(
-  await client
-    .publish("orderCreated", {
-      orderId: "ORD-123", // ✅ TypeScript knows!
-      amount: 99.99,
-    })
-    .recover((e) => {
-      throw e;
-    })
-).unwrap();
+await client
+  .publish("orderCreated", {
+    orderId: "ORD-123", // ✅ TypeScript knows!
+    amount: 99.99,
+  })
+  .unwrapOrElse((e) => {
+    throw e;
+  });
 ```
 
 ```typescript [3. Consume]
@@ -114,20 +110,18 @@ import { TypedAmqpWorker } from "@amqp-contract/worker";
 import { fromPromise, Ok, type AsyncResult, type Result } from "unthrown";
 import { contract } from "./contract";
 
-const worker = (
-  await TypedAmqpWorker.create({
-    contract,
-    handlers: {
-      processOrder: ({ payload }) => {
-        console.log(payload.orderId); // ✅ Fully typed!
-        return Ok(undefined).toAsync();
-      },
+const worker = await TypedAmqpWorker.create({
+  contract,
+  handlers: {
+    processOrder: ({ payload }) => {
+      console.log(payload.orderId); // ✅ Fully typed!
+      return Ok(undefined).toAsync();
     },
-    urls: ["amqp://localhost"],
-  }).recover((e) => {
-    throw e;
-  })
-).unwrap();
+  },
+  urls: ["amqp://localhost"],
+}).unwrapOrElse((e) => {
+  throw e;
+});
 ```
 
 :::

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,10 +97,16 @@ const client = (
   })
 ).unwrap();
 
-await client.publish("orderCreated", {
-  orderId: "ORD-123", // ✅ TypeScript knows!
-  amount: 99.99,
-});
+(
+  await client
+    .publish("orderCreated", {
+      orderId: "ORD-123", // ✅ TypeScript knows!
+      amount: 99.99,
+    })
+    .recover((e) => {
+      throw e;
+    })
+).unwrap();
 ```
 
 ```typescript [3. Consume]

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,6 +92,8 @@ const client = (
   await TypedAmqpClient.create({
     contract,
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 
@@ -116,6 +118,8 @@ const worker = (
       },
     },
     urls: ["amqp://localhost"],
+  }).recover((e) => {
+    throw e;
   })
 ).unwrap();
 ```

--- a/examples/basic-order-processing-client/src/index.spec.ts
+++ b/examples/basic-order-processing-client/src/index.spec.ts
@@ -7,14 +7,12 @@ import { orderContract } from "@amqp-contract-examples/basic-order-processing-co
 describe("Basic Order Processing Client Integration", () => {
   it("should publish a new order successfully", async ({ amqpConnectionUrl }) => {
     // GIVEN
-    const client = (
-      await TypedAmqpClient.create({
-        contract: orderContract,
-        urls: [amqpConnectionUrl],
-      }).recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    const client = await TypedAmqpClient.create({
+      contract: orderContract,
+      urls: [amqpConnectionUrl],
+    }).unwrapOrElse((e) => {
+      throw e;
+    });
 
     const newOrder = {
       orderId: "TEST-001",
@@ -34,23 +32,19 @@ describe("Basic Order Processing Client Integration", () => {
     expect(result).toEqual(Ok(undefined));
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 
   it("should publish order status updates", async ({ amqpConnectionUrl }) => {
     // GIVEN
-    const client = (
-      await TypedAmqpClient.create({
-        contract: orderContract,
-        urls: [amqpConnectionUrl],
-      }).recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    const client = await TypedAmqpClient.create({
+      contract: orderContract,
+      urls: [amqpConnectionUrl],
+    }).unwrapOrElse((e) => {
+      throw e;
+    });
 
     const orderUpdate = {
       orderId: "TEST-001",
@@ -65,23 +59,19 @@ describe("Basic Order Processing Client Integration", () => {
     expect(result).toEqual(Ok(undefined));
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 
   it("should validate order schema before publishing", async ({ amqpConnectionUrl }) => {
     // GIVEN
-    const client = (
-      await TypedAmqpClient.create({
-        contract: orderContract,
-        urls: [amqpConnectionUrl],
-      }).recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    const client = await TypedAmqpClient.create({
+      contract: orderContract,
+      urls: [amqpConnectionUrl],
+    }).unwrapOrElse((e) => {
+      throw e;
+    });
 
     const invalidOrder = {
       orderId: "TEST-001",
@@ -100,10 +90,8 @@ describe("Basic Order Processing Client Integration", () => {
     expect(result.isErr()).toBe(true);
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 });

--- a/examples/basic-order-processing-client/src/index.spec.ts
+++ b/examples/basic-order-processing-client/src/index.spec.ts
@@ -11,6 +11,8 @@ describe("Basic Order Processing Client Integration", () => {
       await TypedAmqpClient.create({
         contract: orderContract,
         urls: [amqpConnectionUrl],
+      }).recover((e) => {
+        throw e;
       })
     ).unwrap();
 
@@ -32,7 +34,11 @@ describe("Basic Order Processing Client Integration", () => {
     expect(result).toEqual(Ok(undefined));
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 
   it("should publish order status updates", async ({ amqpConnectionUrl }) => {
@@ -41,6 +47,8 @@ describe("Basic Order Processing Client Integration", () => {
       await TypedAmqpClient.create({
         contract: orderContract,
         urls: [amqpConnectionUrl],
+      }).recover((e) => {
+        throw e;
       })
     ).unwrap();
 
@@ -57,7 +65,11 @@ describe("Basic Order Processing Client Integration", () => {
     expect(result).toEqual(Ok(undefined));
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 
   it("should validate order schema before publishing", async ({ amqpConnectionUrl }) => {
@@ -66,6 +78,8 @@ describe("Basic Order Processing Client Integration", () => {
       await TypedAmqpClient.create({
         contract: orderContract,
         urls: [amqpConnectionUrl],
+      }).recover((e) => {
+        throw e;
       })
     ).unwrap();
 
@@ -86,6 +100,10 @@ describe("Basic Order Processing Client Integration", () => {
     expect(result.isErr()).toBe(true);
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 });

--- a/examples/basic-order-processing-client/src/index.ts
+++ b/examples/basic-order-processing-client/src/index.ts
@@ -26,7 +26,11 @@ async function main() {
     await TypedAmqpClient.create({
       contract: orderContract,
       urls: [env.AMQP_URL],
-    }).tapErr((error) => logger.error({ error }, "Failed to create client"))
+    })
+      .tapErr((error) => logger.error({ error }, "Failed to create client"))
+      .recover((error) => {
+        throw error;
+      })
   ).unwrap();
 
   logger.info("Client ready");
@@ -47,6 +51,9 @@ async function main() {
         .publish(publisherName, message, options)
         .tapErr((error) => logger.error({ error }, `Failed to publish: ${publisherName}`))
         .tap(() => logger.debug(`Successfully published to ${publisherName}`))
+        .recover((error) => {
+          throw error;
+        })
     ).unwrap();
   };
 
@@ -137,7 +144,11 @@ async function main() {
   await new Promise((resolve) => setTimeout(resolve, 2000));
 
   // Clean up
-  (await client.close()).unwrap();
+  (
+    await client.close().recover((error) => {
+      throw error;
+    })
+  ).unwrap();
   logger.info("Publisher stopped");
   process.exit(0);
 }

--- a/examples/basic-order-processing-client/src/index.ts
+++ b/examples/basic-order-processing-client/src/index.ts
@@ -22,16 +22,14 @@ const logger = pino({
 
 async function main() {
   // Create type-safe client
-  const client = (
-    await TypedAmqpClient.create({
-      contract: orderContract,
-      urls: [env.AMQP_URL],
-    })
-      .tapErr((error) => logger.error({ error }, "Failed to create client"))
-      .recover((error) => {
-        throw error;
-      })
-  ).unwrap();
+  const client = await TypedAmqpClient.create({
+    contract: orderContract,
+    urls: [env.AMQP_URL],
+  })
+    .tapErr((error) => logger.error({ error }, "Failed to create client"))
+    .unwrapOrElse((error) => {
+      throw error;
+    });
 
   logger.info("Client ready");
   logger.info("=".repeat(60));
@@ -46,15 +44,13 @@ async function main() {
     message: Parameters<typeof client.publish<T>>[1],
     options?: PublishOptions,
   ): Promise<void> => {
-    (
-      await client
-        .publish(publisherName, message, options)
-        .tapErr((error) => logger.error({ error }, `Failed to publish: ${publisherName}`))
-        .tap(() => logger.debug(`Successfully published to ${publisherName}`))
-        .recover((error) => {
-          throw error;
-        })
-    ).unwrap();
+    await client
+      .publish(publisherName, message, options)
+      .tapErr((error) => logger.error({ error }, `Failed to publish: ${publisherName}`))
+      .tap(() => logger.debug(`Successfully published to ${publisherName}`))
+      .unwrapOrElse((error) => {
+        throw error;
+      });
   };
 
   // 1. Publish a new order (routing key: order.created)
@@ -144,11 +140,9 @@ async function main() {
   await new Promise((resolve) => setTimeout(resolve, 2000));
 
   // Clean up
-  (
-    await client.close().recover((error) => {
-      throw error;
-    })
-  ).unwrap();
+  await client.close().unwrapOrElse((error) => {
+    throw error;
+  });
   logger.info("Publisher stopped");
   process.exit(0);
 }

--- a/examples/basic-order-processing-worker/src/index.spec.ts
+++ b/examples/basic-order-processing-worker/src/index.spec.ts
@@ -27,6 +27,8 @@ describe("Basic Order Processing Worker Integration", () => {
           fulfillOrder: () => Ok(undefined).toAsync(),
         }),
         urls: [amqpConnectionUrl],
+      }).recover((e) => {
+        throw e;
       })
     ).unwrap();
 
@@ -54,7 +56,11 @@ describe("Basic Order Processing Worker Integration", () => {
       });
       expect(processedOrders).toEqual([newOrder]);
     } finally {
-      (await worker.close()).unwrap();
+      (
+        await worker.close().recover((e) => {
+          throw e;
+        })
+      ).unwrap();
     }
   });
 
@@ -80,7 +86,11 @@ describe("Basic Order Processing Worker Integration", () => {
       }),
       urls: [amqpConnectionUrl],
     });
-    const worker = workerResult.unwrap();
+    const worker = workerResult
+      .recover((e) => {
+        throw e;
+      })
+      .unwrap();
 
     try {
       // WHEN
@@ -117,7 +127,11 @@ describe("Basic Order Processing Worker Integration", () => {
       });
       expect(notifications.length).toBeGreaterThanOrEqual(2);
     } finally {
-      (await worker.close()).unwrap();
+      (
+        await worker.close().recover((e) => {
+          throw e;
+        })
+      ).unwrap();
     }
   });
 
@@ -147,7 +161,11 @@ describe("Basic Order Processing Worker Integration", () => {
       }),
       urls: [amqpConnectionUrl],
     });
-    const worker = workerResult.unwrap();
+    const worker = workerResult
+      .recover((e) => {
+        throw e;
+      })
+      .unwrap();
 
     try {
       const newOrder = {
@@ -174,7 +192,11 @@ describe("Basic Order Processing Worker Integration", () => {
       expect(processedOrders.length).toBeGreaterThanOrEqual(1);
       expect(notifications.length).toBeGreaterThan(0); // Receives all events
     } finally {
-      (await worker.close()).unwrap();
+      (
+        await worker.close().recover((e) => {
+          throw e;
+        })
+      ).unwrap();
     }
   });
 
@@ -199,6 +221,8 @@ describe("Basic Order Processing Worker Integration", () => {
           },
         }),
         urls: [amqpConnectionUrl],
+      }).recover((e) => {
+        throw e;
       })
     ).unwrap();
 
@@ -224,7 +248,11 @@ describe("Basic Order Processing Worker Integration", () => {
       });
       expect(fulfilled).toEqual([command]);
     } finally {
-      (await worker.close()).unwrap();
+      (
+        await worker.close().recover((e) => {
+          throw e;
+        })
+      ).unwrap();
     }
   });
 });

--- a/examples/basic-order-processing-worker/src/index.spec.ts
+++ b/examples/basic-order-processing-worker/src/index.spec.ts
@@ -11,26 +11,24 @@ describe("Basic Order Processing Worker Integration", () => {
   }) => {
     // GIVEN
     const processedOrders: Array<unknown> = [];
-    const worker = (
-      await TypedAmqpWorker.create({
-        contract: orderContract,
-        handlers: defineHandlers(orderContract, {
-          processOrder: ({ payload }) => {
-            processedOrders.push(payload);
-            return Ok(undefined).toAsync();
-          },
-          notifyOrder: () => Ok(undefined).toAsync(),
-          shipOrder: () => Ok(undefined).toAsync(),
-          handleUrgentOrder: () => Ok(undefined).toAsync(),
+    const worker = await TypedAmqpWorker.create({
+      contract: orderContract,
+      handlers: defineHandlers(orderContract, {
+        processOrder: ({ payload }) => {
+          processedOrders.push(payload);
+          return Ok(undefined).toAsync();
+        },
+        notifyOrder: () => Ok(undefined).toAsync(),
+        shipOrder: () => Ok(undefined).toAsync(),
+        handleUrgentOrder: () => Ok(undefined).toAsync(),
 
-          handleFailedOrders: () => Ok(undefined).toAsync(),
-          fulfillOrder: () => Ok(undefined).toAsync(),
-        }),
-        urls: [amqpConnectionUrl],
-      }).recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+        handleFailedOrders: () => Ok(undefined).toAsync(),
+        fulfillOrder: () => Ok(undefined).toAsync(),
+      }),
+      urls: [amqpConnectionUrl],
+    }).unwrapOrElse((e) => {
+      throw e;
+    });
 
     try {
       const newOrder = {
@@ -56,11 +54,9 @@ describe("Basic Order Processing Worker Integration", () => {
       });
       expect(processedOrders).toEqual([newOrder]);
     } finally {
-      (
-        await worker.close().recover((e) => {
-          throw e;
-        })
-      ).unwrap();
+      await worker.close().unwrapOrElse((e) => {
+        throw e;
+      });
     }
   });
 
@@ -86,11 +82,9 @@ describe("Basic Order Processing Worker Integration", () => {
       }),
       urls: [amqpConnectionUrl],
     });
-    const worker = workerResult
-      .recover((e) => {
-        throw e;
-      })
-      .unwrap();
+    const worker = workerResult.unwrapOrElse((e) => {
+      throw e;
+    });
 
     try {
       // WHEN
@@ -127,11 +121,9 @@ describe("Basic Order Processing Worker Integration", () => {
       });
       expect(notifications.length).toBeGreaterThanOrEqual(2);
     } finally {
-      (
-        await worker.close().recover((e) => {
-          throw e;
-        })
-      ).unwrap();
+      await worker.close().unwrapOrElse((e) => {
+        throw e;
+      });
     }
   });
 
@@ -161,11 +153,9 @@ describe("Basic Order Processing Worker Integration", () => {
       }),
       urls: [amqpConnectionUrl],
     });
-    const worker = workerResult
-      .recover((e) => {
-        throw e;
-      })
-      .unwrap();
+    const worker = workerResult.unwrapOrElse((e) => {
+      throw e;
+    });
 
     try {
       const newOrder = {
@@ -192,11 +182,9 @@ describe("Basic Order Processing Worker Integration", () => {
       expect(processedOrders.length).toBeGreaterThanOrEqual(1);
       expect(notifications.length).toBeGreaterThan(0); // Receives all events
     } finally {
-      (
-        await worker.close().recover((e) => {
-          throw e;
-        })
-      ).unwrap();
+      await worker.close().unwrapOrElse((e) => {
+        throw e;
+      });
     }
   });
 
@@ -206,25 +194,23 @@ describe("Basic Order Processing Worker Integration", () => {
   }) => {
     // GIVEN
     const fulfilled: Array<unknown> = [];
-    const worker = (
-      await TypedAmqpWorker.create({
-        contract: orderContract,
-        handlers: defineHandlers(orderContract, {
-          processOrder: () => Ok(undefined).toAsync(),
-          notifyOrder: () => Ok(undefined).toAsync(),
-          shipOrder: () => Ok(undefined).toAsync(),
-          handleUrgentOrder: () => Ok(undefined).toAsync(),
-          handleFailedOrders: () => Ok(undefined).toAsync(),
-          fulfillOrder: ({ payload }) => {
-            fulfilled.push(payload);
-            return Ok(undefined).toAsync();
-          },
-        }),
-        urls: [amqpConnectionUrl],
-      }).recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    const worker = await TypedAmqpWorker.create({
+      contract: orderContract,
+      handlers: defineHandlers(orderContract, {
+        processOrder: () => Ok(undefined).toAsync(),
+        notifyOrder: () => Ok(undefined).toAsync(),
+        shipOrder: () => Ok(undefined).toAsync(),
+        handleUrgentOrder: () => Ok(undefined).toAsync(),
+        handleFailedOrders: () => Ok(undefined).toAsync(),
+        fulfillOrder: ({ payload }) => {
+          fulfilled.push(payload);
+          return Ok(undefined).toAsync();
+        },
+      }),
+      urls: [amqpConnectionUrl],
+    }).unwrapOrElse((e) => {
+      throw e;
+    });
 
     try {
       const command = {
@@ -248,11 +234,9 @@ describe("Basic Order Processing Worker Integration", () => {
       });
       expect(fulfilled).toEqual([command]);
     } finally {
-      (
-        await worker.close().recover((e) => {
-          throw e;
-        })
-      ).unwrap();
+      await worker.close().unwrapOrElse((e) => {
+        throw e;
+      });
     }
   });
 });

--- a/examples/basic-order-processing-worker/src/index.ts
+++ b/examples/basic-order-processing-worker/src/index.ts
@@ -23,7 +23,7 @@ const logger = pino({
 
 async function main() {
   // Create type-safe worker with handlers for each consumer
-  const workerResult = await TypedAmqpWorker.create({
+  const workerResult = TypedAmqpWorker.create({
     contract: orderContract,
     handlers: defineHandlers(orderContract, {
       // Handler for processing NEW orders (order.created)
@@ -165,12 +165,10 @@ async function main() {
       },
     }),
     urls: [env.AMQP_URL],
-  })
-    .tapErr((error) => logger.error({ error }, "Failed to create worker"))
-    .recover((error) => {
-      throw error;
-    });
-  const worker = workerResult.unwrap();
+  }).tapErr((error) => logger.error({ error }, "Failed to create worker"));
+  const worker = await workerResult.unwrapOrElse((error) => {
+    throw error;
+  });
 
   logger.info("Worker ready, waiting for messages...");
   logger.info("=".repeat(60));
@@ -189,11 +187,9 @@ async function main() {
   // Handle graceful shutdown
   process.on("SIGINT", async () => {
     logger.info("Shutting down worker...");
-    (
-      await worker.close().recover((error) => {
-        throw error;
-      })
-    ).unwrap();
+    await worker.close().unwrapOrElse((error) => {
+      throw error;
+    });
     process.exit(0);
   });
 }

--- a/examples/basic-order-processing-worker/src/index.ts
+++ b/examples/basic-order-processing-worker/src/index.ts
@@ -165,7 +165,11 @@ async function main() {
       },
     }),
     urls: [env.AMQP_URL],
-  }).tapErr((error) => logger.error({ error }, "Failed to create worker"));
+  })
+    .tapErr((error) => logger.error({ error }, "Failed to create worker"))
+    .recover((error) => {
+      throw error;
+    });
   const worker = workerResult.unwrap();
 
   logger.info("Worker ready, waiting for messages...");
@@ -185,7 +189,11 @@ async function main() {
   // Handle graceful shutdown
   process.on("SIGINT", async () => {
     logger.info("Shutting down worker...");
-    (await worker.close()).unwrap();
+    (
+      await worker.close().recover((error) => {
+        throw error;
+      })
+    ).unwrap();
     process.exit(0);
   });
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -61,8 +61,7 @@
     "@amqp-contract/contract": "workspace:*",
     "@amqp-contract/core": "workspace:*",
     "@standard-schema/spec": "catalog:",
-    "ts-pattern": "catalog:",
-    "unthrown": "catalog:"
+    "ts-pattern": "catalog:"
   },
   "devDependencies": {
     "@amqp-contract/testing": "workspace:*",
@@ -77,8 +76,12 @@
     "typedoc": "catalog:",
     "typedoc-plugin-markdown": "catalog:",
     "typescript": "catalog:",
+    "unthrown": "catalog:",
     "vitest": "catalog:",
     "zod": "catalog:"
+  },
+  "peerDependencies": {
+    "unthrown": "^4.0.0"
   },
   "engines": {
     "node": ">=22.19"

--- a/packages/client/src/__tests__/client.spec.ts
+++ b/packages/client/src/__tests__/client.spec.ts
@@ -28,15 +28,13 @@ const it = baseIt.extend<{
           contract: TContract,
           options?: Omit<CreateClientOptions<TContract>, "contract" | "urls">,
         ) => {
-          const client = (
-            await TypedAmqpClient.create({
-              contract,
-              urls: [amqpConnectionUrl],
-              ...options,
-            }).recover((e) => {
-              throw e;
-            })
-          ).unwrap();
+          const client = await TypedAmqpClient.create({
+            contract,
+            urls: [amqpConnectionUrl],
+            ...options,
+          }).unwrapOrElse((e) => {
+            throw e;
+          });
 
           clients.push(client);
           return client;
@@ -47,11 +45,9 @@ const it = baseIt.extend<{
       await Promise.all(
         clients.map(async (client) => {
           try {
-            (
-              await client.close().recover((e) => {
-                throw e;
-              })
-            ).unwrap();
+            await client.close().unwrapOrElse((e) => {
+              throw e;
+            });
           } catch (error) {
             // Swallow errors during cleanup to avoid unhandled rejections
             // eslint-disable-next-line no-console
@@ -271,11 +267,9 @@ describe("AmqpClient Integration", () => {
         }),
       ]);
 
-      (
-        await client.close().recover((e) => {
-          throw e;
-        })
-      ).unwrap();
+      await client.close().unwrapOrElse((e) => {
+        throw e;
+      });
     });
 
     it("should override default publish options with publish-specific options", async ({
@@ -329,11 +323,9 @@ describe("AmqpClient Integration", () => {
         }),
       ]);
 
-      (
-        await client.close().recover((e) => {
-          throw e;
-        })
-      ).unwrap();
+      await client.close().unwrapOrElse((e) => {
+        throw e;
+      });
     });
   });
 

--- a/packages/client/src/__tests__/client.spec.ts
+++ b/packages/client/src/__tests__/client.spec.ts
@@ -33,6 +33,8 @@ const it = baseIt.extend<{
               contract,
               urls: [amqpConnectionUrl],
               ...options,
+            }).recover((e) => {
+              throw e;
             })
           ).unwrap();
 
@@ -45,7 +47,11 @@ const it = baseIt.extend<{
       await Promise.all(
         clients.map(async (client) => {
           try {
-            (await client.close()).unwrap();
+            (
+              await client.close().recover((e) => {
+                throw e;
+              })
+            ).unwrap();
           } catch (error) {
             // Swallow errors during cleanup to avoid unhandled rejections
             // eslint-disable-next-line no-console
@@ -265,7 +271,11 @@ describe("AmqpClient Integration", () => {
         }),
       ]);
 
-      (await client.close()).unwrap();
+      (
+        await client.close().recover((e) => {
+          throw e;
+        })
+      ).unwrap();
     });
 
     it("should override default publish options with publish-specific options", async ({
@@ -319,7 +329,11 @@ describe("AmqpClient Integration", () => {
         }),
       ]);
 
-      (await client.close()).unwrap();
+      (
+        await client.close().recover((e) => {
+          throw e;
+        })
+      ).unwrap();
     });
   });
 

--- a/packages/client/src/compression.spec.ts
+++ b/packages/client/src/compression.spec.ts
@@ -10,7 +10,11 @@ describe("Compression utilities", () => {
       const gunzipAsync = promisify(gunzip);
 
       const testData = Buffer.from(JSON.stringify({ message: "Hello, World!" }));
-      const compressed = (await compressBuffer(testData, "gzip")).unwrap();
+      const compressed = (
+        await compressBuffer(testData, "gzip").recover((e) => {
+          throw e;
+        })
+      ).unwrap();
       const decompressed = await gunzipAsync(compressed);
 
       expect(decompressed).toEqual(testData);
@@ -22,7 +26,11 @@ describe("Compression utilities", () => {
       const inflateAsync = promisify(inflate);
 
       const testData = Buffer.from(JSON.stringify({ message: "Hello, World!" }));
-      const compressed = (await compressBuffer(testData, "deflate")).unwrap();
+      const compressed = (
+        await compressBuffer(testData, "deflate").recover((e) => {
+          throw e;
+        })
+      ).unwrap();
       const decompressed = await inflateAsync(compressed);
 
       expect(decompressed).toEqual(testData);
@@ -40,7 +48,11 @@ describe("Compression utilities", () => {
         }),
       );
 
-      const compressed = (await compressBuffer(largeData, "gzip")).unwrap();
+      const compressed = (
+        await compressBuffer(largeData, "gzip").recover((e) => {
+          throw e;
+        })
+      ).unwrap();
 
       // Compressed data should be significantly smaller
       expect(compressed.length).toBeLessThan(largeData.length);

--- a/packages/client/src/compression.spec.ts
+++ b/packages/client/src/compression.spec.ts
@@ -10,11 +10,9 @@ describe("Compression utilities", () => {
       const gunzipAsync = promisify(gunzip);
 
       const testData = Buffer.from(JSON.stringify({ message: "Hello, World!" }));
-      const compressed = (
-        await compressBuffer(testData, "gzip").recover((e) => {
-          throw e;
-        })
-      ).unwrap();
+      const compressed = await compressBuffer(testData, "gzip").unwrapOrElse((e) => {
+        throw e;
+      });
       const decompressed = await gunzipAsync(compressed);
 
       expect(decompressed).toEqual(testData);
@@ -26,11 +24,9 @@ describe("Compression utilities", () => {
       const inflateAsync = promisify(inflate);
 
       const testData = Buffer.from(JSON.stringify({ message: "Hello, World!" }));
-      const compressed = (
-        await compressBuffer(testData, "deflate").recover((e) => {
-          throw e;
-        })
-      ).unwrap();
+      const compressed = await compressBuffer(testData, "deflate").unwrapOrElse((e) => {
+        throw e;
+      });
       const decompressed = await inflateAsync(compressed);
 
       expect(decompressed).toEqual(testData);
@@ -48,11 +44,9 @@ describe("Compression utilities", () => {
         }),
       );
 
-      const compressed = (
-        await compressBuffer(largeData, "gzip").recover((e) => {
-          throw e;
-        })
-      ).unwrap();
+      const compressed = await compressBuffer(largeData, "gzip").unwrapOrElse((e) => {
+        throw e;
+      });
 
       // Compressed data should be significantly smaller
       expect(compressed.length).toBeLessThan(largeData.length);

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -15,16 +15,12 @@ export { MessageValidationError } from "@amqp-contract/core";
 export class RpcTimeoutError extends TaggedError("@amqp-contract/RpcTimeoutError", {
   name: "RpcTimeoutError",
 })<{
-  message: string;
   rpcName: string;
   timeoutMs: number;
 }> {
   constructor(rpcName: string, timeoutMs: number) {
-    super({
-      message: `RPC call to "${rpcName}" timed out after ${timeoutMs}ms with no reply received`,
-      rpcName,
-      timeoutMs,
-    });
+    super({ rpcName, timeoutMs });
+    this.message = `RPC call to "${rpcName}" timed out after ${timeoutMs}ms with no reply received`;
   }
 }
 
@@ -38,13 +34,10 @@ export class RpcTimeoutError extends TaggedError("@amqp-contract/RpcTimeoutError
 export class RpcCancelledError extends TaggedError("@amqp-contract/RpcCancelledError", {
   name: "RpcCancelledError",
 })<{
-  message: string;
   rpcName: string;
 }> {
   constructor(rpcName: string) {
-    super({
-      message: `RPC call to "${rpcName}" was cancelled because the client was closed`,
-      rpcName,
-    });
+    super({ rpcName });
+    this.message = `RPC call to "${rpcName}" was cancelled because the client was closed`;
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,8 +60,7 @@
   "dependencies": {
     "@amqp-contract/contract": "workspace:*",
     "amqp-connection-manager": "catalog:",
-    "amqplib": "catalog:",
-    "unthrown": "catalog:"
+    "amqplib": "catalog:"
   },
   "devDependencies": {
     "@amqp-contract/testing": "workspace:*",
@@ -74,11 +73,13 @@
     "tsdown": "catalog:",
     "typedoc": "catalog:",
     "typescript": "catalog:",
+    "unthrown": "catalog:",
     "vitest": "catalog:",
     "zod": "catalog:"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.0"
+    "@opentelemetry/api": "^1.0.0",
+    "unthrown": "^4.0.0"
   },
   "peerDependenciesMeta": {
     "@opentelemetry/api": {

--- a/packages/core/src/__tests__/amqp-client.spec.ts
+++ b/packages/core/src/__tests__/amqp-client.spec.ts
@@ -35,22 +35,18 @@ describe("AmqpClient Integration", () => {
     });
 
     // Wait for setup to complete
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // THEN - Verify exchanges exist by checking them
     await expect(amqpChannel.checkExchange("orders")).resolves.toBeDefined();
     await expect(amqpChannel.checkExchange("notifications")).resolves.toBeDefined();
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 
   it("should setup queues from contract", async ({ amqpConnectionUrl, amqpChannel }) => {
@@ -67,22 +63,18 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // THEN - Verify queues exist by checking them
     await expect(amqpChannel.checkQueue("order-processing")).resolves.toBeDefined();
     await expect(amqpChannel.checkQueue("notifications")).resolves.toBeDefined();
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 
   it("should setup queue bindings from contract", async ({
@@ -111,11 +103,9 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // Setup consumer before publishing
     const waitForMessages = await initConsumer("orders", "order.created");
@@ -131,11 +121,9 @@ describe("AmqpClient Integration", () => {
     ]);
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 
   it("should setup exchange-to-exchange bindings", async ({
@@ -162,11 +150,9 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // Setup consumer on destination exchange
     const waitForMessages = await initConsumer("destination", "test.important");
@@ -182,11 +168,9 @@ describe("AmqpClient Integration", () => {
     ]);
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 
   it("should setup complete contract with all resources", async ({
@@ -224,11 +208,9 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // Setup consumers
     const waitForOrderMessages = await initConsumer("orders", "order.created");
@@ -251,11 +233,9 @@ describe("AmqpClient Integration", () => {
     ]);
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 
   it("should handle empty contract", async ({ amqpConnectionUrl }) => {
@@ -267,21 +247,17 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // THEN - Should not throw and client should be usable
     expect(client.getConnection()).toBeDefined();
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 
   it("should handle fanout exchange binding without routing key", async ({
@@ -308,11 +284,9 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // Setup consumer
     const waitForMessages = await initConsumer("fanout", "");
@@ -328,11 +302,9 @@ describe("AmqpClient Integration", () => {
     ]);
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 
   it("should pass custom arguments to exchanges", async ({ amqpConnectionUrl, amqpChannel }) => {
@@ -351,21 +323,17 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // THEN - Exchange should exist (arguments would have been passed to RabbitMQ)
     await expect(amqpChannel.checkExchange("orders")).resolves.toBeDefined();
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 
   it("should pass custom arguments to queues", async ({ amqpConnectionUrl, amqpChannel }) => {
@@ -385,21 +353,17 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // THEN - Queue should exist with custom arguments
     await expect(amqpChannel.checkQueue("orders")).resolves.toBeDefined();
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 
   it("should setup bridged exchange-to-exchange bindings from contract", async ({
@@ -429,11 +393,9 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // Setup consumer on the local queue via bridge exchange
     const waitForMessages = await initConsumer(bridgeExchange.name, "order.created");
@@ -449,11 +411,9 @@ describe("AmqpClient Integration", () => {
     ]);
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 
   it("should close channel and connection properly", async ({ amqpConnectionUrl }) => {
@@ -468,18 +428,14 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // WHEN
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // THEN - Client should have been properly closed
     // Note: We can't easily verify connection closure in isolation due to singleton

--- a/packages/core/src/__tests__/amqp-client.spec.ts
+++ b/packages/core/src/__tests__/amqp-client.spec.ts
@@ -35,14 +35,22 @@ describe("AmqpClient Integration", () => {
     });
 
     // Wait for setup to complete
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // THEN - Verify exchanges exist by checking them
     await expect(amqpChannel.checkExchange("orders")).resolves.toBeDefined();
     await expect(amqpChannel.checkExchange("notifications")).resolves.toBeDefined();
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 
   it("should setup queues from contract", async ({ amqpConnectionUrl, amqpChannel }) => {
@@ -59,14 +67,22 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // THEN - Verify queues exist by checking them
     await expect(amqpChannel.checkQueue("order-processing")).resolves.toBeDefined();
     await expect(amqpChannel.checkQueue("notifications")).resolves.toBeDefined();
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 
   it("should setup queue bindings from contract", async ({
@@ -95,7 +111,11 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // Setup consumer before publishing
     const waitForMessages = await initConsumer("orders", "order.created");
@@ -111,7 +131,11 @@ describe("AmqpClient Integration", () => {
     ]);
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 
   it("should setup exchange-to-exchange bindings", async ({
@@ -138,7 +162,11 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // Setup consumer on destination exchange
     const waitForMessages = await initConsumer("destination", "test.important");
@@ -154,7 +182,11 @@ describe("AmqpClient Integration", () => {
     ]);
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 
   it("should setup complete contract with all resources", async ({
@@ -192,7 +224,11 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // Setup consumers
     const waitForOrderMessages = await initConsumer("orders", "order.created");
@@ -215,7 +251,11 @@ describe("AmqpClient Integration", () => {
     ]);
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 
   it("should handle empty contract", async ({ amqpConnectionUrl }) => {
@@ -227,13 +267,21 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // THEN - Should not throw and client should be usable
     expect(client.getConnection()).toBeDefined();
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 
   it("should handle fanout exchange binding without routing key", async ({
@@ -260,7 +308,11 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // Setup consumer
     const waitForMessages = await initConsumer("fanout", "");
@@ -276,7 +328,11 @@ describe("AmqpClient Integration", () => {
     ]);
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 
   it("should pass custom arguments to exchanges", async ({ amqpConnectionUrl, amqpChannel }) => {
@@ -295,13 +351,21 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // THEN - Exchange should exist (arguments would have been passed to RabbitMQ)
     await expect(amqpChannel.checkExchange("orders")).resolves.toBeDefined();
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 
   it("should pass custom arguments to queues", async ({ amqpConnectionUrl, amqpChannel }) => {
@@ -321,13 +385,21 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // THEN - Queue should exist with custom arguments
     await expect(amqpChannel.checkQueue("orders")).resolves.toBeDefined();
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 
   it("should setup bridged exchange-to-exchange bindings from contract", async ({
@@ -357,7 +429,11 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // Setup consumer on the local queue via bridge exchange
     const waitForMessages = await initConsumer(bridgeExchange.name, "order.created");
@@ -373,7 +449,11 @@ describe("AmqpClient Integration", () => {
     ]);
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 
   it("should close channel and connection properly", async ({ amqpConnectionUrl }) => {
@@ -388,10 +468,18 @@ describe("AmqpClient Integration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // WHEN
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // THEN - Client should have been properly closed
     // Note: We can't easily verify connection closure in isolation due to singleton

--- a/packages/core/src/__tests__/channel-config.spec.ts
+++ b/packages/core/src/__tests__/channel-config.spec.ts
@@ -27,22 +27,18 @@ describe("AmqpClient Channel Configuration", () => {
       },
     });
 
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // THEN - Channel should be created with json: false
     // We can't directly test the internal json setting, but we can verify the client was created
     expect(client.getConnection()).toBeDefined();
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 
   it("should keep json as true by default", async ({ amqpConnectionUrl }) => {
@@ -58,21 +54,17 @@ describe("AmqpClient Channel Configuration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // THEN - Default json: true should be used
     expect(client.getConnection()).toBeDefined();
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 
   it("should call custom setup function after topology setup", async ({
@@ -99,11 +91,9 @@ describe("AmqpClient Channel Configuration", () => {
       },
     });
 
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // THEN - Custom setup should have been called
     expect(customSetupMock).toHaveBeenCalledTimes(1);
@@ -114,11 +104,9 @@ describe("AmqpClient Channel Configuration", () => {
     await expect(amqpChannel.checkQueue("custom-queue")).resolves.toBeDefined();
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 
   it("should support callback-based custom setup function", async ({
@@ -148,11 +136,9 @@ describe("AmqpClient Channel Configuration", () => {
       },
     });
 
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // THEN - Callback setup should have been called
     expect(callbackSetupMock).toHaveBeenCalledTimes(1);
@@ -162,11 +148,9 @@ describe("AmqpClient Channel Configuration", () => {
     await expect(amqpChannel.checkQueue("callback-queue")).resolves.toBeDefined();
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 
   it("should override default channel name", async ({ amqpConnectionUrl }) => {
@@ -187,21 +171,17 @@ describe("AmqpClient Channel Configuration", () => {
       },
     });
 
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // THEN - Channel should be created
     expect(client.getConnection()).toBeDefined();
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 
   it("should allow disabling confirmChannel option", async ({ amqpConnectionUrl }) => {
@@ -220,21 +200,17 @@ describe("AmqpClient Channel Configuration", () => {
       },
     });
 
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // THEN - Regular channel should be created
     expect(client.getConnection()).toBeDefined();
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 
   it("should combine user channel options with defaults", async ({ amqpConnectionUrl }) => {
@@ -254,20 +230,16 @@ describe("AmqpClient Channel Configuration", () => {
       },
     });
 
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // THEN - All options should be applied
     expect(client.getConnection()).toBeDefined();
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 });

--- a/packages/core/src/__tests__/channel-config.spec.ts
+++ b/packages/core/src/__tests__/channel-config.spec.ts
@@ -27,14 +27,22 @@ describe("AmqpClient Channel Configuration", () => {
       },
     });
 
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // THEN - Channel should be created with json: false
     // We can't directly test the internal json setting, but we can verify the client was created
     expect(client.getConnection()).toBeDefined();
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 
   it("should keep json as true by default", async ({ amqpConnectionUrl }) => {
@@ -50,13 +58,21 @@ describe("AmqpClient Channel Configuration", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // THEN - Default json: true should be used
     expect(client.getConnection()).toBeDefined();
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 
   it("should call custom setup function after topology setup", async ({
@@ -83,7 +99,11 @@ describe("AmqpClient Channel Configuration", () => {
       },
     });
 
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // THEN - Custom setup should have been called
     expect(customSetupMock).toHaveBeenCalledTimes(1);
@@ -94,7 +114,11 @@ describe("AmqpClient Channel Configuration", () => {
     await expect(amqpChannel.checkQueue("custom-queue")).resolves.toBeDefined();
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 
   it("should support callback-based custom setup function", async ({
@@ -124,7 +148,11 @@ describe("AmqpClient Channel Configuration", () => {
       },
     });
 
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // THEN - Callback setup should have been called
     expect(callbackSetupMock).toHaveBeenCalledTimes(1);
@@ -134,7 +162,11 @@ describe("AmqpClient Channel Configuration", () => {
     await expect(amqpChannel.checkQueue("callback-queue")).resolves.toBeDefined();
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 
   it("should override default channel name", async ({ amqpConnectionUrl }) => {
@@ -155,13 +187,21 @@ describe("AmqpClient Channel Configuration", () => {
       },
     });
 
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // THEN - Channel should be created
     expect(client.getConnection()).toBeDefined();
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 
   it("should allow disabling confirmChannel option", async ({ amqpConnectionUrl }) => {
@@ -180,13 +220,21 @@ describe("AmqpClient Channel Configuration", () => {
       },
     });
 
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // THEN - Regular channel should be created
     expect(client.getConnection()).toBeDefined();
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 
   it("should combine user channel options with defaults", async ({ amqpConnectionUrl }) => {
@@ -206,12 +254,20 @@ describe("AmqpClient Channel Configuration", () => {
       },
     });
 
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // THEN - All options should be applied
     expect(client.getConnection()).toBeDefined();
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 });

--- a/packages/core/src/__tests__/connection-sharing.spec.ts
+++ b/packages/core/src/__tests__/connection-sharing.spec.ts
@@ -24,15 +24,31 @@ describe("AmqpClient Connection Sharing Integration", () => {
     const client1 = new AmqpClient(contract, { urls });
     const client2 = new AmqpClient(contract, { urls });
 
-    (await client1.waitForConnect()).unwrap();
-    (await client2.waitForConnect()).unwrap();
+    (
+      await client1.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
+    (
+      await client2.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // THEN - Both clients should share the same connection instance
     expect(client1.getConnection()).toBe(client2.getConnection());
 
     // CLEANUP
-    (await client1.close()).unwrap();
-    (await client2.close()).unwrap();
+    (
+      await client1.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
+    (
+      await client2.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 
   it("should create separate connections for different URLs", async ({ amqpConnectionUrl }) => {
@@ -48,7 +64,11 @@ describe("AmqpClient Connection Sharing Integration", () => {
     const client1 = new AmqpClient(contract, { urls: [amqpConnectionUrl] });
     const client2 = new AmqpClient(contract, { urls: [`${amqpConnectionUrl}-different`] });
 
-    (await client1.waitForConnect()).unwrap();
+    (
+      await client1.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
     // client2 will fail to connect due to invalid URL, but that's okay for this test
 
     // THEN - Connections should be different instances
@@ -57,8 +77,16 @@ describe("AmqpClient Connection Sharing Integration", () => {
     expect(client1.getConnection()).not.toBe(client2.getConnection());
 
     // CLEANUP
-    (await client1.close()).unwrap();
-    (await client2.close()).unwrap();
+    (
+      await client1.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
+    (
+      await client2.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 
   it("should maintain connection when only one client closes", async ({ amqpConnectionUrl }) => {
@@ -73,19 +101,35 @@ describe("AmqpClient Connection Sharing Integration", () => {
     const client1 = new AmqpClient(contract, { urls });
     const client2 = new AmqpClient(contract, { urls });
 
-    (await client1.waitForConnect()).unwrap();
-    (await client2.waitForConnect()).unwrap();
+    (
+      await client1.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
+    (
+      await client2.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     const sharedConnection = client1.getConnection();
 
     // WHEN - Close first client
-    (await client1.close()).unwrap();
+    (
+      await client1.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // THEN - Connection should still be alive (used by client2)
     expect(sharedConnection.isConnected()).toBe(true);
 
     // CLEANUP
-    (await client2.close()).unwrap();
+    (
+      await client2.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 
   it("should close connection when last client closes", async ({ amqpConnectionUrl }) => {
@@ -100,14 +144,30 @@ describe("AmqpClient Connection Sharing Integration", () => {
     const client1 = new AmqpClient(contract, { urls });
     const client2 = new AmqpClient(contract, { urls });
 
-    (await client1.waitForConnect()).unwrap();
-    (await client2.waitForConnect()).unwrap();
+    (
+      await client1.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
+    (
+      await client2.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     const sharedConnection = client1.getConnection();
 
     // WHEN - Close both clients
-    (await client1.close()).unwrap();
-    (await client2.close()).unwrap();
+    (
+      await client1.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
+    (
+      await client2.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // Give connection a moment to close
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -132,8 +192,16 @@ describe("AmqpClient Connection Sharing Integration", () => {
     const client1b = new AmqpClient(contract, { urls: urls1 });
     const client2a = new AmqpClient(contract, { urls: urls2 });
 
-    (await client1a.waitForConnect()).unwrap();
-    (await client1b.waitForConnect()).unwrap();
+    (
+      await client1a.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
+    (
+      await client1b.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
     // client2a will fail to connect but that's okay
 
     // THEN - Clients with same URLs should share connection
@@ -141,9 +209,21 @@ describe("AmqpClient Connection Sharing Integration", () => {
     expect(client1a.getConnection()).not.toBe(client2a.getConnection());
 
     // CLEANUP
-    (await client1a.close()).unwrap();
-    (await client1b.close()).unwrap();
-    (await client2a.close()).unwrap();
+    (
+      await client1a.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
+    (
+      await client1b.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
+    (
+      await client2a.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 
   it("should handle rapid create and close cycles", async ({ amqpConnectionUrl }) => {
@@ -159,16 +239,32 @@ describe("AmqpClient Connection Sharing Integration", () => {
     // WHEN - Rapidly create and close clients
     for (let i = 0; i < 5; i++) {
       const client = new AmqpClient(contract, { urls });
-      (await client.waitForConnect()).unwrap();
-      (await client.close()).unwrap();
+      (
+        await client.waitForConnect().recover((e) => {
+          throw e;
+        })
+      ).unwrap();
+      (
+        await client.close().recover((e) => {
+          throw e;
+        })
+      ).unwrap();
     }
 
     // THEN - Should not throw errors and last close should clean up connection
     const finalClient = new AmqpClient(contract, { urls });
-    (await finalClient.waitForConnect()).unwrap();
+    (
+      await finalClient.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
     expect(finalClient.getConnection()).toBeDefined();
 
     // CLEANUP
-    (await finalClient.close()).unwrap();
+    (
+      await finalClient.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 });

--- a/packages/core/src/__tests__/connection-sharing.spec.ts
+++ b/packages/core/src/__tests__/connection-sharing.spec.ts
@@ -24,31 +24,23 @@ describe("AmqpClient Connection Sharing Integration", () => {
     const client1 = new AmqpClient(contract, { urls });
     const client2 = new AmqpClient(contract, { urls });
 
-    (
-      await client1.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
-    (
-      await client2.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client1.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
+    await client2.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // THEN - Both clients should share the same connection instance
     expect(client1.getConnection()).toBe(client2.getConnection());
 
     // CLEANUP
-    (
-      await client1.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
-    (
-      await client2.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client1.close().unwrapOrElse((e) => {
+      throw e;
+    });
+    await client2.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 
   it("should create separate connections for different URLs", async ({ amqpConnectionUrl }) => {
@@ -64,11 +56,9 @@ describe("AmqpClient Connection Sharing Integration", () => {
     const client1 = new AmqpClient(contract, { urls: [amqpConnectionUrl] });
     const client2 = new AmqpClient(contract, { urls: [`${amqpConnectionUrl}-different`] });
 
-    (
-      await client1.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client1.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
     // client2 will fail to connect due to invalid URL, but that's okay for this test
 
     // THEN - Connections should be different instances
@@ -77,16 +67,12 @@ describe("AmqpClient Connection Sharing Integration", () => {
     expect(client1.getConnection()).not.toBe(client2.getConnection());
 
     // CLEANUP
-    (
-      await client1.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
-    (
-      await client2.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client1.close().unwrapOrElse((e) => {
+      throw e;
+    });
+    await client2.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 
   it("should maintain connection when only one client closes", async ({ amqpConnectionUrl }) => {
@@ -101,35 +87,27 @@ describe("AmqpClient Connection Sharing Integration", () => {
     const client1 = new AmqpClient(contract, { urls });
     const client2 = new AmqpClient(contract, { urls });
 
-    (
-      await client1.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
-    (
-      await client2.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client1.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
+    await client2.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     const sharedConnection = client1.getConnection();
 
     // WHEN - Close first client
-    (
-      await client1.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client1.close().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // THEN - Connection should still be alive (used by client2)
     expect(sharedConnection.isConnected()).toBe(true);
 
     // CLEANUP
-    (
-      await client2.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client2.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 
   it("should close connection when last client closes", async ({ amqpConnectionUrl }) => {
@@ -144,30 +122,22 @@ describe("AmqpClient Connection Sharing Integration", () => {
     const client1 = new AmqpClient(contract, { urls });
     const client2 = new AmqpClient(contract, { urls });
 
-    (
-      await client1.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
-    (
-      await client2.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client1.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
+    await client2.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     const sharedConnection = client1.getConnection();
 
     // WHEN - Close both clients
-    (
-      await client1.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
-    (
-      await client2.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client1.close().unwrapOrElse((e) => {
+      throw e;
+    });
+    await client2.close().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // Give connection a moment to close
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -192,16 +162,12 @@ describe("AmqpClient Connection Sharing Integration", () => {
     const client1b = new AmqpClient(contract, { urls: urls1 });
     const client2a = new AmqpClient(contract, { urls: urls2 });
 
-    (
-      await client1a.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
-    (
-      await client1b.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client1a.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
+    await client1b.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
     // client2a will fail to connect but that's okay
 
     // THEN - Clients with same URLs should share connection
@@ -209,21 +175,15 @@ describe("AmqpClient Connection Sharing Integration", () => {
     expect(client1a.getConnection()).not.toBe(client2a.getConnection());
 
     // CLEANUP
-    (
-      await client1a.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
-    (
-      await client1b.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
-    (
-      await client2a.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client1a.close().unwrapOrElse((e) => {
+      throw e;
+    });
+    await client1b.close().unwrapOrElse((e) => {
+      throw e;
+    });
+    await client2a.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 
   it("should handle rapid create and close cycles", async ({ amqpConnectionUrl }) => {
@@ -239,32 +199,24 @@ describe("AmqpClient Connection Sharing Integration", () => {
     // WHEN - Rapidly create and close clients
     for (let i = 0; i < 5; i++) {
       const client = new AmqpClient(contract, { urls });
-      (
-        await client.waitForConnect().recover((e) => {
-          throw e;
-        })
-      ).unwrap();
-      (
-        await client.close().recover((e) => {
-          throw e;
-        })
-      ).unwrap();
+      await client.waitForConnect().unwrapOrElse((e) => {
+        throw e;
+      });
+      await client.close().unwrapOrElse((e) => {
+        throw e;
+      });
     }
 
     // THEN - Should not throw errors and last close should clean up connection
     const finalClient = new AmqpClient(contract, { urls });
-    (
-      await finalClient.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await finalClient.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
     expect(finalClient.getConnection()).toBeDefined();
 
     // CLEANUP
-    (
-      await finalClient.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await finalClient.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 });

--- a/packages/core/src/__tests__/dead-letter.spec.ts
+++ b/packages/core/src/__tests__/dead-letter.spec.ts
@@ -36,7 +36,11 @@ describe("Dead Letter Exchange Support", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // THEN - Check that the queue was created with dead letter configuration
     const queueInfo = await amqpChannel.checkQueue("test-queue-with-dlx");
@@ -48,7 +52,11 @@ describe("Dead Letter Exchange Support", () => {
     );
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
     await amqpChannel.deleteQueue("test-queue-with-dlx");
     await amqpChannel.deleteExchange("test-dlx");
   });
@@ -81,7 +89,11 @@ describe("Dead Letter Exchange Support", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // THEN - Check that the queue was created
     const queueInfo = await amqpChannel.checkQueue("test-queue-dlx-no-key");
@@ -92,7 +104,11 @@ describe("Dead Letter Exchange Support", () => {
     );
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
     await amqpChannel.deleteQueue("test-queue-dlx-no-key");
     await amqpChannel.deleteExchange("test-dlx-no-key");
   });
@@ -118,7 +134,11 @@ describe("Dead Letter Exchange Support", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // THEN - Check that the queue was created normally
     const queueInfo = await amqpChannel.checkQueue("test-queue-no-dlx");
@@ -129,7 +149,11 @@ describe("Dead Letter Exchange Support", () => {
     );
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
     await amqpChannel.deleteQueue("test-queue-no-dlx");
   });
 
@@ -166,7 +190,11 @@ describe("Dead Letter Exchange Support", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // THEN - All resources should be created with correct structure
     const mainQueueInfo = await amqpChannel.checkQueue("test-main-queue");
@@ -195,7 +223,11 @@ describe("Dead Letter Exchange Support", () => {
     expect(dlxInfo).toBeDefined();
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
     await amqpChannel.deleteQueue("test-main-queue");
     await amqpChannel.deleteQueue("test-dlx-queue");
     await amqpChannel.deleteExchange("test-main-exchange");
@@ -247,6 +279,10 @@ describe("Dead Letter Exchange Support", () => {
     });
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 });

--- a/packages/core/src/__tests__/dead-letter.spec.ts
+++ b/packages/core/src/__tests__/dead-letter.spec.ts
@@ -36,11 +36,9 @@ describe("Dead Letter Exchange Support", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // THEN - Check that the queue was created with dead letter configuration
     const queueInfo = await amqpChannel.checkQueue("test-queue-with-dlx");
@@ -52,11 +50,9 @@ describe("Dead Letter Exchange Support", () => {
     );
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
     await amqpChannel.deleteQueue("test-queue-with-dlx");
     await amqpChannel.deleteExchange("test-dlx");
   });
@@ -89,11 +85,9 @@ describe("Dead Letter Exchange Support", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // THEN - Check that the queue was created
     const queueInfo = await amqpChannel.checkQueue("test-queue-dlx-no-key");
@@ -104,11 +98,9 @@ describe("Dead Letter Exchange Support", () => {
     );
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
     await amqpChannel.deleteQueue("test-queue-dlx-no-key");
     await amqpChannel.deleteExchange("test-dlx-no-key");
   });
@@ -134,11 +126,9 @@ describe("Dead Letter Exchange Support", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // THEN - Check that the queue was created normally
     const queueInfo = await amqpChannel.checkQueue("test-queue-no-dlx");
@@ -149,11 +139,9 @@ describe("Dead Letter Exchange Support", () => {
     );
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
     await amqpChannel.deleteQueue("test-queue-no-dlx");
   });
 
@@ -190,11 +178,9 @@ describe("Dead Letter Exchange Support", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // THEN - All resources should be created with correct structure
     const mainQueueInfo = await amqpChannel.checkQueue("test-main-queue");
@@ -223,11 +209,9 @@ describe("Dead Letter Exchange Support", () => {
     expect(dlxInfo).toBeDefined();
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
     await amqpChannel.deleteQueue("test-main-queue");
     await amqpChannel.deleteQueue("test-dlx-queue");
     await amqpChannel.deleteExchange("test-main-exchange");
@@ -279,10 +263,8 @@ describe("Dead Letter Exchange Support", () => {
     });
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 });

--- a/packages/core/src/__tests__/prefetch.spec.ts
+++ b/packages/core/src/__tests__/prefetch.spec.ts
@@ -37,22 +37,30 @@ describe("AmqpClient prefetch integration", () => {
     };
 
     const client = new AmqpClient(contract, { urls: [amqpConnectionUrl] });
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // Hold every delivery: never ack, so the broker is forced to honour the
     // per-consumer prefetch cap (it cannot deliver more than `prefetch`
     // unacked messages over the consumer at a time).
     const heldDeliveryTags: number[] = [];
     (
-      await client.consume(
-        "prefetch-q",
-        (msg) => {
-          if (msg) {
-            heldDeliveryTags.push(msg.fields.deliveryTag);
-          }
-        },
-        { prefetch: 2 },
-      )
+      await client
+        .consume(
+          "prefetch-q",
+          (msg) => {
+            if (msg) {
+              heldDeliveryTags.push(msg.fields.deliveryTag);
+            }
+          },
+          { prefetch: 2 },
+        )
+        .recover((e) => {
+          throw e;
+        })
     ).unwrap();
 
     // WHEN publishing more messages than the prefetch allows.
@@ -80,6 +88,10 @@ describe("AmqpClient prefetch integration", () => {
     expect(heldDeliveryTags).toHaveLength(2);
 
     // CLEANUP — close releases unack'd messages back to the queue.
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 });

--- a/packages/core/src/__tests__/prefetch.spec.ts
+++ b/packages/core/src/__tests__/prefetch.spec.ts
@@ -37,31 +37,27 @@ describe("AmqpClient prefetch integration", () => {
     };
 
     const client = new AmqpClient(contract, { urls: [amqpConnectionUrl] });
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // Hold every delivery: never ack, so the broker is forced to honour the
     // per-consumer prefetch cap (it cannot deliver more than `prefetch`
     // unacked messages over the consumer at a time).
     const heldDeliveryTags: number[] = [];
-    (
-      await client
-        .consume(
-          "prefetch-q",
-          (msg) => {
-            if (msg) {
-              heldDeliveryTags.push(msg.fields.deliveryTag);
-            }
-          },
-          { prefetch: 2 },
-        )
-        .recover((e) => {
-          throw e;
-        })
-    ).unwrap();
+    await client
+      .consume(
+        "prefetch-q",
+        (msg) => {
+          if (msg) {
+            heldDeliveryTags.push(msg.fields.deliveryTag);
+          }
+        },
+        { prefetch: 2 },
+      )
+      .unwrapOrElse((e) => {
+        throw e;
+      });
 
     // WHEN publishing more messages than the prefetch allows.
     for (let i = 0; i < 10; i++) {
@@ -88,10 +84,8 @@ describe("AmqpClient prefetch integration", () => {
     expect(heldDeliveryTags).toHaveLength(2);
 
     // CLEANUP — close releases unack'd messages back to the queue.
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 });

--- a/packages/core/src/__tests__/priority-queue.spec.ts
+++ b/packages/core/src/__tests__/priority-queue.spec.ts
@@ -43,22 +43,18 @@ describe("Priority Queue", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // THEN - Verify queue was created with x-max-priority
     const queueInfo = await amqpChannel.checkQueue("test-priority-queue");
     expect(queueInfo.queue).toBe("test-priority-queue");
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
     await amqpChannel.deleteQueue("test-priority-queue");
   });
 
@@ -106,37 +102,29 @@ describe("Priority Queue", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // Publish messages with different priorities
     // Publishing in this order: low (1), medium (5), high (10)
-    (
-      await client
-        .publish(exchange.name, "test", { id: "msg-low", priority: 1 }, { priority: 1 })
-        .recover((e) => {
-          throw e;
-        })
-    ).unwrap();
+    await client
+      .publish(exchange.name, "test", { id: "msg-low", priority: 1 }, { priority: 1 })
+      .unwrapOrElse((e) => {
+        throw e;
+      });
 
-    (
-      await client
-        .publish(exchange.name, "test", { id: "msg-medium", priority: 5 }, { priority: 5 })
-        .recover((e) => {
-          throw e;
-        })
-    ).unwrap();
+    await client
+      .publish(exchange.name, "test", { id: "msg-medium", priority: 5 }, { priority: 5 })
+      .unwrapOrElse((e) => {
+        throw e;
+      });
 
-    (
-      await client
-        .publish(exchange.name, "test", { id: "msg-high", priority: 10 }, { priority: 10 })
-        .recover((e) => {
-          throw e;
-        })
-    ).unwrap();
+    await client
+      .publish(exchange.name, "test", { id: "msg-high", priority: 10 }, { priority: 10 })
+      .unwrapOrElse((e) => {
+        throw e;
+      });
 
     // Give RabbitMQ time to order the messages
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -175,11 +163,9 @@ describe("Priority Queue", () => {
     ]);
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
     await amqpChannel.deleteQueue(extractQueue(priorityQueue).name);
     await amqpChannel.deleteExchange(exchange.name);
   });
@@ -233,27 +219,21 @@ describe("Priority Queue", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (
-      await client.waitForConnect().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.waitForConnect().unwrapOrElse((e) => {
+      throw e;
+    });
 
     // Publish message without priority (defaults to 0)
-    (
-      await client.publish(exchange.name, "test", { id: "msg-default" }).recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.publish(exchange.name, "test", { id: "msg-default" }).unwrapOrElse((e) => {
+      throw e;
+    });
 
     // Publish message with priority 5
-    (
-      await client
-        .publish(exchange.name, "test", { id: "msg-priority" }, { priority: 5 })
-        .recover((e) => {
-          throw e;
-        })
-    ).unwrap();
+    await client
+      .publish(exchange.name, "test", { id: "msg-priority" }, { priority: 5 })
+      .unwrapOrElse((e) => {
+        throw e;
+      });
 
     // Give RabbitMQ time to order the messages
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -288,11 +268,9 @@ describe("Priority Queue", () => {
     expect(consumedMessages).toEqual([{ id: "msg-priority" }, { id: "msg-default" }]);
 
     // CLEANUP
-    (
-      await client.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await client.close().unwrapOrElse((e) => {
+      throw e;
+    });
     await amqpChannel.deleteQueue(extractQueue(priorityQueue).name);
     await amqpChannel.deleteExchange(exchange.name);
   });

--- a/packages/core/src/__tests__/priority-queue.spec.ts
+++ b/packages/core/src/__tests__/priority-queue.spec.ts
@@ -43,14 +43,22 @@ describe("Priority Queue", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // THEN - Verify queue was created with x-max-priority
     const queueInfo = await amqpChannel.checkQueue("test-priority-queue");
     expect(queueInfo.queue).toBe("test-priority-queue");
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
     await amqpChannel.deleteQueue("test-priority-queue");
   });
 
@@ -98,30 +106,36 @@ describe("Priority Queue", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // Publish messages with different priorities
     // Publishing in this order: low (1), medium (5), high (10)
     (
-      await client.publish(exchange.name, "test", { id: "msg-low", priority: 1 }, { priority: 1 })
+      await client
+        .publish(exchange.name, "test", { id: "msg-low", priority: 1 }, { priority: 1 })
+        .recover((e) => {
+          throw e;
+        })
     ).unwrap();
 
     (
-      await client.publish(
-        exchange.name,
-        "test",
-        { id: "msg-medium", priority: 5 },
-        { priority: 5 },
-      )
+      await client
+        .publish(exchange.name, "test", { id: "msg-medium", priority: 5 }, { priority: 5 })
+        .recover((e) => {
+          throw e;
+        })
     ).unwrap();
 
     (
-      await client.publish(
-        exchange.name,
-        "test",
-        { id: "msg-high", priority: 10 },
-        { priority: 10 },
-      )
+      await client
+        .publish(exchange.name, "test", { id: "msg-high", priority: 10 }, { priority: 10 })
+        .recover((e) => {
+          throw e;
+        })
     ).unwrap();
 
     // Give RabbitMQ time to order the messages
@@ -161,7 +175,11 @@ describe("Priority Queue", () => {
     ]);
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
     await amqpChannel.deleteQueue(extractQueue(priorityQueue).name);
     await amqpChannel.deleteExchange(exchange.name);
   });
@@ -215,13 +233,27 @@ describe("Priority Queue", () => {
       urls: [amqpConnectionUrl],
     });
 
-    (await client.waitForConnect()).unwrap();
+    (
+      await client.waitForConnect().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // Publish message without priority (defaults to 0)
-    (await client.publish(exchange.name, "test", { id: "msg-default" })).unwrap();
+    (
+      await client.publish(exchange.name, "test", { id: "msg-default" }).recover((e) => {
+        throw e;
+      })
+    ).unwrap();
 
     // Publish message with priority 5
-    (await client.publish(exchange.name, "test", { id: "msg-priority" }, { priority: 5 })).unwrap();
+    (
+      await client
+        .publish(exchange.name, "test", { id: "msg-priority" }, { priority: 5 })
+        .recover((e) => {
+          throw e;
+        })
+    ).unwrap();
 
     // Give RabbitMQ time to order the messages
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -256,7 +288,11 @@ describe("Priority Queue", () => {
     expect(consumedMessages).toEqual([{ id: "msg-priority" }, { id: "msg-default" }]);
 
     // CLEANUP
-    (await client.close()).unwrap();
+    (
+      await client.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
     await amqpChannel.deleteQueue(extractQueue(priorityQueue).name);
     await amqpChannel.deleteExchange(exchange.name);
   });

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -16,11 +16,11 @@ import { TaggedError } from "unthrown";
 export class TechnicalError extends TaggedError("@amqp-contract/TechnicalError", {
   name: "TechnicalError",
 })<{
-  message: string;
   cause?: unknown;
 }> {
   constructor(message: string, cause?: unknown) {
-    super({ message, cause });
+    super({ cause });
+    this.message = message;
   }
 }
 
@@ -38,11 +38,11 @@ export class TechnicalError extends TaggedError("@amqp-contract/TechnicalError",
 export class MessageValidationError extends TaggedError("@amqp-contract/MessageValidationError", {
   name: "MessageValidationError",
 })<{
-  message: string;
   source: string;
   issues: unknown;
 }> {
   constructor(source: string, issues: unknown) {
-    super({ message: `Message validation failed for "${source}"`, source, issues });
+    super({ source, issues });
+    this.message = `Message validation failed for "${source}"`;
   }
 }

--- a/packages/core/src/parsing.spec.ts
+++ b/packages/core/src/parsing.spec.ts
@@ -9,11 +9,9 @@ describe("safeJsonParse", () => {
 
     expect(result).toBeOk();
     expect(
-      result
-        .recover((e) => {
-          throw e;
-        })
-        .unwrap(),
+      result.unwrapOrElse((e) => {
+        throw e;
+      }),
     ).toEqual({ a: 1, b: "two" });
   });
 
@@ -21,21 +19,11 @@ describe("safeJsonParse", () => {
     const rethrow = (e: unknown): never => {
       throw e;
     };
-    expect(
-      safeJsonParse(Buffer.from("42"), () => new Error())
-        .recover(rethrow)
-        .unwrap(),
-    ).toBe(42);
-    expect(
-      safeJsonParse(Buffer.from('"hello"'), () => new Error())
-        .recover(rethrow)
-        .unwrap(),
-    ).toBe("hello");
-    expect(
-      safeJsonParse(Buffer.from("null"), () => new Error())
-        .recover(rethrow)
-        .unwrap(),
-    ).toBeNull();
+    expect(safeJsonParse(Buffer.from("42"), () => new Error()).unwrapOrElse(rethrow)).toBe(42);
+    expect(safeJsonParse(Buffer.from('"hello"'), () => new Error()).unwrapOrElse(rethrow)).toBe(
+      "hello",
+    );
+    expect(safeJsonParse(Buffer.from("null"), () => new Error()).unwrapOrElse(rethrow)).toBeNull();
   });
 
   it("invokes the error mapper with the underlying parse error and returns Err", () => {

--- a/packages/core/src/parsing.spec.ts
+++ b/packages/core/src/parsing.spec.ts
@@ -8,13 +8,34 @@ describe("safeJsonParse", () => {
     const result = safeJsonParse(buffer, () => new TechnicalError("unused"));
 
     expect(result).toBeOk();
-    expect(result.unwrap()).toEqual({ a: 1, b: "two" });
+    expect(
+      result
+        .recover((e) => {
+          throw e;
+        })
+        .unwrap(),
+    ).toEqual({ a: 1, b: "two" });
   });
 
   it("parses primitive JSON values", () => {
-    expect(safeJsonParse(Buffer.from("42"), () => new Error()).unwrap()).toBe(42);
-    expect(safeJsonParse(Buffer.from('"hello"'), () => new Error()).unwrap()).toBe("hello");
-    expect(safeJsonParse(Buffer.from("null"), () => new Error()).unwrap()).toBeNull();
+    const rethrow = (e: unknown): never => {
+      throw e;
+    };
+    expect(
+      safeJsonParse(Buffer.from("42"), () => new Error())
+        .recover(rethrow)
+        .unwrap(),
+    ).toBe(42);
+    expect(
+      safeJsonParse(Buffer.from('"hello"'), () => new Error())
+        .recover(rethrow)
+        .unwrap(),
+    ).toBe("hello");
+    expect(
+      safeJsonParse(Buffer.from("null"), () => new Error())
+        .recover(rethrow)
+        .unwrap(),
+    ).toBeNull();
   });
 
   it("invokes the error mapper with the underlying parse error and returns Err", () => {
@@ -28,7 +49,8 @@ describe("safeJsonParse", () => {
     expect(result).toBeErr();
     expect(seen).toHaveLength(1);
     expect(seen[0]).toBeInstanceOf(SyntaxError);
-    const err = result.unwrapErr();
+    if (!result.isErr()) throw new Error("expected Err");
+    const err = result.error;
     expect(err).toBeInstanceOf(TechnicalError);
     expect(err.message).toBe("Failed to parse JSON");
     expect(err.cause).toBeInstanceOf(SyntaxError);
@@ -43,6 +65,7 @@ describe("safeJsonParse", () => {
 
     const result = safeJsonParse(Buffer.from("oops"), (raw) => new CustomError(raw));
     expect(result).toBeErr();
-    expect(result.unwrapErr()).toBeInstanceOf(CustomError);
+    if (!result.isErr()) throw new Error("expected Err");
+    expect(result.error).toBeInstanceOf(CustomError);
   });
 });

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -60,8 +60,7 @@
   "dependencies": {
     "@amqp-contract/contract": "workspace:*",
     "@amqp-contract/core": "workspace:*",
-    "@standard-schema/spec": "catalog:",
-    "unthrown": "catalog:"
+    "@standard-schema/spec": "catalog:"
   },
   "devDependencies": {
     "@amqp-contract/testing": "workspace:*",
@@ -76,8 +75,12 @@
     "typedoc": "catalog:",
     "typedoc-plugin-markdown": "catalog:",
     "typescript": "catalog:",
+    "unthrown": "catalog:",
     "vitest": "catalog:",
     "zod": "catalog:"
+  },
+  "peerDependencies": {
+    "unthrown": "^4.0.0"
   },
   "engines": {
     "node": ">=22.19"

--- a/packages/worker/src/__tests__/fixture.ts
+++ b/packages/worker/src/__tests__/fixture.ts
@@ -26,6 +26,8 @@ export const it = baseIt.extend<{
               handlers,
               urls: [amqpConnectionUrl],
               logger: console,
+            }).recover((e) => {
+              throw e;
             })
           ).unwrap();
 
@@ -38,7 +40,11 @@ export const it = baseIt.extend<{
       await Promise.all(
         workers.map(async (worker) => {
           try {
-            (await worker.close()).unwrap();
+            (
+              await worker.close().recover((e) => {
+                throw e;
+              })
+            ).unwrap();
           } catch (error) {
             // Swallow errors during cleanup to avoid unhandled rejections
             // eslint-disable-next-line no-console

--- a/packages/worker/src/__tests__/fixture.ts
+++ b/packages/worker/src/__tests__/fixture.ts
@@ -20,16 +20,14 @@ export const it = baseIt.extend<{
         ) => {
           // Topology setup (exchanges, queues, bindings, wait queues) is done automatically
           // by AmqpClient in the channel setup callback
-          const worker = (
-            await TypedAmqpWorker.create({
-              contract,
-              handlers,
-              urls: [amqpConnectionUrl],
-              logger: console,
-            }).recover((e) => {
-              throw e;
-            })
-          ).unwrap();
+          const worker = await TypedAmqpWorker.create({
+            contract,
+            handlers,
+            urls: [amqpConnectionUrl],
+            logger: console,
+          }).unwrapOrElse((e) => {
+            throw e;
+          });
 
           workers.push(worker);
           return worker;
@@ -40,11 +38,9 @@ export const it = baseIt.extend<{
       await Promise.all(
         workers.map(async (worker) => {
           try {
-            (
-              await worker.close().recover((e) => {
-                throw e;
-              })
-            ).unwrap();
+            await worker.close().unwrapOrElse((e) => {
+              throw e;
+            });
           } catch (error) {
             // Swallow errors during cleanup to avoid unhandled rejections
             // eslint-disable-next-line no-console

--- a/packages/worker/src/__tests__/worker-double-ack.spec.ts
+++ b/packages/worker/src/__tests__/worker-double-ack.spec.ts
@@ -70,21 +70,19 @@ describe("Worker defensive nack guard", () => {
 
     const processed: string[] = [];
 
-    const worker = (
-      await TypedAmqpWorker.create({
-        contract,
-        handlers: {
-          testConsumer: ({ payload }) => {
-            processed.push(payload.id);
-            return Ok(undefined).toAsync();
-          },
+    const worker = await TypedAmqpWorker.create({
+      contract,
+      handlers: {
+        testConsumer: ({ payload }) => {
+          processed.push(payload.id);
+          return Ok(undefined).toAsync();
         },
-        urls: [amqpConnectionUrl],
-        telemetry: provider,
-      }).recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+      },
+      urls: [amqpConnectionUrl],
+      telemetry: provider,
+    }).unwrapOrElse((e) => {
+      throw e;
+    });
 
     try {
       // WHEN we publish two messages back to back. The first triggers the
@@ -115,11 +113,9 @@ describe("Worker defensive nack guard", () => {
       // channel.
       expect(processed.length).toBe(2);
     } finally {
-      (
-        await worker.close().recover((e) => {
-          throw e;
-        })
-      ).unwrap();
+      await worker.close().unwrapOrElse((e) => {
+        throw e;
+      });
     }
   }, 15_000);
 });

--- a/packages/worker/src/__tests__/worker-double-ack.spec.ts
+++ b/packages/worker/src/__tests__/worker-double-ack.spec.ts
@@ -81,6 +81,8 @@ describe("Worker defensive nack guard", () => {
         },
         urls: [amqpConnectionUrl],
         telemetry: provider,
+      }).recover((e) => {
+        throw e;
       })
     ).unwrap();
 
@@ -113,7 +115,11 @@ describe("Worker defensive nack guard", () => {
       // channel.
       expect(processed.length).toBe(2);
     } finally {
-      (await worker.close()).unwrap();
+      (
+        await worker.close().recover((e) => {
+          throw e;
+        })
+      ).unwrap();
     }
   }, 15_000);
 });

--- a/packages/worker/src/__tests__/worker.spec.ts
+++ b/packages/worker/src/__tests__/worker.spec.ts
@@ -645,6 +645,8 @@ describe("AmqpWorker Integration", () => {
         },
         urls: [amqpConnectionUrl],
         logger: mockLogger,
+      }).recover((e) => {
+        throw e;
       })
     ).unwrap();
 
@@ -684,6 +686,10 @@ describe("AmqpWorker Integration", () => {
     expect(unexpectedWarnings).toHaveLength(0);
 
     // Clean up
-    (await worker.close()).unwrap();
+    (
+      await worker.close().recover((e) => {
+        throw e;
+      })
+    ).unwrap();
   });
 });

--- a/packages/worker/src/__tests__/worker.spec.ts
+++ b/packages/worker/src/__tests__/worker.spec.ts
@@ -637,18 +637,16 @@ describe("AmqpWorker Integration", () => {
     };
 
     // Create worker with mock logger
-    const worker = (
-      await TypedAmqpWorker.create({
-        contract,
-        handlers: {
-          testConsumer: defineHandler(contract, "testConsumer", (_msg) => Ok(undefined).toAsync()),
-        },
-        urls: [amqpConnectionUrl],
-        logger: mockLogger,
-      }).recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    const worker = await TypedAmqpWorker.create({
+      contract,
+      handlers: {
+        testConsumer: defineHandler(contract, "testConsumer", (_msg) => Ok(undefined).toAsync()),
+      },
+      urls: [amqpConnectionUrl],
+      logger: mockLogger,
+    }).unwrapOrElse((e) => {
+      throw e;
+    });
 
     // Wait for worker setup
     const WORKER_SETUP_WAIT_MS = 500;
@@ -686,10 +684,8 @@ describe("AmqpWorker Integration", () => {
     expect(unexpectedWarnings).toHaveLength(0);
 
     // Clean up
-    (
-      await worker.close().recover((e) => {
-        throw e;
-      })
-    ).unwrap();
+    await worker.close().unwrapOrElse((e) => {
+      throw e;
+    });
   });
 });

--- a/packages/worker/src/decompression.spec.ts
+++ b/packages/worker/src/decompression.spec.ts
@@ -10,7 +10,11 @@ describe("Decompression utilities", () => {
   describe("decompressBuffer", () => {
     it("should return buffer as-is when no content-encoding is provided", async () => {
       const testData = Buffer.from(JSON.stringify({ message: "Hello, World!" }));
-      const result = (await decompressBuffer(testData, undefined)).unwrap();
+      const result = (
+        await decompressBuffer(testData, undefined).recover((e) => {
+          throw e;
+        })
+      ).unwrap();
 
       expect(result).toEqual(testData);
     });
@@ -19,7 +23,11 @@ describe("Decompression utilities", () => {
       const testData = Buffer.from(JSON.stringify({ message: "Hello, World!" }));
       const compressed = await gzipAsync(testData);
 
-      const decompressed = (await decompressBuffer(compressed, "gzip")).unwrap();
+      const decompressed = (
+        await decompressBuffer(compressed, "gzip").recover((e) => {
+          throw e;
+        })
+      ).unwrap();
 
       expect(decompressed).toEqual(testData);
     });
@@ -28,7 +36,11 @@ describe("Decompression utilities", () => {
       const testData = Buffer.from(JSON.stringify({ message: "Hello, World!" }));
       const compressed = await deflateAsync(testData);
 
-      const decompressed = (await decompressBuffer(compressed, "deflate")).unwrap();
+      const decompressed = (
+        await decompressBuffer(compressed, "deflate").recover((e) => {
+          throw e;
+        })
+      ).unwrap();
 
       expect(decompressed).toEqual(testData);
     });
@@ -37,7 +49,11 @@ describe("Decompression utilities", () => {
       const testData = Buffer.from(JSON.stringify({ message: "Hello, World!" }));
       const compressed = await gzipAsync(testData);
 
-      const decompressed = (await decompressBuffer(compressed, "GZIP")).unwrap();
+      const decompressed = (
+        await decompressBuffer(compressed, "GZIP").recover((e) => {
+          throw e;
+        })
+      ).unwrap();
 
       expect(decompressed).toEqual(testData);
     });
@@ -48,7 +64,8 @@ describe("Decompression utilities", () => {
       const result = await decompressBuffer(testData, "brotli");
 
       expect(result).toBeErr();
-      const error = result.unwrapErr();
+      if (!result.isErr()) throw new Error("expected Err");
+      const error = result.error;
       expect(error.message).toContain('Unsupported content-encoding: "brotli"');
       expect(error.message).toContain("Supported encodings are: gzip, deflate");
       expect(error.message).toContain("Please check your publisher configuration");
@@ -66,7 +83,11 @@ describe("Decompression utilities", () => {
       );
 
       const compressed = await gzipAsync(largeData);
-      const decompressed = (await decompressBuffer(compressed, "gzip")).unwrap();
+      const decompressed = (
+        await decompressBuffer(compressed, "gzip").recover((e) => {
+          throw e;
+        })
+      ).unwrap();
 
       expect(decompressed).toEqual(largeData);
     });

--- a/packages/worker/src/decompression.spec.ts
+++ b/packages/worker/src/decompression.spec.ts
@@ -10,11 +10,9 @@ describe("Decompression utilities", () => {
   describe("decompressBuffer", () => {
     it("should return buffer as-is when no content-encoding is provided", async () => {
       const testData = Buffer.from(JSON.stringify({ message: "Hello, World!" }));
-      const result = (
-        await decompressBuffer(testData, undefined).recover((e) => {
-          throw e;
-        })
-      ).unwrap();
+      const result = await decompressBuffer(testData, undefined).unwrapOrElse((e) => {
+        throw e;
+      });
 
       expect(result).toEqual(testData);
     });
@@ -23,11 +21,9 @@ describe("Decompression utilities", () => {
       const testData = Buffer.from(JSON.stringify({ message: "Hello, World!" }));
       const compressed = await gzipAsync(testData);
 
-      const decompressed = (
-        await decompressBuffer(compressed, "gzip").recover((e) => {
-          throw e;
-        })
-      ).unwrap();
+      const decompressed = await decompressBuffer(compressed, "gzip").unwrapOrElse((e) => {
+        throw e;
+      });
 
       expect(decompressed).toEqual(testData);
     });
@@ -36,11 +32,9 @@ describe("Decompression utilities", () => {
       const testData = Buffer.from(JSON.stringify({ message: "Hello, World!" }));
       const compressed = await deflateAsync(testData);
 
-      const decompressed = (
-        await decompressBuffer(compressed, "deflate").recover((e) => {
-          throw e;
-        })
-      ).unwrap();
+      const decompressed = await decompressBuffer(compressed, "deflate").unwrapOrElse((e) => {
+        throw e;
+      });
 
       expect(decompressed).toEqual(testData);
     });
@@ -49,11 +43,9 @@ describe("Decompression utilities", () => {
       const testData = Buffer.from(JSON.stringify({ message: "Hello, World!" }));
       const compressed = await gzipAsync(testData);
 
-      const decompressed = (
-        await decompressBuffer(compressed, "GZIP").recover((e) => {
-          throw e;
-        })
-      ).unwrap();
+      const decompressed = await decompressBuffer(compressed, "GZIP").unwrapOrElse((e) => {
+        throw e;
+      });
 
       expect(decompressed).toEqual(testData);
     });
@@ -83,11 +75,9 @@ describe("Decompression utilities", () => {
       );
 
       const compressed = await gzipAsync(largeData);
-      const decompressed = (
-        await decompressBuffer(compressed, "gzip").recover((e) => {
-          throw e;
-        })
-      ).unwrap();
+      const decompressed = await decompressBuffer(compressed, "gzip").unwrapOrElse((e) => {
+        throw e;
+      });
 
       expect(decompressed).toEqual(largeData);
     });

--- a/packages/worker/src/errors.ts
+++ b/packages/worker/src/errors.ts
@@ -17,11 +17,11 @@ export { MessageValidationError } from "@amqp-contract/core";
 export class RetryableError extends TaggedError("@amqp-contract/RetryableError", {
   name: "RetryableError",
 })<{
-  message: string;
   cause?: unknown;
 }> {
   constructor(message: string, cause?: unknown) {
-    super({ message, cause });
+    super({ cause });
+    this.message = message;
   }
 }
 
@@ -37,11 +37,11 @@ export class RetryableError extends TaggedError("@amqp-contract/RetryableError",
 export class NonRetryableError extends TaggedError("@amqp-contract/NonRetryableError", {
   name: "NonRetryableError",
 })<{
-  message: string;
   cause?: unknown;
 }> {
   constructor(message: string, cause?: unknown) {
-    super({ message, cause });
+    super({ cause });
+    this.message = message;
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ catalogs:
       specifier: 1.1.0
       version: 1.1.0
     '@unthrown/vitest':
-      specifier: 3.0.0
-      version: 3.0.0
+      specifier: 4.0.0
+      version: 4.0.0
     '@vitest/coverage-v8':
       specifier: 4.1.9
       version: 4.1.9
@@ -100,8 +100,8 @@ catalogs:
       specifier: 6.0.3
       version: 6.0.3
     unthrown:
-      specifier: 3.0.0
-      version: 3.0.0
+      specifier: 4.0.0
+      version: 4.0.0
     valibot:
       specifier: 1.4.2
       version: 1.4.2
@@ -237,7 +237,7 @@ importers:
         version: 6.0.3
       unthrown:
         specifier: 'catalog:'
-        version: 3.0.0
+        version: 4.0.0
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -292,7 +292,7 @@ importers:
         version: 13.1.3
       unthrown:
         specifier: 'catalog:'
-        version: 3.0.0
+        version: 4.0.0
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -394,9 +394,6 @@ importers:
       ts-pattern:
         specifier: 'catalog:'
         version: 5.9.0
-      unthrown:
-        specifier: 'catalog:'
-        version: 3.0.0
     devDependencies:
       '@amqp-contract/testing':
         specifier: workspace:*
@@ -412,7 +409,7 @@ importers:
         version: 24.13.2
       '@unthrown/vitest':
         specifier: 'catalog:'
-        version: 3.0.0(vitest@4.1.9)
+        version: 4.0.0(unthrown@4.0.0)(vitest@4.1.9)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.9(vitest@4.1.9)
@@ -434,6 +431,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      unthrown:
+        specifier: 'catalog:'
+        version: 4.0.0
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -489,9 +489,6 @@ importers:
       amqplib:
         specifier: 'catalog:'
         version: 2.0.1
-      unthrown:
-        specifier: 'catalog:'
-        version: 3.0.0
     devDependencies:
       '@amqp-contract/testing':
         specifier: workspace:*
@@ -510,7 +507,7 @@ importers:
         version: 24.13.2
       '@unthrown/vitest':
         specifier: 'catalog:'
-        version: 3.0.0(vitest@4.1.9)
+        version: 4.0.0(unthrown@4.0.0)(vitest@4.1.9)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.9(vitest@4.1.9)
@@ -523,6 +520,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      unthrown:
+        specifier: 'catalog:'
+        version: 4.0.0
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -575,9 +575,6 @@ importers:
       '@standard-schema/spec':
         specifier: 'catalog:'
         version: 1.1.0
-      unthrown:
-        specifier: 'catalog:'
-        version: 3.0.0
     devDependencies:
       '@amqp-contract/testing':
         specifier: workspace:*
@@ -593,7 +590,7 @@ importers:
         version: 24.13.2
       '@unthrown/vitest':
         specifier: 'catalog:'
-        version: 3.0.0(vitest@4.1.9)
+        version: 4.0.0(unthrown@4.0.0)(vitest@4.1.9)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.9(vitest@4.1.9)
@@ -615,6 +612,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      unthrown:
+        specifier: 'catalog:'
+        version: 4.0.0
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -641,7 +641,7 @@ importers:
         version: link:../packages/worker
       unthrown:
         specifier: 'catalog:'
-        version: 3.0.0
+        version: 4.0.0
     devDependencies:
       '@types/node':
         specifier: 24.13.2
@@ -2653,10 +2653,11 @@ packages:
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
-  '@unthrown/vitest@3.0.0':
-    resolution: {integrity: sha512-imKT5Wo8Kd+DwDa4XcPYzxTc4gXd+7wkPmObIVy5X9pJ67i5SYeS5IHfdRiT/k7Rs6B7K2c/siRRYE+ckfgH9g==}
-    engines: {node: '>=22.19'}
+  '@unthrown/vitest@4.0.0':
+    resolution: {integrity: sha512-KhH1YHj/5DHbW/w/bGzhlIWXyRTUFJRUGlJeATN7XqModTMDhfOSijaV9c0wAcG6UPFnSn9g2OnOIytfS72FLA==}
+    engines: {node: '>=20'}
     peerDependencies:
+      unthrown: ^4.0.0
       vitest: ^4
 
   '@upsetjs/venn.js@2.0.0':
@@ -5144,9 +5145,9 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
-  unthrown@3.0.0:
-    resolution: {integrity: sha512-UXIjZTRgbq3ANGYoH1s1jgK85XDmO2HICllG0wtCSBLBPl+Y+prx36Nk17r2JWdnSeTh8pB1fnzDzNpKTgiPzw==}
-    engines: {node: '>=22.19'}
+  unthrown@4.0.0:
+    resolution: {integrity: sha512-nToVgnaBR4pDjjGebOV1BUJs40dUU9VfBeonyVxveJVqQAFsvcxsjYRQo1KMEkuCseUmuxrltAzsi389MnXtSQ==}
+    engines: {node: '>=20'}
 
   urijs@1.19.11:
     resolution: {integrity: sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==}
@@ -7287,9 +7288,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@unthrown/vitest@3.0.0(vitest@4.1.9)':
+  '@unthrown/vitest@4.0.0(unthrown@4.0.0)(vitest@4.1.9)':
     dependencies:
-      unthrown: 3.0.0
+      unthrown: 4.0.0
       vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@upsetjs/venn.js@2.0.0':
@@ -10089,7 +10090,7 @@ snapshots:
 
   universalify@0.1.2: {}
 
-  unthrown@3.0.0: {}
+  unthrown@4.0.0: {}
 
   urijs@1.19.11: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,7 +32,7 @@ catalog:
   "@orpc/zod": 1.14.6
   "@standard-schema/spec": 1.1.0
   "@types/node": 24.13.2
-  "@unthrown/vitest": 3.0.0
+  "@unthrown/vitest": 4.0.0
   "@vitest/coverage-v8": 4.1.9
   amqp-connection-manager: 5.0.0
   amqplib: 2.0.1
@@ -52,7 +52,7 @@ catalog:
   typedoc: 0.28.19
   typedoc-plugin-markdown: 4.12.0
   typescript: 6.0.3
-  unthrown: 3.0.0
+  unthrown: 4.0.0
   valibot: 1.4.2
   vitepress: 1.6.4
   vitepress-plugin-mermaid: 2.0.17


### PR DESCRIPTION
Migrates amqp-contract to **unthrown 4** and makes it a **peer dependency** (`^4.0.0`) of core/client/worker. Supersedes #536 (which proposed the peer dependency against unthrown 3).

Shipped as a **minor** per maintainer direction. amqp-contract's own API shape is unchanged, but unthrown 4 changes two things consumers rely on — the changeset and upgrade guide document the required action.

## Why this isn't a range bump
unthrown 4 has two breaking type changes, and both amqp-contract's source and its consumers hit them (verified empirically — 123 type errors against v4 before this change):

1. **`.unwrap()` is type-gated** to infallible results (`E = never`). `(await client.publish(...)).unwrap()` and `(await create()).unwrap()` no longer compile.
2. **`TaggedError` reserves `message`** — a `message` payload key is now rejected.

## Changes
- **Error classes** (5 across core/client/worker): message moved out of the `TaggedError` payload into the constructor (`this.message = …`).
- **`.unwrap()` on fallible results** → `.recover((e) => { throw e }).unwrap()` across tests and examples; `isErr()`-narrowing where the error value is asserted. Library internals were already unwrap-clean (they use `flatMap`/`match`).
- **Peer dependency**: `unthrown@^4.0.0` in core/client/worker (kept as devDependency so each package builds/tests); catalog + `@unthrown/vitest` bumped to 4.
- **Docs**: all examples updated to the v4 idiom; new "Getting the value out" section in the error-model guide; `2.2.x → 2.3.x` entry in the upgrade guide; FAQ/client-usage prose corrected.

## Verification
- `pnpm build`, `pnpm typecheck` (**0 errors**), `pnpm lint`, `pnpm test` all pass against unthrown 4.
- **Full integration suite passes** against real RabbitMQ (testcontainers): core, client, worker, tests, and both examples — error messages confirmed flowing through the broker (`MessageValidationError: Message validation failed for "…"`).

## Consumer action (in the changeset + upgrade guide)
Bump your own `unthrown` to `^4` (auto-installed by npm 7+/pnpm 8+), and switch any `.unwrap()` on a fallible amqp-contract result to `.match()` or `.recover((e) => { throw e }).unwrap()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)