### PR TITLE
feat: add typed per-RPC error maps

### DIFF
--- a/.agents/rules/contract-patterns.md
+++ b/.agents/rules/contract-patterns.md
@@ -269,6 +269,7 @@ The `Infer*` naming pattern indicates type inference helpers that extract types 
 - `ClientInferPublisherInput<Contract, "publisherName">` — input shape for `client.publish(...)`
 - `ClientInferRpcRequestInput<Contract, "rpcName">` — input shape for `client.call(...)`
 - `ClientInferRpcResponseOutput<Contract, "rpcName">` — typed response from `client.call(...)`
+- `ClientInferRpcErrors<Contract, "rpcName">` — union of declared `RpcError<code, data>` members in `client.call(...)`'s error channel (`never` when the RPC declares no `errors`)
 
 **Re-exported from `@amqp-contract/worker`:**
 
@@ -276,5 +277,4 @@ The `Infer*` naming pattern indicates type inference helpers that extract types 
 - `WorkerInferConsumedMessage<Contract, "consumerName">` — `{ payload, headers }` envelope for a regular consumer
 - `WorkerInferConsumerHeaders<Contract, "consumerName">` — just the headers slice
 - `WorkerInferConsumerHandlerEntry<Contract, "consumerName">` — handler-or-`[handler, opts]` tuple shape
-
-The RPC equivalents (`WorkerInferRpcHandler`, `WorkerInferRpcConsumedMessage`, `WorkerInferRpcRequest`, `WorkerInferRpcResponse`, `WorkerInferRpcHeaders`) and the unified `WorkerInferHandlers<Contract>` exist in `packages/worker/src/types.ts` but are **not** currently re-exported from the package root. Inline RPC handlers don't need them — the `handlers` parameter on `TypedAmqpWorker.create` infers each name's signature automatically.
+- The RPC equivalents (`WorkerInferRpcHandler`, `WorkerInferRpcConsumedMessage`, `WorkerInferRpcRequest`, `WorkerInferRpcResponse`, `WorkerInferRpcHeaders`, `WorkerInferRpcErrors`) and the unified `WorkerInferHandlers<Contract>` — see `packages/worker/src/index.ts`. Inline RPC handlers rarely need them: the `handlers` parameter on `TypedAmqpWorker.create` infers each name's signature automatically.

--- a/.agents/rules/handlers.md
+++ b/.agents/rules/handlers.md
@@ -32,7 +32,9 @@ const asyncHandler = ({ payload }) =>
 
 ## RPC handler
 
-`defineRpc` creates a request-reply slot. RPC handlers return `AsyncResult<TResponse, HandlerError>` — the worker validates the response against the RPC's response schema and publishes it back to the caller's `replyTo` with the same `correlationId`.
+`defineRpc` creates a request-reply slot. RPC handlers return `AsyncResult<TResponse, HandlerError | WorkerInferRpcErrors<...>>` — the worker validates the response against the RPC's response schema and publishes it back to the caller's `replyTo` with the same `correlationId`.
+
+When the RPC declares an `errors` map (`defineRpc(queue, { request, response, errors })`), the handler may also return `Err(rpcError(code, data))` for a declared code — the worker validates `data` against the declared schema, publishes an error reply (marked by the `RPC_ERROR_CODE_HEADER` header), and **acks the request**; typed business errors never enter the retry/DLQ pipeline. Undeclared codes or invalid error data are contract violations routed to the DLQ. See `packages/worker/src/worker.ts` (`publishRpcErrorReply`) and [docs/guide/error-model.md](../../docs/guide/error-model.md#typed-rpc-errors-rpcerror).
 
 You can define RPC handlers either with `defineHandler` / `defineHandlers` (overloaded against `InferRpcNames<TContract>`, and `validateHandlerTargetExists` checks both `contract.consumers` and `contract.rpcs`) or inline inside `TypedAmqpWorker.create({ handlers: { … } })`. The inline `handlers` parameter is typed against `WorkerInferHandlers<TContract>`, so each name (consumer or RPC) gets the correct signature inferred:
 

--- a/.changeset/typed-rpc-error-maps.md
+++ b/.changeset/typed-rpc-error-maps.md
@@ -1,0 +1,26 @@
+---
+"@amqp-contract/contract": minor
+"@amqp-contract/core": minor
+"@amqp-contract/client": minor
+"@amqp-contract/worker": minor
+---
+
+Add typed RPC error maps: declare per-RPC business errors in the contract and get them typed end-to-end.
+
+`defineRpc` now accepts an optional `errors` map (error code → `defineMessage(...)` for the error's `data` payload):
+
+```typescript
+const getOrder = defineRpc(queue, {
+  request: defineMessage(z.object({ orderId: z.string() })),
+  response: defineMessage(z.object({ orderId: z.string(), status: z.string() })),
+  errors: {
+    ORDER_NOT_FOUND: defineMessage(z.object({ orderId: z.string() })),
+  },
+});
+```
+
+- **Worker**: RPC handlers can return `Err(rpcError(code, data))` for declared codes — the handler's error channel widens to `HandlerError | RpcError<code, data>`. The worker validates `data` against the declared schema, publishes an error reply, and acks the request (business errors are never retried). Undeclared codes or invalid data route to the DLQ.
+- **Client**: `client.call(...)` error union gains the declared `RpcError<code, data>` members; error data is re-validated on arrival. Discriminate with `isRpcError(error)` and narrow on `error.code`.
+- New exports: `RpcError`, `isRpcError`, `rpcError` (worker), `RpcErrorMap` (contract), `ClientInferRpcErrors` / `WorkerInferRpcErrors` inference helpers, `RPC_ERROR_CODE_HEADER` (core).
+
+The wire format is backward compatible: success replies are unchanged; error replies are marked by the `x-amqp-contract-error-code` AMQP header with a `{ message, data }` JSON body. RPCs that declare no errors behave exactly as before.

--- a/docs/guide/error-model.md
+++ b/docs/guide/error-model.md
@@ -11,6 +11,7 @@ Error
 ├── HandlerError                     (worker-side, returned by handlers)
 │   ├── RetryableError               — go through queue retry mode
 │   └── NonRetryableError            — straight to DLQ, skip retry
+├── RpcError<code, data>             (typed business error declared on an RPC)
 ├── TechnicalError                   (any AMQP / framework failure)
 └── MessageValidationError           (Standard Schema validation issue)
 
@@ -110,6 +111,69 @@ On the worker side, validation failures route directly to the DLQ via `nack(requ
 
 On the client side (publisher input or RPC response validation), `MessageValidationError` is returned via `Err(...)` from `publish()` / `call()` so you can decide how to react before sending.
 
+## Typed RPC errors (`RpcError`)
+
+An RPC can declare its business failures in the contract, alongside the request and response schemas. Each error code maps to a `defineMessage(...)` validating the error's `data` payload:
+
+```ts
+import { defineMessage, defineQueue, defineRpc } from "@amqp-contract/contract";
+import { z } from "zod";
+
+const getOrder = defineRpc(defineQueue("rpc.get-order"), {
+  request: defineMessage(z.object({ orderId: z.string() })),
+  response: defineMessage(z.object({ orderId: z.string(), status: z.string() })),
+  errors: {
+    ORDER_NOT_FOUND: defineMessage(z.object({ orderId: z.string() })),
+  },
+});
+```
+
+Declared errors widen both ends of the RPC:
+
+**Worker side** — the handler's error channel becomes `HandlerError | RpcError<code, data>`. Return one with the `rpcError` factory:
+
+```ts
+import { rpcError } from "@amqp-contract/worker";
+import { Err, Ok } from "unthrown";
+
+const handlers = defineHandlers(contract, {
+  getOrder: ({ payload }) => {
+    const order = orders.get(payload.orderId);
+    if (!order) {
+      return Err(rpcError("ORDER_NOT_FOUND", { orderId: payload.orderId })).toAsync();
+    }
+    return Ok({ orderId: order.id, status: order.status }).toAsync();
+  },
+});
+```
+
+A returned `RpcError` is the RPC's _business-failure channel_, not a processing failure: the worker validates `data` against the declared schema, publishes an error reply to the caller, and **acks the request — business errors are never retried**. Only `RetryableError` / `NonRetryableError` enter the retry/DLQ pipeline.
+
+**Client side** — the `call()` error union gains the declared `RpcError<code, data>` members. Discriminate with `isRpcError` and narrow on `code`:
+
+```ts
+import { isRpcError } from "@amqp-contract/client";
+
+const result = await client.call("getOrder", { orderId: "42" }, { timeoutMs: 5_000 });
+if (result.isErr() && isRpcError(result.error)) {
+  // result.error.code is "ORDER_NOT_FOUND"; result.error.data is { orderId: string }
+  console.log(`Order ${result.error.data.orderId} not found`);
+}
+```
+
+Error `data` is validated twice: on the worker before the reply is published, and again on the client when it arrives — the same double-validation contract as responses.
+
+### Contract enforcement at runtime
+
+The type system prevents undeclared codes, but a cast (or two services running different contract versions) can bypass it. The runtime holds the line:
+
+- **Worker**: an undeclared code or `data` failing its schema is a contract violation — the reply is not published and the request routes to the DLQ as a `NonRetryableError`. The caller times out.
+- **Client**: an error reply whose code the local contract doesn't declare resolves to `Err(TechnicalError)`; error data failing its schema resolves to `Err(MessageValidationError)`.
+
+### Wire format
+
+Success replies are unchanged. An error reply is marked by the `x-amqp-contract-error-code` AMQP header (exported as `RPC_ERROR_CODE_HEADER` from `@amqp-contract/core`) carrying the code, with a `{ message, data }` JSON body. RPCs that declare no `errors` behave exactly as before.
+
 ## Client-side RPC errors
 
 ### `RpcTimeoutError`
@@ -127,6 +191,7 @@ const result = await client.call("calculate", { a: 1, b: 2 }, { timeoutMs: 5_000
 result.match({
   ok: (response) => /* ... */,
   err: (err) => {
+    if (isRpcError(err)) /* declared business error — narrow on err.code */;
     if (err instanceof RpcTimeoutError) /* retry, or fall back */;
     if (err instanceof RpcCancelledError) /* shutting down */;
     if (err instanceof MessageValidationError) /* response shape wrong */;

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -4,12 +4,15 @@ import {
   type ContractDefinition,
   type InferPublisherNames,
   type InferRpcNames,
+  type RpcErrorMap,
 } from "@amqp-contract/contract";
 import {
   AmqpClient,
   PublishOptions as AmqpClientPublishOptions,
   type Logger,
   MessagingSemanticConventions,
+  RPC_ERROR_CODE_HEADER,
+  RpcError,
   TechnicalError,
   type TelemetryProvider,
   defaultTelemetryProvider,
@@ -28,6 +31,7 @@ import { compressBuffer } from "./compression.js";
 import { MessageValidationError, RpcCancelledError, RpcTimeoutError } from "./errors.js";
 import type {
   ClientInferPublisherInput,
+  ClientInferRpcErrors,
   ClientInferRpcRequestInput,
   ClientInferRpcResponseOutput,
 } from "./types.js";
@@ -49,10 +53,16 @@ const DIRECT_REPLY_TO = "amq.rabbitmq.reply-to";
 type PendingCall = {
   rpcName: string;
   responseSchema: StandardSchemaV1;
+  /**
+   * The RPC's declared `errors` map (code → message definition), used to
+   * validate the `data` of a typed error reply. Undefined when the RPC
+   * declares no errors — any error reply then resolves to a TechnicalError.
+   */
+  rpcErrorSchemas?: RpcErrorMap | undefined;
   resolve: (
     result: Result<
       unknown,
-      TechnicalError | MessageValidationError | RpcTimeoutError | RpcCancelledError
+      TechnicalError | MessageValidationError | RpcTimeoutError | RpcCancelledError | RpcError
     >,
   ) => void;
   timer: ReturnType<typeof setTimeout>;
@@ -262,6 +272,15 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
     }
     const parsed = parseResult.value;
 
+    // A reply carrying the error-code header is a typed error reply: its body
+    // is `{ message, data }` rather than the response payload. Resolve it
+    // through the RPC's declared error schemas instead of the response schema.
+    const errorCode = msg.properties.headers?.[RPC_ERROR_CODE_HEADER];
+    if (typeof errorCode === "string") {
+      this.resolveRpcErrorReply(pending, errorCode, parsed);
+      return;
+    }
+
     // Wrap the validate call itself — a Standard Schema implementation may
     // throw synchronously, and the throw would otherwise escape the consume
     // callback and could crash the reply consumer.
@@ -288,6 +307,68 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
       (error: unknown) => {
         pending.resolve(
           Err(new TechnicalError(`RPC reply validation threw for "${pending.rpcName}"`, error)),
+        );
+      },
+    );
+  }
+
+  /**
+   * Resolve a pending call with a typed error reply: look up the error's
+   * schema in the RPC's declared `errors` map, validate the reply's `data`
+   * against it, and resolve the caller with `Err(RpcError<code, data>)`.
+   *
+   * An error code the contract does not declare resolves to a TechnicalError —
+   * it means the two sides run different contract versions (or the worker
+   * bypassed the type system), and the client has no schema to give the data
+   * a type under.
+   */
+  private resolveRpcErrorReply(pending: PendingCall, errorCode: string, parsed: unknown): void {
+    const errorSchema = pending.rpcErrorSchemas?.[errorCode];
+    if (!errorSchema) {
+      pending.resolve(
+        Err(
+          new TechnicalError(
+            `RPC "${pending.rpcName}" replied with undeclared error code "${errorCode}"`,
+          ),
+        ),
+      );
+      return;
+    }
+
+    const body =
+      typeof parsed === "object" && parsed !== null
+        ? (parsed as { message?: unknown; data?: unknown })
+        : {};
+    const message = typeof body.message === "string" ? body.message : undefined;
+
+    // Wrap the validate call itself — a Standard Schema implementation may
+    // throw synchronously, and the throw would otherwise escape the consume
+    // callback and could crash the reply consumer.
+    let rawValidation: ReturnType<StandardSchemaV1["~standard"]["validate"]>;
+    try {
+      rawValidation = errorSchema.payload["~standard"].validate(body.data);
+    } catch (error: unknown) {
+      pending.resolve(
+        Err(new TechnicalError(`RPC error data validation threw for "${pending.rpcName}"`, error)),
+      );
+      return;
+    }
+    const validationPromise =
+      rawValidation instanceof Promise ? rawValidation : Promise.resolve(rawValidation);
+
+    validationPromise.then(
+      (validation) => {
+        if (validation.issues) {
+          pending.resolve(Err(new MessageValidationError(pending.rpcName, validation.issues)));
+          return;
+        }
+        pending.resolve(Err(new RpcError(errorCode, validation.value, message)));
+      },
+      (error: unknown) => {
+        pending.resolve(
+          Err(
+            new TechnicalError(`RPC error data validation threw for "${pending.rpcName}"`, error),
+          ),
         );
       },
     );
@@ -423,10 +504,19 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
     options: CallOptions,
   ): AsyncResult<
     ClientInferRpcResponseOutput<TContract, TName>,
-    TechnicalError | MessageValidationError | RpcTimeoutError | RpcCancelledError
+    | TechnicalError
+    | MessageValidationError
+    | RpcTimeoutError
+    | RpcCancelledError
+    | ClientInferRpcErrors<TContract, TName>
   > {
     type ResponseType = ClientInferRpcResponseOutput<TContract, TName>;
-    type CallError = TechnicalError | MessageValidationError | RpcTimeoutError | RpcCancelledError;
+    type CallError =
+      | TechnicalError
+      | MessageValidationError
+      | RpcTimeoutError
+      | RpcCancelledError
+      | ClientInferRpcErrors<TContract, TName>;
     type CallResult = Result<ResponseType, CallError>;
 
     // setTimeout truncates fractional ms and clamps anything outside the
@@ -482,6 +572,7 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
     this.pendingCalls.set(correlationId, {
       rpcName: String(rpcName),
       responseSchema,
+      rpcErrorSchemas: rpc.errors,
       resolve: resolveCall as PendingCall["resolve"],
       timer,
     });

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -323,7 +323,12 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
    * a type under.
    */
   private resolveRpcErrorReply(pending: PendingCall, errorCode: string, parsed: unknown): void {
-    const errorSchema = pending.rpcErrorSchemas?.[errorCode];
+    // `Object.hasOwn` rather than plain indexing so prototype properties
+    // (e.g. "toString") are not misclassified as declared error codes.
+    const errorSchema =
+      pending.rpcErrorSchemas && Object.hasOwn(pending.rpcErrorSchemas, errorCode)
+        ? pending.rpcErrorSchemas[errorCode]
+        : undefined;
     if (!errorSchema) {
       pending.resolve(
         Err(

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -1,6 +1,6 @@
 import { TaggedError } from "unthrown";
 
-export { MessageValidationError } from "@amqp-contract/core";
+export { isRpcError, MessageValidationError, RpcError } from "@amqp-contract/core";
 
 /**
  * Returned from `TypedAmqpClient.call()` when the configured `timeoutMs` elapses

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,8 +1,15 @@
 export { TypedAmqpClient } from "./client.js";
 export type { CallOptions, CreateClientOptions, PublishOptions } from "./client.js";
-export { MessageValidationError, RpcCancelledError, RpcTimeoutError } from "./errors.js";
+export {
+  isRpcError,
+  MessageValidationError,
+  RpcCancelledError,
+  RpcError,
+  RpcTimeoutError,
+} from "./errors.js";
 export type {
   ClientInferPublisherInput,
+  ClientInferRpcErrors,
   ClientInferRpcRequestInput,
   ClientInferRpcResponseOutput,
 } from "./types.js";

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -4,8 +4,11 @@ import type {
   InferRpcNames,
   MessageDefinition,
   PublisherEntry,
+  QueueEntry,
   RpcDefinition,
+  RpcErrorMap,
 } from "@amqp-contract/contract";
+import type { RpcError } from "@amqp-contract/core";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 
 /**
@@ -78,5 +81,29 @@ export type ClientInferRpcResponseOutput<
   InferRpc<TContract, TName> extends RpcDefinition<MessageDefinition, infer TResponse>
     ? TResponse extends MessageDefinition
       ? InferSchemaOutput<TResponse["payload"]>
+      : never
+    : never;
+
+/**
+ * Typed error union for `client.call(name, ...)` — one `RpcError<code, data>`
+ * member per entry in the RPC's declared `errors` map, with `data` typed as
+ * the declared schema's *output* (the client re-validates error data when the
+ * reply arrives). Resolves to `never` when the RPC declares no errors, so the
+ * call's error union stays purely transport-level.
+ */
+export type ClientInferRpcErrors<
+  TContract extends ContractDefinition,
+  TName extends InferRpcNames<TContract>,
+> =
+  InferRpc<TContract, TName> extends RpcDefinition<
+    MessageDefinition,
+    MessageDefinition,
+    QueueEntry,
+    infer TErrors
+  >
+    ? TErrors extends RpcErrorMap
+      ? {
+          [K in keyof TErrors & string]: RpcError<K, InferSchemaOutput<TErrors[K]["payload"]>>;
+        }[keyof TErrors & string]
       : never
     : never;

--- a/packages/contract/src/builder.test-d.ts
+++ b/packages/contract/src/builder.test-d.ts
@@ -17,6 +17,7 @@ import {
   defineMessage,
   definePublisher,
   defineQueue,
+  defineRpc,
 } from "./builder.js";
 import type {
   ConsumerDefinition,
@@ -463,5 +464,35 @@ describe("ContractOutput strict literal keys", () => {
 
     expectTypeOf(contract.exchanges.logs).toMatchTypeOf<HeadersExchangeDefinition>();
     expectTypeOf<keyof typeof contract.queues>().toEqualTypeOf<"logs">();
+  });
+});
+
+describe("defineRpc typed errors", () => {
+  const queue = defineQueue("rpc.orders", { type: "classic", durable: false });
+  const request = defineMessage(z.object({ orderId: z.string() }));
+  const response = defineMessage(z.object({ status: z.string() }));
+
+  test("captures the declared error map type on the definition", () => {
+    const notFound = defineMessage(z.object({ orderId: z.string() }));
+    const rpc = defineRpc(queue, { request, response, errors: { ORDER_NOT_FOUND: notFound } });
+
+    expectTypeOf(rpc.errors).toEqualTypeOf<{ ORDER_NOT_FOUND: typeof notFound } | undefined>();
+    expectTypeOf<keyof NonNullable<typeof rpc.errors>>().toEqualTypeOf<"ORDER_NOT_FOUND">();
+  });
+
+  test("errors type is undefined when no errors are declared", () => {
+    const rpc = defineRpc(queue, { request, response });
+
+    expectTypeOf(rpc.errors).toEqualTypeOf<undefined>();
+  });
+
+  test("error map survives defineContract", () => {
+    const notFound = defineMessage(z.object({ orderId: z.string() }));
+    const getOrder = defineRpc(queue, { request, response, errors: { ORDER_NOT_FOUND: notFound } });
+    const contract = defineContract({ rpcs: { getOrder } });
+
+    expectTypeOf<
+      keyof NonNullable<typeof contract.rpcs.getOrder.errors>
+    >().toEqualTypeOf<"ORDER_NOT_FOUND">();
   });
 });

--- a/packages/contract/src/builder/rpc.spec.ts
+++ b/packages/contract/src/builder/rpc.spec.ts
@@ -16,6 +16,30 @@ describe("defineRpc", () => {
 
     // THEN
     expect(rpc).toEqual({ queue, request, response });
+    // No errors declared → no `errors` key at all (not `errors: undefined`),
+    // so consumers of the definition can use `"errors" in rpc` checks.
+    expect(Object.hasOwn(rpc, "errors")).toBe(false);
+  });
+
+  it("carries the declared error map through to the definition", () => {
+    // GIVEN
+    const notFound = defineMessage(z.object({ id: z.string() }));
+    const limitExceeded = defineMessage(z.object({ limit: z.number() }));
+
+    // WHEN
+    const rpc = defineRpc(queue, {
+      request,
+      response,
+      errors: { NOT_FOUND: notFound, LIMIT_EXCEEDED: limitExceeded },
+    });
+
+    // THEN
+    expect(rpc).toEqual({
+      queue,
+      request,
+      response,
+      errors: { NOT_FOUND: notFound, LIMIT_EXCEEDED: limitExceeded },
+    });
   });
 
   describe("defineContract integration", () => {
@@ -39,6 +63,18 @@ describe("defineRpc", () => {
         consumers: {},
         bindings: {},
       });
+    });
+
+    it("exposes the RPC's error map under contract.rpcs", () => {
+      // GIVEN
+      const notFound = defineMessage(z.object({ id: z.string() }));
+      const calculate = defineRpc(queue, { request, response, errors: { NOT_FOUND: notFound } });
+
+      // WHEN
+      const contract = defineContract({ rpcs: { calculate } });
+
+      // THEN
+      expect(contract.rpcs.calculate.errors).toEqual({ NOT_FOUND: notFound });
     });
 
     it("throws when an RPC name collides with a consumer name", () => {

--- a/packages/contract/src/builder/rpc.ts
+++ b/packages/contract/src/builder/rpc.ts
@@ -1,4 +1,4 @@
-import type { MessageDefinition, QueueEntry, RpcDefinition } from "../types.js";
+import type { MessageDefinition, QueueEntry, RpcDefinition, RpcErrorMap } from "../types.js";
 
 /**
  * Define an RPC operation: a request/response pair flowing over a request
@@ -18,37 +18,53 @@ import type { MessageDefinition, QueueEntry, RpcDefinition } from "../types.js";
  *   (server side) and outgoing requests (client side).
  * @param messages.response - Schema validated against handler return values
  *   (server side) and incoming replies (client side).
+ * @param messages.errors - Optional typed error map: error code → message
+ *   definition for the error's `data` payload. Declared errors widen the
+ *   handler's `Err` channel (return `Err(rpcError(code, data))`) and the
+ *   client's `call()` error union; error data is schema-validated on both
+ *   sides. Business errors are replied and acked — never retried.
  *
  * @example
  * ```typescript
  * import { defineQueue, defineMessage, defineRpc, defineContract } from '@amqp-contract/contract';
  * import { z } from 'zod';
  *
- * const calculate = defineRpc(defineQueue('rpc.calculate'), {
- *   request: defineMessage(z.object({ a: z.number(), b: z.number() })),
- *   response: defineMessage(z.object({ sum: z.number() })),
+ * const getOrder = defineRpc(defineQueue('rpc.get-order'), {
+ *   request: defineMessage(z.object({ orderId: z.string() })),
+ *   response: defineMessage(z.object({ orderId: z.string(), status: z.string() })),
+ *   errors: {
+ *     ORDER_NOT_FOUND: defineMessage(z.object({ orderId: z.string() })),
+ *   },
  * });
  *
- * const contract = defineContract({ rpcs: { calculate } });
+ * const contract = defineContract({ rpcs: { getOrder } });
  *
- * // Server (worker): handler returns the typed response
- * //   handlers: { calculate: ({ payload }) => Ok({ sum: payload.a + payload.b }).toAsync() }
+ * // Server (worker): return the response, or a declared typed error
+ * //   handlers: {
+ * //     getOrder: ({ payload }) =>
+ * //       orders.has(payload.orderId)
+ * //         ? Ok(orders.get(payload.orderId)).toAsync()
+ * //         : Err(rpcError('ORDER_NOT_FOUND', { orderId: payload.orderId })).toAsync(),
+ * //   }
  *
- * // Client: typed call with required timeout
- * //   const result = await client.call('calculate', { a: 1, b: 2 }, { timeoutMs: 5_000 });
+ * // Client: typed call — the error union includes RpcError<'ORDER_NOT_FOUND', { orderId: string }>
+ * //   const result = await client.call('getOrder', { orderId: '42' }, { timeoutMs: 5_000 });
+ * //   if (result.isErr() && isRpcError(result.error)) console.log(result.error.code);
  * ```
  */
 export function defineRpc<
   TRequestMessage extends MessageDefinition,
   TResponseMessage extends MessageDefinition,
   TQueue extends QueueEntry,
+  TErrors extends RpcErrorMap | undefined = undefined,
 >(
   queue: TQueue,
-  messages: { request: TRequestMessage; response: TResponseMessage },
-): RpcDefinition<TRequestMessage, TResponseMessage, TQueue> {
+  messages: { request: TRequestMessage; response: TResponseMessage; errors?: TErrors },
+): RpcDefinition<TRequestMessage, TResponseMessage, TQueue, TErrors> {
   return {
     queue,
     request: messages.request,
     response: messages.response,
+    ...(messages.errors !== undefined && { errors: messages.errors }),
   };
 }

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -70,6 +70,7 @@ export type {
   ResolvedTtlBackoffRetryOptions,
   ResolvedImmediateRequeueRetryOptions,
   RpcDefinition,
+  RpcErrorMap,
   TopicExchangeDefinition,
   TtlBackoffRetryOptions,
 } from "./types.js";

--- a/packages/contract/src/types.ts
+++ b/packages/contract/src/types.ts
@@ -1030,6 +1030,19 @@ export type BridgedPublisherConfigBase = {
 };
 
 /**
+ * Typed error map for an RPC: error code → message definition validating the
+ * error's `data` payload.
+ *
+ * Reuses {@link MessageDefinition} so error data gets the same Standard Schema
+ * validation and AsyncAPI metadata (`summary` / `description`) as request and
+ * response payloads. The `headers` slot of an error's message definition is
+ * ignored — error replies carry the code in a fixed AMQP header instead.
+ *
+ * @see defineRpc for declaring errors on an RPC
+ */
+export type RpcErrorMap = Record<string, MessageDefinition>;
+
+/**
  * Definition of an RPC operation: a request/response pair flowing over a
  * request queue with replies routed back via direct reply-to.
  *
@@ -1041,6 +1054,7 @@ export type BridgedPublisherConfigBase = {
  * @template TRequestMessage - The request message definition
  * @template TResponseMessage - The response message definition
  * @template TQueue - The request queue entry
+ * @template TErrors - The typed error map (undefined when the RPC declares none)
  *
  * @see defineRpc for creating RPC definitions
  */
@@ -1048,6 +1062,7 @@ export type RpcDefinition<
   TRequestMessage extends MessageDefinition = MessageDefinition,
   TResponseMessage extends MessageDefinition = MessageDefinition,
   TQueue extends QueueEntry = QueueEntry,
+  TErrors extends RpcErrorMap | undefined = RpcErrorMap | undefined,
 > = {
   /** The queue that receives RPC requests. Replies are routed back via direct reply-to. */
   queue: TQueue;
@@ -1055,6 +1070,13 @@ export type RpcDefinition<
   request: TRequestMessage;
   /** Schema for the response payload (validated on both worker reply and client receive). */
   response: TResponseMessage;
+  /**
+   * Typed business errors the handler may return via `Err(rpcError(code, data))`.
+   * Error data is validated against the declared schema on the worker before
+   * the error reply is published, and re-validated on the client when it
+   * arrives. Business errors are replied and acked — never retried.
+   */
+  errors?: TErrors;
 };
 
 /**

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -46,3 +46,89 @@ export class MessageValidationError extends TaggedError("@amqp-contract/MessageV
     super({ message: `Message validation failed for "${source}"`, source, issues });
   }
 }
+
+/**
+ * AMQP message header carrying the error code of a typed RPC error reply.
+ *
+ * A reply message with this header is an error reply: its body is
+ * `{ message, data }` where `data` conforms to the error's declared schema in
+ * the RPC's `errors` map. A reply without it is a regular success reply whose
+ * body is the response payload — so success replies are wire-compatible with
+ * contracts that declare no errors.
+ */
+export const RPC_ERROR_CODE_HEADER = "x-amqp-contract-error-code";
+
+/**
+ * A typed, contract-declared RPC error — the business-failure channel of an
+ * RPC, as opposed to the transport failures modeled by {@link TechnicalError}.
+ *
+ * Declared per-RPC via `defineRpc(queue, { request, response, errors })`,
+ * where each error code maps to a message definition validating the error's
+ * `data` payload. A worker handler surfaces one by returning
+ * `Err(rpcError(code, data))`; the worker validates `data` against the
+ * declared schema, publishes an error reply, and acks the request (business
+ * errors are not retried). The caller's `client.call(...)` resolves to
+ * `Err(RpcError<code, data>)` with `data` re-validated on arrival.
+ *
+ * Carries a `_tag` of `"@amqp-contract/RpcError"` for exhaustive dispatch via
+ * `matchTags`; the `Error.name` is kept bare (`"RpcError"`). Discriminate
+ * between codes on the `code` property.
+ */
+export class RpcError<TCode extends string = string, TData = unknown> extends TaggedError(
+  "@amqp-contract/RpcError",
+  { name: "RpcError" },
+)<{
+  message: string;
+  code: string;
+  data: unknown;
+}> {
+  declare readonly code: TCode;
+  declare readonly data: TData;
+
+  constructor(code: TCode, data: TData, message?: string) {
+    super({ message: message ?? `RPC failed with error "${code}"`, code, data });
+  }
+}
+
+/**
+ * Type guard to check if an error is an {@link RpcError}.
+ *
+ * Narrowing to a specific code (and thus a typed `data`) is done on the
+ * `code` property after the guard, or via `matchTags` on the `_tag`.
+ */
+export function isRpcError(error: unknown): error is RpcError {
+  return error instanceof RpcError;
+}
+
+/**
+ * Create an {@link RpcError} with less verbosity.
+ *
+ * The code/data pair must match one of the entries declared in the RPC's
+ * `errors` map — the handler's return type enforces this at compile time, and
+ * the worker validates `data` against the declared schema at runtime before
+ * replying.
+ *
+ * @param code - The error code, as declared in the RPC's `errors` map
+ * @param data - The error data, validated against the declared schema
+ * @param message - Optional human-readable message (defaults to a generic one)
+ *
+ * @example
+ * ```typescript
+ * import { rpcError } from '@amqp-contract/worker';
+ * import { Err } from 'unthrown';
+ *
+ * const handler = ({ payload }) => {
+ *   if (!orders.has(payload.orderId)) {
+ *     return Err(rpcError('ORDER_NOT_FOUND', { orderId: payload.orderId })).toAsync();
+ *   }
+ *   // ...
+ * };
+ * ```
+ */
+export function rpcError<TCode extends string, TData>(
+  code: TCode,
+  data: TData,
+  message?: string,
+): RpcError<TCode, TData> {
+  return new RpcError(code, data, message);
+}

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -78,7 +78,6 @@ export class RpcError<TCode extends string = string, TData = unknown> extends Ta
   "@amqp-contract/RpcError",
   { name: "RpcError" },
 )<{
-  message: string;
   code: string;
   data: unknown;
 }> {
@@ -86,7 +85,8 @@ export class RpcError<TCode extends string = string, TData = unknown> extends Ta
   declare readonly data: TData;
 
   constructor(code: TCode, data: TData, message?: string) {
-    super({ message: message ?? `RPC failed with error "${code}"`, code, data });
+    super({ code, data });
+    this.message = message ?? `RPC failed with error "${code}"`;
   }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,7 +10,14 @@ export {
   _getConnectionCountForTesting,
   _resetConnectionsForTesting,
 } from "./connection-manager.js";
-export { MessageValidationError, TechnicalError } from "./errors.js";
+export {
+  isRpcError,
+  MessageValidationError,
+  RPC_ERROR_CODE_HEADER,
+  RpcError,
+  rpcError,
+  TechnicalError,
+} from "./errors.js";
 export type { Logger, LoggerContext } from "./logger.js";
 export { safeJsonParse } from "./parsing.js";
 export { setupAmqpTopology } from "./setup.js";

--- a/packages/worker/src/errors.ts
+++ b/packages/worker/src/errors.ts
@@ -1,6 +1,6 @@
 import { TaggedError } from "unthrown";
 
-export { MessageValidationError } from "@amqp-contract/core";
+export { isRpcError, MessageValidationError, RpcError, rpcError } from "@amqp-contract/core";
 
 /**
  * Retryable errors - transient failures that may succeed on retry

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -5,13 +5,16 @@ export {
   MessageValidationError,
   NonRetryableError,
   RetryableError,
+  RpcError,
   // Type guards
   isHandlerError,
   isNonRetryableError,
   isRetryableError,
+  isRpcError,
   // Factory functions
   nonRetryable,
   retryable,
+  rpcError,
 } from "./errors.js";
 // HandlerError is now a tagged union type (RetryableError | NonRetryableError),
 // not a class — re-export it as a type.
@@ -25,6 +28,7 @@ export type {
   WorkerInferConsumerHeaders,
   WorkerInferHandlers,
   WorkerInferRpcConsumedMessage,
+  WorkerInferRpcErrors,
   WorkerInferRpcHandler,
   WorkerInferRpcHandlerEntry,
   WorkerInferRpcHeaders,

--- a/packages/worker/src/types.ts
+++ b/packages/worker/src/types.ts
@@ -5,8 +5,11 @@ import type {
   InferConsumerNames,
   InferRpcNames,
   MessageDefinition,
+  QueueEntry,
   RpcDefinition,
+  RpcErrorMap,
 } from "@amqp-contract/contract";
+import type { RpcError } from "@amqp-contract/core";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import type { ConsumeMessage } from "amqplib";
 import type { AsyncResult } from "unthrown";
@@ -18,6 +21,13 @@ import { ConsumerOptions } from "./worker.js";
  */
 type InferSchemaOutput<TSchema extends StandardSchemaV1> =
   TSchema extends StandardSchemaV1<infer _TInput, infer TOutput> ? TOutput : never;
+
+/**
+ * Infer the input type from a schema (used for RPC error data — the handler
+ * supplies the pre-validation shape; the worker validates before replying).
+ */
+type InferSchemaInput<TSchema extends StandardSchemaV1> =
+  TSchema extends StandardSchemaV1<infer TInput> ? TInput : never;
 
 /**
  * Extract the ConsumerDefinition from any consumer entry type.
@@ -117,6 +127,30 @@ export type WorkerInferRpcHeaders<
     : undefined;
 
 /**
+ * Infer the typed error union for an RPC handler — one `RpcError<code, data>`
+ * member per entry in the RPC's `errors` map, with `data` typed as the
+ * declared schema's *input* (the worker validates before replying). Resolves
+ * to `never` when the RPC declares no errors, leaving the handler's error
+ * channel as plain `HandlerError`.
+ */
+export type WorkerInferRpcErrors<
+  TContract extends ContractDefinition,
+  TName extends InferRpcNames<TContract>,
+> =
+  InferRpc<TContract, TName> extends RpcDefinition<
+    MessageDefinition,
+    MessageDefinition,
+    QueueEntry,
+    infer TErrors
+  >
+    ? TErrors extends RpcErrorMap
+      ? {
+          [K in keyof TErrors & string]: RpcError<K, InferSchemaInput<TErrors[K]["payload"]>>;
+        }[keyof TErrors & string]
+      : never
+    : never;
+
+/**
  * Infer the response payload type for an RPC. The handler must return a
  * `AsyncResult<TResponse, HandlerError>` matching this shape.
  */
@@ -204,10 +238,13 @@ export type WorkerInferConsumerHandler<
 
 /**
  * Handler signature for an RPC. Returns
- * `AsyncResult<TResponse, HandlerError>` where `TResponse` is the inferred
- * response payload. The worker validates the response against the RPC's
- * response schema and publishes it back to `msg.properties.replyTo` with the
- * same `correlationId`.
+ * `AsyncResult<TResponse, HandlerError | RpcError>` where `TResponse` is the
+ * inferred response payload and the `RpcError` members come from the RPC's
+ * declared `errors` map (absent when none are declared). The worker validates
+ * the response against the RPC's response schema and publishes it back to
+ * `msg.properties.replyTo` with the same `correlationId`; a declared
+ * `RpcError` is validated, published as an error reply, and the request is
+ * acked (business errors are not retried).
  */
 export type WorkerInferRpcHandler<
   TContract extends ContractDefinition,
@@ -215,7 +252,10 @@ export type WorkerInferRpcHandler<
 > = (
   message: WorkerInferRpcConsumedMessage<TContract, TName>,
   rawMessage: ConsumeMessage,
-) => AsyncResult<WorkerInferRpcResponse<TContract, TName>, HandlerError>;
+) => AsyncResult<
+  WorkerInferRpcResponse<TContract, TName>,
+  HandlerError | WorkerInferRpcErrors<TContract, TName>
+>;
 
 /**
  * Handler entry for a regular consumer — function or `[handler, options]`.

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -128,9 +128,11 @@ export type CreateWorkerOptions<TContract extends ContractDefinition> = {
    * Handlers for each `consumers` and `rpcs` entry in the contract.
    *
    * - Regular consumers return `AsyncResult<void, HandlerError>`.
-   * - RPC handlers return `AsyncResult<TResponse, HandlerError | RpcError>`
-   *   where `TResponse` is inferred from the RPC's response message schema
-   *   and the `RpcError` members come from the RPC's declared `errors` map.
+   * - RPC handlers return `AsyncResult<TResponse, HandlerError>` where
+   *   `TResponse` is inferred from the RPC's response message schema. When
+   *   the RPC declares an `errors` map, the error channel additionally
+   *   accepts the declared `RpcError<code, data>` members (otherwise it
+   *   stays plain `HandlerError`).
    *
    * Use `defineHandler` / `defineHandlers` to create handlers with full type
    * inference.
@@ -548,7 +550,12 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
     error: RpcError,
   ): AsyncResult<void, HandlerError> {
     const queueName = extractQueue(view.consumer.queue).name;
-    const errorSchema = view.errorSchemas?.[error.code];
+    // `Object.hasOwn` rather than plain indexing so prototype properties
+    // (e.g. "toString") are not misclassified as declared error codes.
+    const errorSchema =
+      view.errorSchemas && Object.hasOwn(view.errorSchemas, error.code)
+        ? view.errorSchemas[error.code]
+        : undefined;
     if (!errorSchema) {
       return Err<HandlerError>(
         new NonRetryableError(

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -3,6 +3,7 @@ import {
   type ContractDefinition,
   type InferConsumerNames,
   type InferRpcNames,
+  type RpcErrorMap,
   extractConsumer,
   extractQueue,
 } from "@amqp-contract/contract";
@@ -10,11 +11,14 @@ import {
   AmqpClient,
   ConsumerOptions as AmqpClientConsumerOptions,
   type Logger,
+  RPC_ERROR_CODE_HEADER,
+  type RpcError,
   TechnicalError,
   type TelemetryProvider,
   defaultTelemetryProvider,
   endSpanError,
   endSpanSuccess,
+  isRpcError,
   recordConsumeMetric,
   safeJsonParse,
   startConsumeSpan,
@@ -48,12 +52,27 @@ type HandlerName<TContract extends ContractDefinition> =
  * Resolved handler entry stored on the worker, regardless of whether the
  * source is a `consumers` or `rpcs` slot. The handler signature is widened
  * here because both kinds share the same dispatch loop; specific call sites
- * cast back to the correct typed handler.
+ * cast back to the correct typed handler. RPC handlers may additionally fail
+ * with a contract-declared `RpcError`, which the dispatch path publishes back
+ * to the caller instead of routing to retry/DLQ.
  */
 type StoredHandler = (
   message: { payload: unknown; headers: unknown },
   rawMessage: ConsumeMessage,
-) => AsyncResult<unknown, HandlerError>;
+) => AsyncResult<unknown, HandlerError | RpcError>;
+
+/**
+ * `ConsumerDefinition`-shaped view over a `consumers` or `rpcs` entry, as
+ * produced by `resolveConsumerView`. `isRpc` (with `responseSchema` and
+ * `errorSchemas`) tells the dispatch path whether to validate the handler
+ * return value and publish a reply.
+ */
+type ConsumerView = {
+  consumer: ConsumerDefinition;
+  isRpc: boolean;
+  responseSchema?: StandardSchemaV1 | undefined;
+  errorSchemas?: RpcErrorMap | undefined;
+};
 
 export type ConsumerOptions = AmqpClientConsumerOptions;
 
@@ -109,8 +128,9 @@ export type CreateWorkerOptions<TContract extends ContractDefinition> = {
    * Handlers for each `consumers` and `rpcs` entry in the contract.
    *
    * - Regular consumers return `AsyncResult<void, HandlerError>`.
-   * - RPC handlers return `AsyncResult<TResponse, HandlerError>` where
-   *   `TResponse` is inferred from the RPC's response message schema.
+   * - RPC handlers return `AsyncResult<TResponse, HandlerError | RpcError>`
+   *   where `TResponse` is inferred from the RPC's response message schema
+   *   and the `RpcError` members come from the RPC's declared `errors` map.
    *
    * Use `defineHandler` / `defineHandlers` to create handlers with full type
    * inference.
@@ -238,11 +258,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
    * accompanying `responseSchema`) tells `processMessage` whether to validate
    * the handler return value and publish a reply.
    */
-  private resolveConsumerView(name: HandlerName<TContract>): {
-    consumer: ConsumerDefinition;
-    isRpc: boolean;
-    responseSchema?: StandardSchemaV1;
-  } {
+  private resolveConsumerView(name: HandlerName<TContract>): ConsumerView {
     // Use `Object.hasOwn` rather than `key in rpcs` so prototype properties
     // (e.g. "toString") on a plain object are not misclassified as RPC names.
     const rpcs = this.contract.rpcs;
@@ -252,6 +268,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
         consumer: { queue: rpc.queue, message: rpc.request },
         isRpc: true,
         responseSchema: rpc.response.payload,
+        errorSchemas: rpc.errors,
       };
     }
     const consumerEntry = this.contract.consumers![name as string]!;
@@ -494,41 +511,133 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
     responseSchema: StandardSchemaV1,
     response: unknown,
   ): AsyncResult<void, HandlerError> {
+    return this.requireReplyAddress(msg, rpcName, queueName)
+      .toAsync()
+      .flatMap(({ replyTo, correlationId }) =>
+        this.validateReplyPayload(
+          responseSchema,
+          response,
+          `RPC response for "${String(rpcName)}"`,
+          String(rpcName),
+        ).flatMap((validatedResponse) =>
+          this.publishReply(validatedResponse, replyTo, {
+            correlationId,
+            contentType: "application/json",
+          }),
+        ),
+      );
+  }
+
+  /**
+   * Validate a declared `RpcError` returned by an RPC handler and publish it
+   * as an error reply: same `replyTo` / `correlationId` routing as a success
+   * reply, plus the error code in the `RPC_ERROR_CODE_HEADER` header and a
+   * `{ message, data }` body with `data` validated against the error's schema
+   * from the RPC's `errors` map.
+   *
+   * Failure semantics mirror {@link publishRpcResponse} (NonRetryableError →
+   * DLQ), with one addition: an error code absent from the `errors` map is a
+   * contract violation by the handler — the type system prevents it, but a
+   * cast or untyped call site can bypass that — and is routed to the DLQ
+   * rather than sent to a caller that has no schema for it.
+   */
+  private publishRpcErrorReply(
+    msg: ConsumeMessage,
+    view: ConsumerView,
+    rpcName: HandlerName<TContract>,
+    error: RpcError,
+  ): AsyncResult<void, HandlerError> {
+    const queueName = extractQueue(view.consumer.queue).name;
+    const errorSchema = view.errorSchemas?.[error.code];
+    if (!errorSchema) {
+      return Err<HandlerError>(
+        new NonRetryableError(
+          `RPC "${String(rpcName)}" returned undeclared error code "${error.code}"`,
+          error,
+        ),
+      ).toAsync();
+    }
+
+    return this.requireReplyAddress(msg, rpcName, queueName)
+      .toAsync()
+      .flatMap(({ replyTo, correlationId }) =>
+        this.validateReplyPayload(
+          errorSchema.payload as StandardSchemaV1,
+          error.data,
+          `RPC error data for "${String(rpcName)}" code "${error.code}"`,
+          String(rpcName),
+        ).flatMap((validatedData) =>
+          this.publishReply({ message: error.message, data: validatedData }, replyTo, {
+            correlationId,
+            contentType: "application/json",
+            headers: { [RPC_ERROR_CODE_HEADER]: error.code },
+          }),
+        ),
+      );
+  }
+
+  /**
+   * Extract and require the `replyTo` / `correlationId` pair an RPC reply is
+   * routed by. Missing either is a NonRetryableError: the caller is already
+   * lost (or cannot demultiplex the reply), so retrying the original message
+   * cannot recover the reply path — the poison message lands in DLQ for
+   * inspection rather than being silently ack'd.
+   */
+  private requireReplyAddress(
+    msg: ConsumeMessage,
+    rpcName: HandlerName<TContract>,
+    queueName: string,
+  ): Result<{ replyTo: string; correlationId: string }, HandlerError> {
     const replyTo = msg.properties.replyTo;
     const correlationId = msg.properties.correlationId;
     if (typeof replyTo !== "string" || replyTo.length === 0) {
-      this.logger?.error(
-        "RPC handler returned a response but the incoming message has no replyTo",
-        { rpcName: String(rpcName), queueName },
-      );
+      this.logger?.error("RPC handler returned a reply but the incoming message has no replyTo", {
+        rpcName: String(rpcName),
+        queueName,
+      });
       return Err(
         new NonRetryableError(
           `RPC "${String(rpcName)}" received a message without replyTo; cannot deliver response`,
         ),
-      ).toAsync();
+      );
     }
     if (typeof correlationId !== "string" || correlationId.length === 0) {
       // Without a correlationId the client cannot match the reply to its
       // pending call — publishing anyway would guarantee a client-side timeout.
       this.logger?.error(
-        "RPC handler returned a response but the incoming message has no correlationId",
+        "RPC handler returned a reply but the incoming message has no correlationId",
         { rpcName: String(rpcName), queueName, replyTo },
       );
       return Err(
         new NonRetryableError(
           `RPC "${String(rpcName)}" received a message without correlationId; cannot deliver response`,
         ),
-      ).toAsync();
+      );
     }
+    return Ok({ replyTo, correlationId });
+  }
 
+  /**
+   * Validate a reply payload (RPC response or RPC error data) against its
+   * schema. Validation failures are NonRetryableError — the handler produced
+   * the wrong shape; retrying the same input will not fix it.
+   */
+  private validateReplyPayload(
+    schema: StandardSchemaV1,
+    value: unknown,
+    description: string,
+    source: string,
+  ): AsyncResult<unknown, HandlerError> {
     // Wrap the call to `validate` itself in try/catch — a Standard Schema
     // implementation may throw synchronously (not via a rejected Promise), and
     // we don't want that to crash the consume callback.
     let rawValidation: ReturnType<StandardSchemaV1["~standard"]["validate"]>;
     try {
-      rawValidation = responseSchema["~standard"].validate(response);
+      rawValidation = schema["~standard"].validate(value);
     } catch (error: unknown) {
-      return Err(new NonRetryableError("RPC response schema validation threw", error)).toAsync();
+      return Err<HandlerError>(
+        new NonRetryableError(`${description} schema validation threw`, error),
+      ).toAsync();
     }
     const validationPromise =
       rawValidation instanceof Promise ? rawValidation : Promise.resolve(rawValidation);
@@ -536,41 +645,47 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
     return fromPromise(
       validationPromise,
       (error: unknown) =>
-        new NonRetryableError("RPC response schema validation threw", error) as HandlerError,
-    )
-      .flatMap((validation) => {
-        if (validation.issues) {
-          return Err<HandlerError>(
-            new NonRetryableError(
-              `RPC response for "${String(rpcName)}" failed schema validation`,
-              new MessageValidationError(String(rpcName), validation.issues),
-            ),
-          );
-        }
-        return Ok(validation.value);
-      })
-      .flatMap((validatedResponse) =>
-        this.amqpClient
-          .publish("", replyTo, validatedResponse, {
-            correlationId,
-            contentType: "application/json",
-          })
-          // Reply-side failures are not retryable from the inbox: by the time
-          // the broker can't deliver the reply, the caller's RPC future has
-          // already (or will soon) time out. Retrying the original message
-          // re-runs the handler against a stale caller. Send to DLQ instead so
-          // the failure is visible without churning the queue.
-          .mapErr(
-            (error: TechnicalError): HandlerError =>
-              new NonRetryableError("Failed to publish RPC response", error),
-          )
-          .flatMap((published) =>
-            published
-              ? Ok(undefined)
-              : Err<HandlerError>(
-                  new NonRetryableError("Failed to publish RPC response: channel buffer full"),
-                ),
+        new NonRetryableError(`${description} schema validation threw`, error) as HandlerError,
+    ).flatMap((validation) => {
+      if (validation.issues) {
+        return Err<HandlerError>(
+          new NonRetryableError(
+            `${description} failed schema validation`,
+            new MessageValidationError(source, validation.issues),
           ),
+        );
+      }
+      return Ok(validation.value);
+    });
+  }
+
+  /**
+   * Publish a validated reply body to the caller's reply queue via the AMQP
+   * default exchange.
+   *
+   * Reply-side failures are not retryable from the inbox: by the time the
+   * broker can't deliver the reply, the caller's RPC future has already (or
+   * will shortly) time out. Retrying the original message re-runs the handler
+   * against a stale caller. Send to DLQ instead so the failure is visible
+   * without churning the queue.
+   */
+  private publishReply(
+    body: unknown,
+    replyTo: string,
+    options: { correlationId: string; contentType: string; headers?: Record<string, unknown> },
+  ): AsyncResult<void, HandlerError> {
+    return this.amqpClient
+      .publish("", replyTo, body, options)
+      .mapErr(
+        (error: TechnicalError): HandlerError =>
+          new NonRetryableError("Failed to publish RPC reply", error),
+      )
+      .flatMap((published) =>
+        published
+          ? Ok(undefined)
+          : Err<HandlerError>(
+              new NonRetryableError("Failed to publish RPC reply: channel buffer full"),
+            ),
       );
   }
 
@@ -601,7 +716,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
     handler: StoredHandler,
     validatedMessage: { payload: unknown; headers: unknown },
     msg: ConsumeMessage,
-  ): AsyncResult<unknown, HandlerError> {
+  ): AsyncResult<unknown, HandlerError | RpcError> {
     return handler(validatedMessage, msg);
   }
 
@@ -612,7 +727,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
    */
   private publishReplyIfRpc(
     msg: ConsumeMessage,
-    view: { consumer: ConsumerDefinition; isRpc: boolean; responseSchema?: StandardSchemaV1 },
+    view: ConsumerView,
     name: HandlerName<TContract>,
     handlerResponse: unknown,
   ): AsyncResult<void, HandlerError> {
@@ -642,7 +757,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
    */
   private processMessage(
     msg: ConsumeMessage,
-    view: { consumer: ConsumerDefinition; isRpc: boolean; responseSchema?: StandardSchemaV1 },
+    view: ConsumerView,
     name: HandlerName<TContract>,
     handler: StoredHandler,
     state: { messageHandled: boolean },
@@ -677,48 +792,37 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
               state.messageHandled = true;
             }),
           )
-          .orElse((handlerError: HandlerError) => {
-            this.logger?.error("Error processing message", {
-              consumerName: String(name),
-              queueName,
-              errorType: handlerError.name,
-              retryCount:
-                (msg.properties.headers?.["x-delivery-count"] as number | undefined) ??
-                (msg.properties.headers?.["x-retry-count"] as number | undefined) ??
-                0,
-              error: handlerError.message,
-            });
-
-            // Route the failure to retry / DLQ via handleError. On its
-            // success paths (retry republish, immediate-requeue nack, DLQ
-            // nack) the message has been ack'd or nack'd, so mark it
-            // handled. On its failure paths (e.g. TTL-backoff misconfig)
-            // no ack/nack happens and the message will be redelivered —
-            // leave messageHandled false so the consume catch-all can
-            // defensive-nack if needed.
-            //
-            // Either way, re-fail the chain with the original handlerError
-            // as `cause` so the failure-telemetry path fires; routing-
-            // internal errors (TechnicalError) take precedence and surface
-            // as the chain's error directly.
-            return handleError(
-              { amqpClient: this.amqpClient, logger: this.logger },
-              handlerError,
-              msg,
-              String(name),
-              consumer,
-            )
-              .tap(() => {
-                state.messageHandled = true;
-              })
-              .flatMap(() =>
-                Err(
-                  new TechnicalError(
-                    `Handler "${String(name)}" failed: ${handlerError.message}`,
-                    handlerError,
-                  ),
-                ).toAsync(),
-              );
+          .orElse((handlerError: HandlerError | RpcError) => {
+            // A contract-declared RpcError is the RPC's business-failure
+            // channel, not a processing failure: publish it back to the
+            // caller and ack the request. Only if the error reply itself
+            // cannot be produced (undeclared code, schema mismatch, publish
+            // failure) does the failure fall through to retry/DLQ routing.
+            if (isRpcError(handlerError) && view.isRpc) {
+              return this.publishRpcErrorReply(msg, view, name, handlerError)
+                .tap(() => {
+                  this.logger?.info("RPC handler replied with a typed error", {
+                    consumerName: String(name),
+                    queueName,
+                    errorCode: handlerError.code,
+                  });
+                  this.amqpClient.ack(msg);
+                  state.messageHandled = true;
+                })
+                .orElse((replyError: HandlerError) =>
+                  this.routeHandlerError(replyError, msg, name, consumer, queueName, state),
+                );
+            }
+            // An RpcError from a non-RPC consumer is type-impossible but
+            // runtime-reachable through casts; treat it as a permanent
+            // failure rather than crashing the dispatch loop.
+            const routableError: HandlerError = isRpcError(handlerError)
+              ? new NonRetryableError(
+                  `Consumer "${String(name)}" returned an RpcError but is not an RPC`,
+                  handlerError,
+                )
+              : handlerError;
+            return this.routeHandlerError(routableError, msg, name, consumer, queueName, state);
           }),
       )
       .tap(() => {
@@ -770,11 +874,63 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
   }
 
   /**
+   * Route a handler failure to retry / DLQ via {@link handleError}. On its
+   * success paths (retry republish, immediate-requeue nack, DLQ nack) the
+   * message has been ack'd or nack'd, so mark it handled. On its failure
+   * paths (e.g. TTL-backoff misconfig) no ack/nack happens and the message
+   * will be redelivered — leave `messageHandled` false so the consume
+   * catch-all can defensive-nack if needed.
+   *
+   * Either way, re-fail the chain with the original handlerError as `cause`
+   * so the failure-telemetry path fires; routing-internal errors
+   * (TechnicalError) take precedence and surface as the chain's error
+   * directly.
+   */
+  private routeHandlerError(
+    handlerError: HandlerError,
+    msg: ConsumeMessage,
+    name: HandlerName<TContract>,
+    consumer: ConsumerDefinition,
+    queueName: string,
+    state: { messageHandled: boolean },
+  ): AsyncResult<void, TechnicalError> {
+    this.logger?.error("Error processing message", {
+      consumerName: String(name),
+      queueName,
+      errorType: handlerError.name,
+      retryCount:
+        (msg.properties.headers?.["x-delivery-count"] as number | undefined) ??
+        (msg.properties.headers?.["x-retry-count"] as number | undefined) ??
+        0,
+      error: handlerError.message,
+    });
+
+    return handleError(
+      { amqpClient: this.amqpClient, logger: this.logger },
+      handlerError,
+      msg,
+      String(name),
+      consumer,
+    )
+      .tap(() => {
+        state.messageHandled = true;
+      })
+      .flatMap(() =>
+        Err(
+          new TechnicalError(
+            `Handler "${String(name)}" failed: ${handlerError.message}`,
+            handlerError,
+          ),
+        ).toAsync(),
+      );
+  }
+
+  /**
    * Consume messages one at a time.
    */
   private consumeSingle(
     name: HandlerName<TContract>,
-    view: { consumer: ConsumerDefinition; isRpc: boolean; responseSchema?: StandardSchemaV1 },
+    view: ConsumerView,
     handler: StoredHandler,
   ): AsyncResult<void, TechnicalError> {
     const queueName = extractQueue(view.consumer.queue).name;

--- a/tests/src/rpc.spec.ts
+++ b/tests/src/rpc.spec.ts
@@ -1,6 +1,8 @@
 import {
+  isRpcError,
   MessageValidationError,
   RpcCancelledError,
+  RpcError,
   RpcTimeoutError,
   TypedAmqpClient,
 } from "@amqp-contract/client";
@@ -13,8 +15,8 @@ import {
 } from "@amqp-contract/contract";
 import { TechnicalError } from "@amqp-contract/core";
 import { it as baseIt } from "@amqp-contract/testing/extension";
-import { TypedAmqpWorker } from "@amqp-contract/worker";
-import { fromSafePromise, Ok } from "unthrown";
+import { rpcError, TypedAmqpWorker } from "@amqp-contract/worker";
+import { Err, fromSafePromise, Ok } from "unthrown";
 import { describe, expect } from "vitest";
 import { z } from "zod";
 
@@ -206,6 +208,147 @@ describe("TypedAmqpClient RPC", () => {
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error).toBeInstanceOf(TechnicalError);
+    }
+  });
+});
+
+const buildErrorContract = (queueName: string) => {
+  const queue = defineQueue(queueName, { type: "classic", durable: false });
+  const request = defineMessage(z.object({ a: z.number(), b: z.number() }));
+  const response = defineMessage(z.object({ sum: z.number() }));
+  const calculate = defineRpc(queue, {
+    request,
+    response,
+    errors: {
+      NEGATIVE_NUMBERS: defineMessage(z.object({ a: z.number(), b: z.number() })),
+      LIMIT_EXCEEDED: defineMessage(z.object({ limit: z.number() })),
+    },
+  });
+  return defineContract({ rpcs: { calculate } });
+};
+
+describe("TypedAmqpClient RPC typed errors", () => {
+  it("round-trips a declared typed error with validated data", async ({
+    workerFactory,
+    clientFactory,
+  }) => {
+    const contract = buildErrorContract("rpc.calculate.typed-error");
+
+    await workerFactory(contract, {
+      calculate: ({ payload }) =>
+        payload.a < 0 || payload.b < 0
+          ? Err(
+              rpcError("NEGATIVE_NUMBERS", { a: payload.a, b: payload.b }, "negatives rejected"),
+            ).toAsync()
+          : Ok({ sum: payload.a + payload.b }).toAsync(),
+    });
+    const client = await clientFactory(contract);
+
+    const result = await client.call("calculate", { a: -1, b: 2 }, { timeoutMs: 5_000 });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(isRpcError(result.error)).toBe(true);
+      if (isRpcError(result.error)) {
+        expect(result.error.code).toBe("NEGATIVE_NUMBERS");
+        expect(result.error.data).toEqual({ a: -1, b: 2 });
+        expect(result.error.message).toBe("negatives rejected");
+      }
+    }
+  });
+
+  it("still resolves success replies on an RPC that declares errors", async ({
+    workerFactory,
+    clientFactory,
+  }) => {
+    const contract = buildErrorContract("rpc.calculate.typed-error-ok");
+
+    await workerFactory(contract, {
+      calculate: ({ payload }) =>
+        payload.a < 0 || payload.b < 0
+          ? Err(rpcError("NEGATIVE_NUMBERS", { a: payload.a, b: payload.b })).toAsync()
+          : Ok({ sum: payload.a + payload.b }).toAsync(),
+    });
+    const client = await clientFactory(contract);
+
+    const result = await client.call("calculate", { a: 2, b: 3 }, { timeoutMs: 5_000 });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({ sum: 5 });
+    }
+  });
+
+  it("discriminates between multiple declared error codes", async ({
+    workerFactory,
+    clientFactory,
+  }) => {
+    const contract = buildErrorContract("rpc.calculate.typed-error-codes");
+
+    await workerFactory(contract, {
+      calculate: ({ payload }) =>
+        payload.a + payload.b > 100
+          ? Err(rpcError("LIMIT_EXCEEDED", { limit: 100 })).toAsync()
+          : Ok({ sum: payload.a + payload.b }).toAsync(),
+    });
+    const client = await clientFactory(contract);
+
+    const result = await client.call("calculate", { a: 60, b: 60 }, { timeoutMs: 5_000 });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr() && isRpcError(result.error)) {
+      expect(result.error.code).toBe("LIMIT_EXCEEDED");
+      if (result.error.code === "LIMIT_EXCEEDED") {
+        expect(result.error.data).toEqual({ limit: 100 });
+      }
+    }
+  });
+
+  it("times out when the handler returns an undeclared error code (worker DLQ path)", async ({
+    workerFactory,
+    clientFactory,
+  }) => {
+    const contract = buildErrorContract("rpc.calculate.undeclared-error");
+
+    await workerFactory(contract, {
+      // Cast through unknown to deliberately bypass the type system — the
+      // worker refuses to publish an undeclared code, so the client times out.
+      calculate: () =>
+        Err(
+          rpcError("NOT_DECLARED", {}) as unknown as RpcError<"LIMIT_EXCEEDED", { limit: number }>,
+        ).toAsync(),
+    });
+    const client = await clientFactory(contract);
+
+    const result = await client.call("calculate", { a: 1, b: 1 }, { timeoutMs: 500 });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(RpcTimeoutError);
+    }
+  });
+
+  it("times out when the error data fails its declared schema (worker DLQ path)", async ({
+    workerFactory,
+    clientFactory,
+  }) => {
+    const contract = buildErrorContract("rpc.calculate.invalid-error-data");
+
+    await workerFactory(contract, {
+      // Wrong data shape for the declared code — worker-side validation drops
+      // the reply before publishing, so the client times out.
+      calculate: () =>
+        Err(
+          rpcError("LIMIT_EXCEEDED", { wrong: "shape" } as unknown as { limit: number }),
+        ).toAsync(),
+    });
+    const client = await clientFactory(contract);
+
+    const result = await client.call("calculate", { a: 1, b: 1 }, { timeoutMs: 500 });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(RpcTimeoutError);
     }
   });
 });


### PR DESCRIPTION
## Summary

Adds oRPC-inspired **typed error maps** to RPC definitions — an RPC's business failures are now declared in the contract and typed end-to-end, closing the gap where a handler's `Err` never reached the caller (it went to retry/DLQ and the client timed out).

```typescript
const getOrder = defineRpc(queue, {
  request: defineMessage(z.object({ orderId: z.string() })),
  response: defineMessage(z.object({ orderId: z.string(), status: z.string() })),
  errors: {
    ORDER_NOT_FOUND: defineMessage(z.object({ orderId: z.string() })),
  },
});
```

- **Worker**: RPC handler error channel widens to `HandlerError | RpcError<code, data>`. Return `Err(rpcError(code, data))` — the worker validates `data` against the declared schema, publishes an error reply, and **acks the request** (business errors never retry). Undeclared codes / invalid data are contract violations routed to the DLQ.
- **Client**: `call()` error union gains the declared `RpcError<code, data>` members; error data is re-validated on arrival. Narrow with `isRpcError(error)` then `error.code`.
- **Wire format**: backward compatible. Success replies unchanged; error replies are marked by the `x-amqp-contract-error-code` header with a `{ message, data }` JSON body. RPCs without `errors` behave exactly as before.

## Implementation notes

- `RpcError` lives in `@amqp-contract/core` (shared by both sides), re-exported from client and worker. Generic `RpcError<TCode, TData>` via `declare` property narrowing over a `TaggedError` base (`_tag: "@amqp-contract/RpcError"`).
- Worker reply path refactored: `requireReplyAddress` / `validateReplyPayload` / `publishReply` are now shared between success and error replies; failure semantics (NonRetryableError → DLQ) are unchanged.
- New inference helpers: `ClientInferRpcErrors` (schema output side) and `WorkerInferRpcErrors` (schema input side).

## Testing

- Unit + type tests: contract builder (`errors` passthrough, `TErrors` inference) — all green.
- Integration (real RabbitMQ via testcontainers): 5 new round-trip tests — typed error with validated data, success on an error-declaring RPC, multi-code discrimination, undeclared-code DLQ path, invalid-error-data DLQ path. Full `tests/`, worker, and client integration suites pass locally.
- `pnpm typecheck` green across all 16 packages; changeset included (minor, fixed group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)