### PR TITLE
feat: add worker middleware and client interceptors

### DIFF
--- a/.agents/rules/handlers.md
+++ b/.agents/rules/handlers.md
@@ -34,6 +34,8 @@ const asyncHandler = ({ payload }) =>
 
 `defineRpc` creates a request-reply slot. RPC handlers return `AsyncResult<TResponse, HandlerError | WorkerInferRpcErrors<...>>` — the worker validates the response against the RPC's response schema and publishes it back to the caller's `replyTo` with the same `correlationId`.
 
+All handlers (consumer and RPC) receive a third `context` argument populated by the worker's middleware chain (`TypedAmqpWorker.create({ middleware: composeMiddleware(...) })`) — an empty object when no middleware is configured. See `packages/worker/src/middleware.ts` and [docs/guide/middleware-and-interceptors.md](../../docs/guide/middleware-and-interceptors.md).
+
 When the RPC declares an `errors` map (`defineRpc(queue, { request, response, errors })`), the handler may also return `Err(rpcError(code, data))` for a declared code — the worker validates `data` against the declared schema, publishes an error reply (marked by the `RPC_ERROR_CODE_HEADER` header), and **acks the request**; typed business errors never enter the retry/DLQ pipeline. Undeclared codes or invalid error data are contract violations routed to the DLQ. See `packages/worker/src/worker.ts` (`publishRpcErrorReply`) and [docs/guide/error-model.md](../../docs/guide/error-model.md#typed-rpc-errors-rpcerror).
 
 You can define RPC handlers either with `defineHandler` / `defineHandlers` (overloaded against `InferRpcNames<TContract>`, and `validateHandlerTargetExists` checks both `contract.consumers` and `contract.rpcs`) or inline inside `TypedAmqpWorker.create({ handlers: { … } })`. The inline `handlers` parameter is typed against `WorkerInferHandlers<TContract>`, so each name (consumer or RPC) gets the correct signature inferred:

--- a/.changeset/middleware-and-interceptors.md
+++ b/.changeset/middleware-and-interceptors.md
@@ -1,0 +1,32 @@
+---
+"@amqp-contract/worker": minor
+"@amqp-contract/client": minor
+---
+
+Add worker middleware and client interceptors for cross-cutting concerns (trace propagation, auth, idempotency, logging) without handler wrapping.
+
+**Worker middleware** — wraps every handler invocation (consumers and RPCs) after message validation, with oRPC-style typed context injection:
+
+```typescript
+const auth = defineMiddleware<EmptyContext, { tenantId: string }>((args, next) => {
+  const tenantId = args.rawMessage.properties.headers?.["x-tenant-id"];
+  if (typeof tenantId !== "string") return Err(nonRetryable("unauthenticated")).toAsync();
+  return next({ context: { tenantId } });
+});
+
+TypedAmqpWorker.create({
+  contract,
+  middleware: composeMiddleware(auth, timing),
+  handlers: {
+    // third argument is typed as { tenantId: string }
+    processOrder: ({ payload }, _raw, context) => ...,
+  },
+  urls,
+});
+```
+
+Short-circuit results route exactly like handler results: `retryable`/`nonRetryable` → retry/DLQ, `rpcError(code, data)` → typed RPC error reply, `Ok(value)` → skips the handler (RPC reply validated as usual). New exports: `defineMiddleware`, `composeMiddleware`, `WorkerMiddleware`, `WorkerMiddlewareArgs`, `WorkerMiddlewareNext`, `EmptyContext`.
+
+**Client interceptors** — `publishInterceptors` wrap validation + publish (patched messages are re-validated), `callInterceptors` wrap the full RPC round trip; both can patch args, observe outcomes, retry by calling `next` again, or short-circuit. First array entry is outermost. New exports: `PublishInterceptor`, `CallInterceptor` (+ args/next types).
+
+**Note:** handlers now always receive a third `context` argument (an empty object when no middleware is configured). Existing two-parameter handlers are unaffected; only tests asserting exact handler call arity need a third `expect.anything()`.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -112,6 +112,10 @@ export default withMermaid(
               { text: "Client Usage", link: "/guide/client-usage" },
               { text: "Worker Usage", link: "/guide/worker-usage" },
               { text: "Error Model", link: "/guide/error-model" },
+              {
+                text: "Middleware & Interceptors",
+                link: "/guide/middleware-and-interceptors",
+              },
               { text: "Retry Strategies", link: "/guide/retry-strategies" },
               { text: "Testing", link: "/guide/testing" },
             ],

--- a/docs/guide/middleware-and-interceptors.md
+++ b/docs/guide/middleware-and-interceptors.md
@@ -1,0 +1,116 @@
+# Middleware & Interceptors
+
+Cross-cutting concerns — trace propagation, auth, idempotency, logging — shouldn't be copy-pasted into every handler or wrapped around every `publish` call. amqp-contract provides two composable primitives:
+
+- **Worker middleware** wraps every handler invocation (consumers and RPCs) after message validation, and can inject **typed context** that handlers receive as their third argument.
+- **Client interceptors** wrap `publish(...)` and `call(...)`, and can patch the outgoing message/options, observe outcomes, retry, or short-circuit.
+
+Both follow the same shape: a function receiving `(args, next)` that calls `next()` to continue — or doesn't, to short-circuit. Everything stays inside unthrown's `AsyncResult`; nothing throws.
+
+## Worker middleware
+
+### Injecting typed context (guard-and-narrow)
+
+A middleware validates something once and passes the proven result downstream. Handlers declare the context as their third parameter:
+
+```ts
+import {
+  composeMiddleware,
+  defineMiddleware,
+  nonRetryable,
+  TypedAmqpWorker,
+  type EmptyContext,
+} from "@amqp-contract/worker";
+import { Err, Ok } from "unthrown";
+
+const auth = defineMiddleware<EmptyContext, { tenantId: string }>((args, next) => {
+  const tenantId = args.rawMessage.properties.headers?.["x-tenant-id"];
+  if (typeof tenantId !== "string") {
+    // Short-circuit: routed to DLQ like any handler error — the handler never runs.
+    return Err(nonRetryable("Missing x-tenant-id header")).toAsync();
+  }
+  return next({ context: { tenantId } });
+});
+
+const timing = defineMiddleware<{ tenantId: string }, { tenantId: string }>((args, next) => {
+  const start = Date.now();
+  return next().tap(() => {
+    console.log(`${args.handlerName} (${args.context.tenantId}): ${Date.now() - start}ms`);
+  });
+});
+
+const worker = (
+  await TypedAmqpWorker.create({
+    contract,
+    middleware: composeMiddleware(auth, timing),
+    handlers: {
+      // context is typed as { tenantId: string } — proven by the middleware
+      processOrder: ({ payload }, _raw, context) =>
+        processFor(context.tenantId, payload).mapErr((e) => nonRetryable("failed", e)),
+    },
+    urls: ["amqp://localhost"],
+  })
+).unwrap();
+```
+
+`composeMiddleware(outermost, ..., innermost)` runs left-to-right; context types accumulate across the chain, and the final context type is what handlers receive. Without a `middleware` option, handlers get an empty object (`EmptyContext`).
+
+### Semantics
+
+- Middleware runs **after** payload/header validation — `args.message` is already schema-checked. Parse/validation failures go to the DLQ before any middleware runs.
+- The chain wraps consumers **and** RPC handlers; `args.isRpc` discriminates, and `args.handlerName` carries the contract key.
+- Short-circuit results route exactly like handler results:
+  - `Err(retryable(...))` → queue retry mode; `Err(nonRetryable(...))` → DLQ.
+  - `Err(rpcError(code, data))` on an RPC with a declared `errors` map → typed error reply to the caller (see [Error Model](./error-model.md#typed-rpc-errors-rpcerror)).
+  - `Ok(value)` skips the handler; for an RPC, `value` is validated against the response schema and published as the reply (cache pattern).
+- Calling `next()` returns the handler's `AsyncResult` — middleware can `.tap` / `.mapErr` / `.orElse` it for post-processing.
+
+## Client interceptors
+
+### Publish interceptors
+
+Run outside validation and publishing — a patched message goes through schema validation exactly like the original. The canonical use is stamping headers:
+
+```ts
+import { TypedAmqpClient, type PublishInterceptor } from "@amqp-contract/client";
+
+const stampTrace: PublishInterceptor = (args, next) =>
+  next({
+    options: {
+      ...args.options,
+      headers: { ...args.options.headers, traceparent: currentTraceparent() },
+    },
+  });
+
+const client = (
+  await TypedAmqpClient.create({
+    contract,
+    urls: ["amqp://localhost"],
+    publishInterceptors: [stampTrace],
+  })
+).unwrap();
+```
+
+### Call interceptors
+
+Wrap the full RPC round trip (request validation, publish, reply await). They can adjust `timeoutMs`, patch the request, observe typed errors, or retry by calling `next` again:
+
+```ts
+import { RpcTimeoutError, type CallInterceptor } from "@amqp-contract/client";
+import { Err } from "unthrown";
+
+const retryTimeoutsOnce: CallInterceptor = (args, next) =>
+  next().orElse((error) => (error instanceof RpcTimeoutError ? next() : Err(error).toAsync()));
+```
+
+The first interceptor in either array is the **outermost**. Telemetry spans stay outside the chain, so interceptor work is covered by the existing OpenTelemetry instrumentation.
+
+## Trace propagation end to end
+
+The two sides compose into W3C trace-context propagation without touching a single handler: a publish interceptor stamps `traceparent` from the active span, and a worker middleware reads `args.rawMessage.properties.headers.traceparent`, resumes the remote context, and injects the span into the handler context. See [OpenTelemetry](./opentelemetry-observability.md) for the instrumentation this hooks into.
+
+## See also
+
+- [Error Model](./error-model.md) — how short-circuit errors route.
+- [Worker Usage](./worker-usage.md) — handler signatures.
+- [Client Usage](./client-usage.md) — publish/call return types.

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -4,6 +4,7 @@ import {
   type ContractDefinition,
   type InferPublisherNames,
   type InferRpcNames,
+  type RpcDefinition,
   type RpcErrorMap,
 } from "@amqp-contract/contract";
 import {
@@ -29,6 +30,14 @@ import { Err, fromPromise, fromSafePromise, Ok, type AsyncResult, type Result } 
 import { randomUUID } from "node:crypto";
 import { compressBuffer } from "./compression.js";
 import { MessageValidationError, RpcCancelledError, RpcTimeoutError } from "./errors.js";
+import { chainInterceptors } from "./interceptors.js";
+import type {
+  CallError as InterceptorCallError,
+  CallInterceptor,
+  PublishError,
+  PublishInterceptor,
+  PublishInterceptorArgs,
+} from "./interceptors.js";
 import type {
   ClientInferPublisherInput,
   ClientInferRpcErrors,
@@ -107,6 +116,18 @@ export type CreateClientOptions<TContract extends ContractDefinition> = {
    * disable the timeout and let amqp-connection-manager retry indefinitely.
    */
   connectTimeoutMs?: number | null | undefined;
+  /**
+   * Interceptors wrapping every `publish(...)`: the first entry is the
+   * outermost. Each can patch the message/options, observe the outcome,
+   * retry by calling `next` again, or short-circuit. A patched message is
+   * validated exactly like the caller's original.
+   */
+  publishInterceptors?: readonly PublishInterceptor[] | undefined;
+  /**
+   * Interceptors wrapping every `call(...)` round trip (request validation,
+   * publish, reply await): the first entry is the outermost.
+   */
+  callInterceptors?: readonly CallInterceptor[] | undefined;
 };
 
 /**
@@ -151,6 +172,8 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
     private readonly defaultPublishOptions: PublishOptions,
     private readonly logger?: Logger,
     private readonly telemetry: TelemetryProvider = defaultTelemetryProvider,
+    private readonly publishInterceptors: readonly PublishInterceptor[] = [],
+    private readonly callInterceptors: readonly CallInterceptor[] = [],
   ) {}
 
   /**
@@ -171,6 +194,8 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
     logger,
     telemetry,
     connectTimeoutMs,
+    publishInterceptors,
+    callInterceptors,
   }: CreateClientOptions<TContract>): AsyncResult<TypedAmqpClient<TContract>, TechnicalError> {
     const client = new TypedAmqpClient(
       contract,
@@ -178,6 +203,8 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
       { persistent: true, ...defaultPublishOptions },
       logger,
       telemetry ?? defaultTelemetryProvider,
+      publishInterceptors ?? [],
+      callInterceptors ?? [],
     );
 
     const setup = client
@@ -406,8 +433,10 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
       [MessagingSemanticConventions.AMQP_PUBLISHER_NAME]: String(publisherName),
     });
 
-    const validateMessage = (): AsyncResult<unknown, TechnicalError | MessageValidationError> => {
-      const validationResult = publisher.message.payload["~standard"].validate(message);
+    const validateMessage = (
+      rawMessage: unknown,
+    ): AsyncResult<unknown, TechnicalError | MessageValidationError> => {
+      const validationResult = publisher.message.payload["~standard"].validate(rawMessage);
       const promise =
         validationResult instanceof Promise ? validationResult : Promise.resolve(validationResult);
       return fromPromise(
@@ -424,9 +453,12 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
       });
     };
 
-    const publishMessage = (validatedMessage: unknown): AsyncResult<void, TechnicalError> => {
+    const publishMessage = (
+      validatedMessage: unknown,
+      callOptions: PublishOptions,
+    ): AsyncResult<void, TechnicalError> => {
       // Merge default options with provided options
-      const mergedOptions = { ...this.defaultPublishOptions, ...options };
+      const mergedOptions = { ...this.defaultPublishOptions, ...callOptions };
 
       // Extract compression from merged options and create publish options without it
       const { compression, ...restOptions } = mergedOptions;
@@ -469,8 +501,18 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
       );
     };
 
-    return validateMessage()
-      .flatMap((validatedMessage) => publishMessage(validatedMessage))
+    // Interceptors wrap validation + publish; telemetry stays outermost so
+    // the span covers interceptor work too.
+    const terminal = (args: PublishInterceptorArgs): AsyncResult<void, PublishError> =>
+      validateMessage(args.message).flatMap((validatedMessage) =>
+        publishMessage(validatedMessage, args.options),
+      );
+
+    return chainInterceptors(
+      this.publishInterceptors,
+      { publisherName: String(publisherName), message, options: options ?? {} },
+      terminal,
+    )
       .tap(() => {
         const durationMs = Date.now() - startTime;
         endSpanSuccess(span);
@@ -522,7 +564,57 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
       | RpcTimeoutError
       | RpcCancelledError
       | ClientInferRpcErrors<TContract, TName>;
-    type CallResult = Result<ResponseType, CallError>;
+
+    const startTime = Date.now();
+    // Non-null assertion safe: TName is constrained to RPC names in the contract.
+    const rpc = this.contract.rpcs![rpcName as string]!;
+    const queueName = extractQueue(rpc.queue).name;
+
+    // RPC publishes to the default exchange with the queue name as routing key.
+    const span = startPublishSpan(this.telemetry, "", queueName, {
+      [MessagingSemanticConventions.AMQP_PUBLISHER_NAME]: String(rpcName),
+    });
+
+    // Interceptors wrap the full round trip (request validation, publish,
+    // reply await) so they can adjust timeouts, stamp headers, or retry by
+    // calling `next` again; telemetry stays outermost. Error/value types are
+    // erased through the chain and restored at this public boundary.
+    const chained = chainInterceptors(
+      this.callInterceptors,
+      { rpcName: String(rpcName), request, options },
+      (args) => this.executeCall(String(rpcName), rpc, args.request, args.options),
+    );
+
+    const instrumented = chained
+      .tap(() => {
+        const durationMs = Date.now() - startTime;
+        endSpanSuccess(span);
+        recordPublishMetric(this.telemetry, "", queueName, true, durationMs);
+      })
+      .tapErr((error) => {
+        const durationMs = Date.now() - startTime;
+        endSpanError(span, error);
+        recordPublishMetric(this.telemetry, "", queueName, false, durationMs);
+      });
+
+    // Safe: executeCall resolves with the schema-validated response, and its
+    // wire-level error union is the widened form of CallError.
+    return instrumented as AsyncResult<ResponseType, CallError>;
+  }
+
+  /**
+   * The uninstrumented RPC round trip: timeout validation, correlation
+   * bookkeeping, request validation, publish, and reply await. Runs as the
+   * terminal of the call-interceptor chain — `call()` owns telemetry and the
+   * typed public signature.
+   */
+  private executeCall(
+    rpcName: string,
+    rpc: RpcDefinition,
+    request: unknown,
+    options: CallOptions,
+  ): AsyncResult<unknown, InterceptorCallError> {
+    type CallResult = Result<unknown, InterceptorCallError>;
 
     // setTimeout truncates fractional ms and clamps anything outside the
     // 32-bit signed integer range (~24.8 days) to 1ms, so reject those up
@@ -534,24 +626,16 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
       options.timeoutMs <= 0 ||
       options.timeoutMs > TIMEOUT_MAX_MS
     ) {
-      return Err<CallError>(
+      return Err<InterceptorCallError>(
         new TechnicalError(
-          `Invalid timeoutMs for RPC call to "${String(rpcName)}": expected a finite positive number ≤ ${TIMEOUT_MAX_MS}, got ${String(options.timeoutMs)}`,
+          `Invalid timeoutMs for RPC call to "${rpcName}": expected a finite positive number ≤ ${TIMEOUT_MAX_MS}, got ${String(options.timeoutMs)}`,
         ),
       ).toAsync();
     }
 
-    const startTime = Date.now();
-    // Non-null assertion safe: TName is constrained to RPC names in the contract.
-    const rpc = this.contract.rpcs![rpcName as string]!;
     const requestSchema = rpc.request.payload;
     const responseSchema = rpc.response.payload;
     const queueName = extractQueue(rpc.queue).name;
-
-    // RPC publishes to the default exchange with the queue name as routing key.
-    const span = startPublishSpan(this.telemetry, "", queueName, {
-      [MessagingSemanticConventions.AMQP_PUBLISHER_NAME]: String(rpcName),
-    });
 
     const correlationId = randomUUID();
 
@@ -564,18 +648,18 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
     });
     // `callPromise` resolves to a `Result` (never rejects), so lift it with
     // `fromSafePromise` and collapse the nested `Result` back into the channel.
-    const callResultAsync: AsyncResult<ResponseType, CallError> = fromSafePromise(
+    const callResultAsync: AsyncResult<unknown, InterceptorCallError> = fromSafePromise(
       callPromise,
     ).flatMap((result) => result);
 
     const timer = setTimeout(() => {
       if (!this.pendingCalls.has(correlationId)) return;
       this.pendingCalls.delete(correlationId);
-      resolveCall(Err(new RpcTimeoutError(String(rpcName), options.timeoutMs)));
+      resolveCall(Err(new RpcTimeoutError(rpcName, options.timeoutMs)));
     }, options.timeoutMs);
 
     this.pendingCalls.set(correlationId, {
-      rpcName: String(rpcName),
+      rpcName,
       responseSchema,
       rpcErrorSchemas: rpc.errors,
       resolve: resolveCall as PendingCall["resolve"],
@@ -603,7 +687,7 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
       ).flatMap((validation) =>
         validation.issues
           ? Err<TechnicalError | MessageValidationError>(
-              new MessageValidationError(String(rpcName), validation.issues),
+              new MessageValidationError(rpcName, validation.issues),
             )
           : Ok(validation.value),
       );
@@ -631,7 +715,7 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
             ? Ok(undefined)
             : Err<TechnicalError>(
                 new TechnicalError(
-                  `Failed to publish RPC request for "${String(rpcName)}": channel buffer full`,
+                  `Failed to publish RPC request for "${rpcName}": channel buffer full`,
                 ),
               ),
         );
@@ -640,7 +724,7 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
     return validateRequest()
       .flatMap((validated) => publishRequest(validated))
       .flatMap(() => callResultAsync)
-      .orElse((error: CallError) => {
+      .orElse((error: InterceptorCallError) => {
         // If preflight failed (validate or publish), the pending entry still
         // exists and the timer is alive. Clean both up so the call doesn't
         // leak. Timer-fired errors and reply-resolved errors have already
@@ -650,16 +734,6 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
           this.pendingCalls.delete(correlationId);
         }
         return Err(error).toAsync();
-      })
-      .tap(() => {
-        const durationMs = Date.now() - startTime;
-        endSpanSuccess(span);
-        recordPublishMetric(this.telemetry, "", queueName, true, durationMs);
-      })
-      .tapErr((error) => {
-        const durationMs = Date.now() - startTime;
-        endSpanError(span, error);
-        recordPublishMetric(this.telemetry, "", queueName, false, durationMs);
       });
   }
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -34,6 +34,7 @@ import { chainInterceptors } from "./interceptors.js";
 import type {
   CallError as InterceptorCallError,
   CallInterceptor,
+  CallInterceptorArgs,
   PublishError,
   PublishInterceptor,
   PublishInterceptorArgs,
@@ -508,7 +509,14 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
         publishMessage(validatedMessage, args.options),
       );
 
-    return chainInterceptors(
+    // Explicit type arguments: TArgs must be the wire-level interceptor shape
+    // (message: unknown), not the narrower type inferred from this literal.
+    return chainInterceptors<
+      PublishInterceptorArgs,
+      { message?: unknown; options?: PublishOptions },
+      void,
+      PublishError
+    >(
       this.publishInterceptors,
       { publisherName: String(publisherName), message, options: options ?? {} },
       terminal,
@@ -578,11 +586,15 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
     // Interceptors wrap the full round trip (request validation, publish,
     // reply await) so they can adjust timeouts, stamp headers, or retry by
     // calling `next` again; telemetry stays outermost. Error/value types are
-    // erased through the chain and restored at this public boundary.
-    const chained = chainInterceptors(
-      this.callInterceptors,
-      { rpcName: String(rpcName), request, options },
-      (args) => this.executeCall(String(rpcName), rpc, args.request, args.options),
+    // erased through the chain and restored at this public boundary; TArgs is
+    // pinned to the wire-level interceptor shape (request: unknown).
+    const chained = chainInterceptors<
+      CallInterceptorArgs,
+      { request?: unknown; options?: CallOptions },
+      unknown,
+      InterceptorCallError
+    >(this.callInterceptors, { rpcName: String(rpcName), request, options }, (args) =>
+      this.executeCall(String(rpcName), rpc, args.request, args.options),
     );
 
     const instrumented = chained

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -8,6 +8,14 @@ export {
   RpcTimeoutError,
 } from "./errors.js";
 export type {
+  CallInterceptor,
+  CallInterceptorArgs,
+  CallInterceptorNext,
+  PublishInterceptor,
+  PublishInterceptorArgs,
+  PublishInterceptorNext,
+} from "./interceptors.js";
+export type {
   ClientInferPublisherInput,
   ClientInferRpcErrors,
   ClientInferRpcRequestInput,

--- a/packages/client/src/interceptors.spec.ts
+++ b/packages/client/src/interceptors.spec.ts
@@ -1,0 +1,113 @@
+import { TechnicalError } from "@amqp-contract/core";
+import { Err, Ok, type AsyncResult } from "unthrown";
+import { describe, expect, it } from "vitest";
+import {
+  chainInterceptors,
+  type PublishError,
+  type PublishInterceptor,
+  type PublishInterceptorArgs,
+} from "./interceptors.js";
+
+const baseArgs: PublishInterceptorArgs = {
+  publisherName: "orderCreated",
+  message: { orderId: "1" },
+  options: {},
+};
+
+describe("chainInterceptors", () => {
+  it("runs interceptors left-to-right with the first as outermost", async () => {
+    // GIVEN
+    const order: string[] = [];
+    const make =
+      (label: string): PublishInterceptor =>
+      (_args, next) => {
+        order.push(`${label}:before`);
+        return next().tap(() => order.push(`${label}:after`));
+      };
+
+    // WHEN
+    const result = await chainInterceptors([make("outer"), make("inner")], baseArgs, () => {
+      order.push("terminal");
+      return Ok(undefined).toAsync();
+    });
+
+    // THEN
+    expect(result.isOk()).toBe(true);
+    expect(order).toEqual([
+      "outer:before",
+      "inner:before",
+      "terminal",
+      "inner:after",
+      "outer:after",
+    ]);
+  });
+
+  it("applies patches so inner interceptors and the terminal see them", async () => {
+    // GIVEN
+    const stampHeader: PublishInterceptor = (args, next) =>
+      next({ options: { ...args.options, headers: { "x-trace": "abc" } } });
+    const raisePriority: PublishInterceptor = (args, next) =>
+      next({ options: { ...args.options, priority: 7 } });
+
+    // WHEN
+    let finalArgs: PublishInterceptorArgs | undefined;
+    await chainInterceptors([stampHeader, raisePriority], baseArgs, (args) => {
+      finalArgs = args;
+      return Ok(undefined).toAsync();
+    });
+
+    // THEN — the inner interceptor received the stamped header and kept it
+    expect(finalArgs?.options).toEqual({ headers: { "x-trace": "abc" }, priority: 7 });
+    expect(finalArgs?.message).toEqual({ orderId: "1" });
+    expect(finalArgs?.publisherName).toBe("orderCreated");
+  });
+
+  it("short-circuits when an interceptor returns without calling next", async () => {
+    // GIVEN
+    const block: PublishInterceptor = () => Err(new TechnicalError("blocked")).toAsync();
+    let terminalRan = false;
+
+    // WHEN
+    const result = await chainInterceptors([block], baseArgs, () => {
+      terminalRan = true;
+      return Ok(undefined).toAsync();
+    });
+
+    // THEN
+    expect(terminalRan).toBe(false);
+    expect(result.isErr()).toBe(true);
+  });
+
+  it("supports retrying by calling next more than once", async () => {
+    // GIVEN
+    let attempts = 0;
+    const retryOnce: PublishInterceptor = (_args, next) =>
+      next().orElse(
+        (error): AsyncResult<void, PublishError> => (attempts < 2 ? next() : Err(error).toAsync()),
+      );
+
+    // WHEN
+    const result = await chainInterceptors([retryOnce], baseArgs, () => {
+      attempts += 1;
+      return attempts < 2
+        ? Err(new TechnicalError("transient")).toAsync()
+        : Ok(undefined).toAsync();
+    });
+
+    // THEN
+    expect(attempts).toBe(2);
+    expect(result.isOk()).toBe(true);
+  });
+
+  it("runs the terminal directly when no interceptors are configured", async () => {
+    // WHEN
+    const result = await chainInterceptors([], baseArgs, (args) =>
+      args.publisherName === "orderCreated"
+        ? Ok(undefined).toAsync()
+        : Err(new TechnicalError("wrong args")).toAsync(),
+    );
+
+    // THEN
+    expect(result.isOk()).toBe(true);
+  });
+});

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -115,7 +115,12 @@ export type CallInterceptor = (
  *
  * @internal Shared by `publish()` and `call()`; not part of the public API.
  */
-export function chainInterceptors<TArgs extends object, TPatch, TValue, TError>(
+export function chainInterceptors<
+  TArgs extends object,
+  TPatch extends Partial<TArgs>,
+  TValue,
+  TError,
+>(
   interceptors: readonly ((
     args: TArgs,
     next: (patch?: TPatch) => AsyncResult<TValue, TError>,

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -1,0 +1,131 @@
+import type { MessageValidationError, RpcError, TechnicalError } from "@amqp-contract/core";
+import type { AsyncResult } from "unthrown";
+import type { CallOptions, PublishOptions } from "./client.js";
+import type { RpcCancelledError, RpcTimeoutError } from "./errors.js";
+
+/**
+ * Error union a publish interceptor chain resolves with — identical to the
+ * error channel of `client.publish(...)`.
+ */
+export type PublishError = TechnicalError | MessageValidationError;
+
+/**
+ * Error union a call interceptor chain resolves with. The `RpcError` member
+ * is the widened (untyped) form; the public `client.call(...)` signature
+ * narrows it to the RPC's declared error union.
+ */
+export type CallError =
+  | TechnicalError
+  | MessageValidationError
+  | RpcTimeoutError
+  | RpcCancelledError
+  | RpcError;
+
+/**
+ * Arguments a publish interceptor observes. `message` is the pre-validation
+ * payload — a patched message goes through schema validation exactly like the
+ * caller's original.
+ */
+export type PublishInterceptorArgs = {
+  /** The contract `publishers` key being published. */
+  publisherName: string;
+  /** The (not yet validated) message payload. */
+  message: unknown;
+  /** Per-call publish options (defaults are merged later, inside the client). */
+  options: PublishOptions;
+};
+
+/**
+ * Continuation a publish interceptor calls to run the rest of the chain.
+ * The optional patch replaces `message` and/or `options` for everything
+ * downstream (inner interceptors, validation, and the publish itself).
+ */
+export type PublishInterceptorNext = (patch?: {
+  message?: unknown;
+  options?: PublishOptions;
+}) => AsyncResult<void, PublishError>;
+
+/**
+ * Intercepts `client.publish(...)`: runs outside validation and publishing,
+ * so it can stamp headers (e.g. trace context), transform the payload, retry
+ * by calling `next` again, or short-circuit by returning without calling
+ * `next`. The first interceptor in the array is the outermost.
+ *
+ * @example Stamp a correlation header on every outgoing message
+ * ```typescript
+ * const stampTenant: PublishInterceptor = (args, next) =>
+ *   next({
+ *     options: {
+ *       ...args.options,
+ *       headers: { ...args.options.headers, 'x-tenant-id': currentTenant() },
+ *     },
+ *   });
+ * ```
+ */
+export type PublishInterceptor = (
+  args: PublishInterceptorArgs,
+  next: PublishInterceptorNext,
+) => AsyncResult<void, PublishError>;
+
+/**
+ * Arguments a call interceptor observes. `request` is the pre-validation
+ * request payload.
+ */
+export type CallInterceptorArgs = {
+  /** The contract `rpcs` key being called. */
+  rpcName: string;
+  /** The (not yet validated) request payload. */
+  request: unknown;
+  /** Per-call options (`timeoutMs`, `publishOptions`). */
+  options: CallOptions;
+};
+
+/**
+ * Continuation a call interceptor calls to run the rest of the chain. The
+ * resolved value is the RPC response (typed at the public `call()` boundary).
+ */
+export type CallInterceptorNext = (patch?: {
+  request?: unknown;
+  options?: CallOptions;
+}) => AsyncResult<unknown, CallError>;
+
+/**
+ * Intercepts `client.call(...)`: wraps the full request/reply round trip, so
+ * it can adjust timeouts, stamp request headers, observe replies and typed
+ * errors, or retry by calling `next` again. The first interceptor in the
+ * array is the outermost.
+ *
+ * @example Retry timed-out calls once
+ * ```typescript
+ * const retryOnce: CallInterceptor = (args, next) =>
+ *   next().orElse((error) =>
+ *     error instanceof RpcTimeoutError ? next() : Err(error).toAsync(),
+ *   );
+ * ```
+ */
+export type CallInterceptor = (
+  args: CallInterceptorArgs,
+  next: CallInterceptorNext,
+) => AsyncResult<unknown, CallError>;
+
+/**
+ * Run an interceptor chain: interceptors execute left-to-right (first =
+ * outermost), each receiving the args as patched by everything outside it;
+ * `terminal` receives the final args and performs the real operation.
+ *
+ * @internal Shared by `publish()` and `call()`; not part of the public API.
+ */
+export function chainInterceptors<TArgs extends object, TPatch, TValue, TError>(
+  interceptors: readonly ((
+    args: TArgs,
+    next: (patch?: TPatch) => AsyncResult<TValue, TError>,
+  ) => AsyncResult<TValue, TError>)[],
+  args: TArgs,
+  terminal: (args: TArgs) => AsyncResult<TValue, TError>,
+): AsyncResult<TValue, TError> {
+  const run = (index: number, current: TArgs): AsyncResult<TValue, TError> =>
+    index >= interceptors.length
+      ? terminal(current)
+      : interceptors[index]!(current, (patch) => run(index + 1, { ...current, ...patch }));
+  return run(0, args);
+}

--- a/packages/worker/src/handlers.ts
+++ b/packages/worker/src/handlers.ts
@@ -3,6 +3,7 @@ import type {
   InferConsumerNames,
   InferRpcNames,
 } from "@amqp-contract/contract";
+import type { EmptyContext } from "./middleware.js";
 import type {
   WorkerInferConsumerHandler,
   WorkerInferConsumerHandlerEntry,
@@ -121,37 +122,41 @@ function validateHandlers<TContract extends ContractDefinition>(
 export function defineHandler<
   TContract extends ContractDefinition,
   TName extends InferConsumerNames<TContract>,
+  TContext extends Record<string, unknown> | EmptyContext = EmptyContext,
 >(
   contract: TContract,
   name: TName,
-  handler: WorkerInferConsumerHandler<TContract, TName>,
-): WorkerInferConsumerHandlerEntry<TContract, TName>;
+  handler: WorkerInferConsumerHandler<TContract, TName, TContext>,
+): WorkerInferConsumerHandlerEntry<TContract, TName, TContext>;
 export function defineHandler<
   TContract extends ContractDefinition,
   TName extends InferConsumerNames<TContract>,
+  TContext extends Record<string, unknown> | EmptyContext = EmptyContext,
 >(
   contract: TContract,
   name: TName,
-  handler: WorkerInferConsumerHandler<TContract, TName>,
+  handler: WorkerInferConsumerHandler<TContract, TName, TContext>,
   options: ConsumerOptions,
-): WorkerInferConsumerHandlerEntry<TContract, TName>;
+): WorkerInferConsumerHandlerEntry<TContract, TName, TContext>;
 export function defineHandler<
   TContract extends ContractDefinition,
   TName extends InferRpcNames<TContract>,
+  TContext extends Record<string, unknown> | EmptyContext = EmptyContext,
 >(
   contract: TContract,
   name: TName,
-  handler: WorkerInferRpcHandler<TContract, TName>,
-): WorkerInferRpcHandlerEntry<TContract, TName>;
+  handler: WorkerInferRpcHandler<TContract, TName, TContext>,
+): WorkerInferRpcHandlerEntry<TContract, TName, TContext>;
 export function defineHandler<
   TContract extends ContractDefinition,
   TName extends InferRpcNames<TContract>,
+  TContext extends Record<string, unknown> | EmptyContext = EmptyContext,
 >(
   contract: TContract,
   name: TName,
-  handler: WorkerInferRpcHandler<TContract, TName>,
+  handler: WorkerInferRpcHandler<TContract, TName, TContext>,
   options: ConsumerOptions,
-): WorkerInferRpcHandlerEntry<TContract, TName>;
+): WorkerInferRpcHandlerEntry<TContract, TName, TContext>;
 export function defineHandler<
   TContract extends ContractDefinition,
   TName extends InferConsumerNames<TContract> | InferRpcNames<TContract>,
@@ -195,10 +200,13 @@ export function defineHandler<
  * });
  * ```
  */
-export function defineHandlers<TContract extends ContractDefinition>(
+export function defineHandlers<
+  TContract extends ContractDefinition,
+  TContext extends Record<string, unknown> | EmptyContext = EmptyContext,
+>(
   contract: TContract,
-  handlers: WorkerInferHandlers<TContract>,
-): WorkerInferHandlers<TContract> {
+  handlers: WorkerInferHandlers<TContract, TContext>,
+): WorkerInferHandlers<TContract, TContext> {
   validateHandlers(contract, handlers);
   return handlers;
 }

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -20,6 +20,13 @@ export {
 // not a class — re-export it as a type.
 export type { HandlerError } from "./errors.js";
 export { defineHandler, defineHandlers } from "./handlers.js";
+export { composeMiddleware, defineMiddleware } from "./middleware.js";
+export type {
+  EmptyContext,
+  WorkerMiddleware,
+  WorkerMiddlewareArgs,
+  WorkerMiddlewareNext,
+} from "./middleware.js";
 export type {
   WorkerConsumedMessage,
   WorkerInferConsumedMessage,

--- a/packages/worker/src/middleware.spec.ts
+++ b/packages/worker/src/middleware.spec.ts
@@ -1,0 +1,130 @@
+import type { ConsumeMessage } from "amqplib";
+import { Err, Ok } from "unthrown";
+import { describe, expect, it } from "vitest";
+import { nonRetryable } from "./errors.js";
+import { composeMiddleware, defineMiddleware, type WorkerMiddlewareArgs } from "./middleware.js";
+
+const baseArgs: WorkerMiddlewareArgs<Record<string, unknown>> = {
+  message: { payload: { id: "1" }, headers: undefined },
+  rawMessage: { properties: { headers: {} } } as unknown as ConsumeMessage,
+  handlerName: "processOrder",
+  isRpc: false,
+  context: {},
+};
+
+describe("composeMiddleware", () => {
+  it("runs middleware left-to-right with the first as outermost", async () => {
+    // GIVEN
+    const order: string[] = [];
+    const outer = defineMiddleware((_args, next) => {
+      order.push("outer:before");
+      return next().tap(() => order.push("outer:after"));
+    });
+    const inner = defineMiddleware((_args, next) => {
+      order.push("inner:before");
+      return next().tap(() => order.push("inner:after"));
+    });
+
+    // WHEN
+    const chain = composeMiddleware(outer, inner);
+    const result = await chain(baseArgs, () => {
+      order.push("handler");
+      return Ok(undefined).toAsync();
+    });
+
+    // THEN
+    expect(result.isOk()).toBe(true);
+    expect(order).toEqual([
+      "outer:before",
+      "inner:before",
+      "handler",
+      "inner:after",
+      "outer:after",
+    ]);
+  });
+
+  it("accumulates context across the chain", async () => {
+    // GIVEN
+    const first = defineMiddleware<Record<never, never>, { a: number }>((_args, next) =>
+      next({ context: { a: 1 } }),
+    );
+    const second = defineMiddleware<{ a: number }, { a: number; b: string }>((args, next) =>
+      next({ context: { ...args.context, b: `a=${args.context.a}` } }),
+    );
+
+    // WHEN
+    let seen: Record<string, unknown> | undefined;
+    const chain = composeMiddleware(first, second);
+    const result = await chain(baseArgs, (opts) => {
+      seen = opts?.context;
+      return Ok(undefined).toAsync();
+    });
+
+    // THEN
+    expect(result.isOk()).toBe(true);
+    expect(seen).toEqual({ a: 1, b: "a=1" });
+  });
+
+  it("merges injected context over the incoming one when a middleware passes only its own fields", async () => {
+    // GIVEN — second middleware injects without spreading args.context
+    const first = defineMiddleware<Record<never, never>, { a: number }>((_args, next) =>
+      next({ context: { a: 1 } }),
+    );
+    const second = defineMiddleware<{ a: number }, { a: number; b: string }>((_args, next) =>
+      // Deliberately not spreading: the dispatcher merges over the current context.
+      next({ context: { b: "solo" } as { a: number; b: string } }),
+    );
+
+    // WHEN
+    let seen: Record<string, unknown> | undefined;
+    const chain = composeMiddleware(first, second);
+    await chain(baseArgs, (opts) => {
+      seen = opts?.context;
+      return Ok(undefined).toAsync();
+    });
+
+    // THEN
+    expect(seen).toEqual({ a: 1, b: "solo" });
+  });
+
+  it("short-circuits when a middleware returns without calling next", async () => {
+    // GIVEN
+    const guard = defineMiddleware((_args, _next) =>
+      Err(nonRetryable("blocked by guard")).toAsync(),
+    );
+    let handlerRan = false;
+
+    // WHEN
+    const chain = composeMiddleware(guard);
+    const result = await chain(baseArgs, () => {
+      handlerRan = true;
+      return Ok(undefined).toAsync();
+    });
+
+    // THEN
+    expect(handlerRan).toBe(false);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe("blocked by guard");
+    }
+  });
+
+  it("exposes dispatch metadata to every middleware", async () => {
+    // GIVEN
+    const seen: Array<{ handlerName: string; isRpc: boolean }> = [];
+    const observer = defineMiddleware((args, next) => {
+      seen.push({ handlerName: args.handlerName, isRpc: args.isRpc });
+      return next();
+    });
+
+    // WHEN
+    const chain = composeMiddleware(observer, observer);
+    await chain({ ...baseArgs, isRpc: true }, () => Ok(undefined).toAsync());
+
+    // THEN
+    expect(seen).toEqual([
+      { handlerName: "processOrder", isRpc: true },
+      { handlerName: "processOrder", isRpc: true },
+    ]);
+  });
+});

--- a/packages/worker/src/middleware.ts
+++ b/packages/worker/src/middleware.ts
@@ -114,6 +114,12 @@ export function defineMiddleware<
  * across the chain — each middleware's `TContextIn` must match what the
  * previous one produced.
  *
+ * Typed overloads cover up to 8 middleware. For longer chains, nest: a
+ * composed chain is itself a `WorkerMiddleware<EmptyContext, T>` and can be
+ * the *first* argument of an outer `composeMiddleware` call —
+ * `composeMiddleware(composeMiddleware(a, ..., h), i, j)` — preserving
+ * context-type accumulation at any length.
+ *
  * @example
  * ```typescript
  * const middleware = composeMiddleware(logging, auth, idempotency);
@@ -156,6 +162,57 @@ export function composeMiddleware<
   m4: WorkerMiddleware<TC, TD>,
   m5: WorkerMiddleware<TD, TE>,
 ): WorkerMiddleware<EmptyContext, TE>;
+export function composeMiddleware<
+  TA extends Record<string, unknown>,
+  TB extends TA,
+  TC extends TB,
+  TD extends TC,
+  TE extends TD,
+  TF extends TE,
+>(
+  m1: WorkerMiddleware<EmptyContext, TA>,
+  m2: WorkerMiddleware<TA, TB>,
+  m3: WorkerMiddleware<TB, TC>,
+  m4: WorkerMiddleware<TC, TD>,
+  m5: WorkerMiddleware<TD, TE>,
+  m6: WorkerMiddleware<TE, TF>,
+): WorkerMiddleware<EmptyContext, TF>;
+export function composeMiddleware<
+  TA extends Record<string, unknown>,
+  TB extends TA,
+  TC extends TB,
+  TD extends TC,
+  TE extends TD,
+  TF extends TE,
+  TG extends TF,
+>(
+  m1: WorkerMiddleware<EmptyContext, TA>,
+  m2: WorkerMiddleware<TA, TB>,
+  m3: WorkerMiddleware<TB, TC>,
+  m4: WorkerMiddleware<TC, TD>,
+  m5: WorkerMiddleware<TD, TE>,
+  m6: WorkerMiddleware<TE, TF>,
+  m7: WorkerMiddleware<TF, TG>,
+): WorkerMiddleware<EmptyContext, TG>;
+export function composeMiddleware<
+  TA extends Record<string, unknown>,
+  TB extends TA,
+  TC extends TB,
+  TD extends TC,
+  TE extends TD,
+  TF extends TE,
+  TG extends TF,
+  TH extends TG,
+>(
+  m1: WorkerMiddleware<EmptyContext, TA>,
+  m2: WorkerMiddleware<TA, TB>,
+  m3: WorkerMiddleware<TB, TC>,
+  m4: WorkerMiddleware<TC, TD>,
+  m5: WorkerMiddleware<TD, TE>,
+  m6: WorkerMiddleware<TE, TF>,
+  m7: WorkerMiddleware<TF, TG>,
+  m8: WorkerMiddleware<TG, TH>,
+): WorkerMiddleware<EmptyContext, TH>;
 export function composeMiddleware(
   ...middlewares: readonly AnyWorkerMiddleware[]
 ): AnyWorkerMiddleware {

--- a/packages/worker/src/middleware.ts
+++ b/packages/worker/src/middleware.ts
@@ -1,0 +1,174 @@
+import type { RpcError } from "@amqp-contract/core";
+import type { ConsumeMessage } from "amqplib";
+import type { AsyncResult } from "unthrown";
+import type { HandlerError } from "./errors.js";
+
+/**
+ * The middleware context handlers see when no middleware injects anything.
+ *
+ * `Record<never, never>` rather than `{}` so an empty context is a real
+ * "no properties" type instead of the anything-goes empty-object type.
+ */
+export type EmptyContext = Record<never, never>;
+
+/**
+ * Arguments passed to a worker middleware — everything the downstream handler
+ * will receive, plus dispatch metadata and the context accumulated by outer
+ * middleware.
+ */
+export type WorkerMiddlewareArgs<TContextIn extends Record<string, unknown> | EmptyContext> = {
+  /** The validated message (payload and headers already schema-checked). */
+  message: { payload: unknown; headers: unknown };
+  /** The raw amqplib message (delivery tag, AMQP properties, raw headers, …). */
+  rawMessage: ConsumeMessage;
+  /** The `consumers` / `rpcs` key being dispatched. */
+  handlerName: string;
+  /** True when the handler is an RPC server (its result is published as a reply). */
+  isRpc: boolean;
+  /** Context accumulated by outer middleware (empty for the outermost one). */
+  context: TContextIn;
+};
+
+/**
+ * Continuation a middleware calls to run the rest of the chain (inner
+ * middleware, then the handler). `opts.context` is the full context the
+ * downstream sees — pass `{ ...args.context, ...injected }` (or just the
+ * injected fields; the dispatcher merges over the current context either way).
+ *
+ * The returned AsyncResult carries the handler outcome: `undefined` for a
+ * regular consumer, the (not yet validated) response for an RPC. A middleware
+ * can transform or inspect it before returning.
+ */
+export type WorkerMiddlewareNext<TContextOut extends Record<string, unknown> | EmptyContext> =
+  (opts?: { context?: TContextOut }) => AsyncResult<unknown, HandlerError | RpcError>;
+
+/**
+ * A worker middleware: wraps every handler invocation (consumers and RPCs)
+ * after message validation.
+ *
+ * Middleware follow the guard-and-narrow pattern: check something, then call
+ * `next({ context })` to run the rest of the chain with typed fields injected
+ * into the handler's third argument — or short-circuit by returning without
+ * calling `next`:
+ *
+ * - `Err(retryable(...))` / `Err(nonRetryable(...))` routes through the normal
+ *   retry/DLQ pipeline, exactly as if the handler had returned it.
+ * - `Err(rpcError(code, data))` (on an RPC with a declared `errors` map)
+ *   publishes a typed error reply.
+ * - `Ok(value)` skips the handler entirely; for an RPC, `value` is validated
+ *   against the response schema and published as the reply (cache pattern).
+ *
+ * @typeParam TContextIn - context provided by outer middleware
+ * @typeParam TContextOut - context this middleware passes downstream
+ *
+ * @example
+ * ```typescript
+ * import { defineMiddleware, nonRetryable } from '@amqp-contract/worker';
+ * import { Err } from 'unthrown';
+ *
+ * const auth = defineMiddleware<EmptyContext, { tenantId: string }>((args, next) => {
+ *   const tenantId = args.rawMessage.properties.headers?.['x-tenant-id'];
+ *   if (typeof tenantId !== 'string') {
+ *     return Err(nonRetryable('Missing x-tenant-id header')).toAsync();
+ *   }
+ *   return next({ context: { tenantId } });
+ * });
+ * ```
+ */
+export type WorkerMiddleware<
+  TContextIn extends Record<string, unknown> | EmptyContext = EmptyContext,
+  TContextOut extends TContextIn = TContextIn,
+> = (
+  args: WorkerMiddlewareArgs<TContextIn>,
+  next: WorkerMiddlewareNext<TContextOut>,
+) => AsyncResult<unknown, HandlerError | RpcError>;
+
+/**
+ * Widened middleware shape used internally by the dispatcher, where context
+ * types have been erased. Public call sites keep the typed
+ * {@link WorkerMiddleware} form.
+ */
+export type AnyWorkerMiddleware = WorkerMiddleware<
+  Record<string, unknown>,
+  Record<string, unknown>
+>;
+
+/**
+ * Identity helper that pins a middleware's context types without a variable
+ * annotation — `defineMiddleware<In, Out>(fn)` reads better than
+ * `const mw: WorkerMiddleware<In, Out> = fn`.
+ */
+export function defineMiddleware<
+  TContextIn extends Record<string, unknown> | EmptyContext = EmptyContext,
+  TContextOut extends TContextIn = TContextIn,
+>(
+  middleware: WorkerMiddleware<TContextIn, TContextOut>,
+): WorkerMiddleware<TContextIn, TContextOut> {
+  return middleware;
+}
+
+/**
+ * Compose middleware left-to-right: the first argument is the outermost
+ * (runs first, sees the emptiest context), the last is the innermost (its
+ * injected context is what handlers receive). Context types accumulate
+ * across the chain — each middleware's `TContextIn` must match what the
+ * previous one produced.
+ *
+ * @example
+ * ```typescript
+ * const middleware = composeMiddleware(logging, auth, idempotency);
+ * // handlers receive the context injected by all three
+ * ```
+ */
+export function composeMiddleware<TA extends Record<string, unknown>>(
+  m1: WorkerMiddleware<EmptyContext, TA>,
+): WorkerMiddleware<EmptyContext, TA>;
+export function composeMiddleware<TA extends Record<string, unknown>, TB extends TA>(
+  m1: WorkerMiddleware<EmptyContext, TA>,
+  m2: WorkerMiddleware<TA, TB>,
+): WorkerMiddleware<EmptyContext, TB>;
+export function composeMiddleware<TA extends Record<string, unknown>, TB extends TA, TC extends TB>(
+  m1: WorkerMiddleware<EmptyContext, TA>,
+  m2: WorkerMiddleware<TA, TB>,
+  m3: WorkerMiddleware<TB, TC>,
+): WorkerMiddleware<EmptyContext, TC>;
+export function composeMiddleware<
+  TA extends Record<string, unknown>,
+  TB extends TA,
+  TC extends TB,
+  TD extends TC,
+>(
+  m1: WorkerMiddleware<EmptyContext, TA>,
+  m2: WorkerMiddleware<TA, TB>,
+  m3: WorkerMiddleware<TB, TC>,
+  m4: WorkerMiddleware<TC, TD>,
+): WorkerMiddleware<EmptyContext, TD>;
+export function composeMiddleware<
+  TA extends Record<string, unknown>,
+  TB extends TA,
+  TC extends TB,
+  TD extends TC,
+  TE extends TD,
+>(
+  m1: WorkerMiddleware<EmptyContext, TA>,
+  m2: WorkerMiddleware<TA, TB>,
+  m3: WorkerMiddleware<TB, TC>,
+  m4: WorkerMiddleware<TC, TD>,
+  m5: WorkerMiddleware<TD, TE>,
+): WorkerMiddleware<EmptyContext, TE>;
+export function composeMiddleware(
+  ...middlewares: readonly AnyWorkerMiddleware[]
+): AnyWorkerMiddleware {
+  return (args, next) => {
+    const run = (
+      index: number,
+      context: Record<string, unknown>,
+    ): ReturnType<AnyWorkerMiddleware> =>
+      index >= middlewares.length
+        ? next({ context })
+        : middlewares[index]!({ ...args, context }, (opts) =>
+            run(index + 1, { ...context, ...opts?.context }),
+          );
+    return run(0, args.context);
+  };
+}

--- a/packages/worker/src/types.ts
+++ b/packages/worker/src/types.ts
@@ -14,6 +14,7 @@ import type { StandardSchemaV1 } from "@standard-schema/spec";
 import type { ConsumeMessage } from "amqplib";
 import type { AsyncResult } from "unthrown";
 import type { HandlerError } from "./errors.js";
+import type { EmptyContext } from "./middleware.js";
 import { ConsumerOptions } from "./worker.js";
 
 /**
@@ -223,6 +224,11 @@ export type WorkerInferRpcConsumedMessage<
 // All handlers return `AsyncResult<TResponse, HandlerError>` for explicit
 // error handling. Regular consumers return `void`; RPC handlers return the
 // response payload. RetryableError → exponential backoff retry; NonRetryableError → DLQ.
+//
+// Every handler additionally receives a third `context` argument, populated by
+// the worker's middleware chain (an empty object when no middleware is
+// configured). `TContext` defaults to `EmptyContext` so handlers that ignore
+// the argument keep their existing two-parameter shape.
 
 /**
  * Handler signature for a regular consumer (event/command). Returns
@@ -231,9 +237,11 @@ export type WorkerInferRpcConsumedMessage<
 export type WorkerInferConsumerHandler<
   TContract extends ContractDefinition,
   TName extends InferConsumerNames<TContract>,
+  TContext extends Record<string, unknown> | EmptyContext = EmptyContext,
 > = (
   message: WorkerInferConsumedMessage<TContract, TName>,
   rawMessage: ConsumeMessage,
+  context: TContext,
 ) => AsyncResult<void, HandlerError>;
 
 /**
@@ -249,9 +257,11 @@ export type WorkerInferConsumerHandler<
 export type WorkerInferRpcHandler<
   TContract extends ContractDefinition,
   TName extends InferRpcNames<TContract>,
+  TContext extends Record<string, unknown> | EmptyContext = EmptyContext,
 > = (
   message: WorkerInferRpcConsumedMessage<TContract, TName>,
   rawMessage: ConsumeMessage,
+  context: TContext,
 ) => AsyncResult<
   WorkerInferRpcResponse<TContract, TName>,
   HandlerError | WorkerInferRpcErrors<TContract, TName>
@@ -263,9 +273,10 @@ export type WorkerInferRpcHandler<
 export type WorkerInferConsumerHandlerEntry<
   TContract extends ContractDefinition,
   TName extends InferConsumerNames<TContract>,
+  TContext extends Record<string, unknown> | EmptyContext = EmptyContext,
 > =
-  | WorkerInferConsumerHandler<TContract, TName>
-  | readonly [WorkerInferConsumerHandler<TContract, TName>, ConsumerOptions];
+  | WorkerInferConsumerHandler<TContract, TName, TContext>
+  | readonly [WorkerInferConsumerHandler<TContract, TName, TContext>, ConsumerOptions];
 
 /**
  * Handler entry for an RPC — function or `[handler, options]`.
@@ -273,14 +284,18 @@ export type WorkerInferConsumerHandlerEntry<
 export type WorkerInferRpcHandlerEntry<
   TContract extends ContractDefinition,
   TName extends InferRpcNames<TContract>,
+  TContext extends Record<string, unknown> | EmptyContext = EmptyContext,
 > =
-  | WorkerInferRpcHandler<TContract, TName>
-  | readonly [WorkerInferRpcHandler<TContract, TName>, ConsumerOptions];
+  | WorkerInferRpcHandler<TContract, TName, TContext>
+  | readonly [WorkerInferRpcHandler<TContract, TName, TContext>, ConsumerOptions];
 
 /**
  * All handlers for a contract: one entry per `consumers` key plus one entry
  * per `rpcs` key. The two name spaces are disjoint so the resulting object
  * type is unambiguous.
+ *
+ * `TContext` is the context produced by the worker's middleware chain; the
+ * third handler argument is typed with it.
  *
  * @example
  * ```typescript
@@ -294,11 +309,14 @@ export type WorkerInferRpcHandlerEntry<
  * };
  * ```
  */
-export type WorkerInferHandlers<TContract extends ContractDefinition> = ([
-  InferConsumerNames<TContract>,
-] extends [never]
+export type WorkerInferHandlers<
+  TContract extends ContractDefinition,
+  TContext extends Record<string, unknown> | EmptyContext = EmptyContext,
+> = ([InferConsumerNames<TContract>] extends [never]
   ? {}
-  : { [K in InferConsumerNames<TContract>]: WorkerInferConsumerHandlerEntry<TContract, K> }) &
+  : {
+      [K in InferConsumerNames<TContract>]: WorkerInferConsumerHandlerEntry<TContract, K, TContext>;
+    }) &
   ([InferRpcNames<TContract>] extends [never]
     ? {}
-    : { [K in InferRpcNames<TContract>]: WorkerInferRpcHandlerEntry<TContract, K> });
+    : { [K in InferRpcNames<TContract>]: WorkerInferRpcHandlerEntry<TContract, K, TContext> });

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -38,6 +38,7 @@ import {
 import { decompressBuffer } from "./decompression.js";
 import type { HandlerError } from "./errors.js";
 import { MessageValidationError, NonRetryableError } from "./errors.js";
+import type { AnyWorkerMiddleware, EmptyContext, WorkerMiddleware } from "./middleware.js";
 import { handleError } from "./retry.js";
 import type { WorkerInferHandlers } from "./types.js";
 
@@ -59,6 +60,7 @@ type HandlerName<TContract extends ContractDefinition> =
 type StoredHandler = (
   message: { payload: unknown; headers: unknown },
   rawMessage: ConsumeMessage,
+  context: Record<string, unknown>,
 ) => AsyncResult<unknown, HandlerError | RpcError>;
 
 /**
@@ -121,7 +123,10 @@ function isHandlerTuple(entry: unknown): entry is [unknown, ConsumerOptions] {
  * Note: Retry configuration is defined at the queue level in the contract,
  * not at the handler level. See `QueueDefinition.retry` for configuration options.
  */
-export type CreateWorkerOptions<TContract extends ContractDefinition> = {
+export type CreateWorkerOptions<
+  TContract extends ContractDefinition,
+  TContext extends Record<string, unknown> | EmptyContext = EmptyContext,
+> = {
   /** The AMQP contract definition specifying consumers and their message schemas */
   contract: TContract;
   /**
@@ -134,10 +139,24 @@ export type CreateWorkerOptions<TContract extends ContractDefinition> = {
    *   accepts the declared `RpcError<code, data>` members (otherwise it
    *   stays plain `HandlerError`).
    *
+   * Handlers receive the middleware-produced context as a third argument
+   * (an empty object when no `middleware` is configured).
+   *
    * Use `defineHandler` / `defineHandlers` to create handlers with full type
    * inference.
    */
-  handlers: WorkerInferHandlers<TContract>;
+  handlers: WorkerInferHandlers<TContract, TContext>;
+  /**
+   * Optional middleware wrapping every handler invocation (consumers and
+   * RPCs), applied after message validation. Compose multiple middleware
+   * with `composeMiddleware(outermost, ..., innermost)`; the chain's final
+   * context type is what handlers receive as their third argument.
+   *
+   * A middleware can short-circuit by returning without calling `next`:
+   * handler-style errors route through retry/DLQ (or a typed RPC error
+   * reply), and an `Ok(value)` skips the handler entirely.
+   */
+  middleware?: WorkerMiddleware<EmptyContext, TContext> | undefined;
   /** AMQP broker URL(s). Multiple URLs provide failover support */
   urls: ConnectionUrl[];
   /** Optional connection configuration (heartbeat, reconnect settings, etc.) */
@@ -227,6 +246,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
     private readonly defaultConsumerOptions: ConsumerOptions,
     private readonly logger?: Logger,
     telemetry?: TelemetryProvider,
+    private readonly middleware?: AnyWorkerMiddleware,
   ) {
     this.telemetry = telemetry ?? defaultTelemetryProvider;
 
@@ -304,16 +324,23 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
    * });
    * ```
    */
-  static create<TContract extends ContractDefinition>({
+  static create<
+    TContract extends ContractDefinition,
+    TContext extends Record<string, unknown> | EmptyContext = EmptyContext,
+  >({
     contract,
     handlers,
+    middleware,
     urls,
     connectionOptions,
     defaultConsumerOptions,
     logger,
     telemetry,
     connectTimeoutMs,
-  }: CreateWorkerOptions<TContract>): AsyncResult<TypedAmqpWorker<TContract>, TechnicalError> {
+  }: CreateWorkerOptions<TContract, TContext>): AsyncResult<
+    TypedAmqpWorker<TContract>,
+    TechnicalError
+  > {
     const worker = new TypedAmqpWorker(
       contract,
       new AmqpClient(contract, {
@@ -321,10 +348,13 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
         connectionOptions,
         connectTimeoutMs,
       }),
-      handlers,
+      // Context types are erased at the dispatch boundary: handlers receive
+      // whatever the (type-checked) middleware chain produced at runtime.
+      handlers as WorkerInferHandlers<TContract>,
       defaultConsumerOptions ?? {},
       logger,
       telemetry,
+      middleware as AnyWorkerMiddleware | undefined,
     );
 
     // Note: Wait queues are now created by the core package in setupAmqpTopology
@@ -714,17 +744,36 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
   }
 
   /**
-   * Invoke the handler and ack the message on success. Returns the handler's
-   * response (RPC) or `undefined` (regular consumer). Errors propagate as
-   * `HandlerError` for downstream RPC reply publishing or routing via
-   * {@link handleError}.
+   * Invoke the handler — through the middleware chain when one is configured.
+   * Returns the handler's response (RPC) or `undefined` (regular consumer).
+   * Errors propagate as `HandlerError` for downstream RPC reply publishing or
+   * routing via {@link handleError}.
+   *
+   * The middleware chain wraps only the handler, not validation or ack/nack:
+   * a middleware that never calls `next` short-circuits the handler, and its
+   * returned result flows through the exact same reply/retry/DLQ routing a
+   * handler result would.
    */
   private runHandler(
     handler: StoredHandler,
     validatedMessage: { payload: unknown; headers: unknown },
     msg: ConsumeMessage,
+    name: HandlerName<TContract>,
+    isRpc: boolean,
   ): AsyncResult<unknown, HandlerError | RpcError> {
-    return handler(validatedMessage, msg);
+    if (!this.middleware) {
+      return handler(validatedMessage, msg, {});
+    }
+    return this.middleware(
+      {
+        message: validatedMessage,
+        rawMessage: msg,
+        handlerName: String(name),
+        isRpc,
+        context: {},
+      },
+      (opts) => handler(validatedMessage, msg, opts?.context ?? {}),
+    );
   }
 
   /**
@@ -788,7 +837,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
         state.messageHandled = true;
       })
       .flatMap<void, TechnicalError>((validatedMessage) =>
-        this.runHandler(handler, validatedMessage, msg)
+        this.runHandler(handler, validatedMessage, msg, name, view.isRpc)
           .flatMap((handlerResponse) =>
             this.publishReplyIfRpc(msg, view, name, handlerResponse).tap(() => {
               this.logger?.info("Message consumed successfully", {

--- a/tests/src/client-worker.spec.ts
+++ b/tests/src/client-worker.spec.ts
@@ -186,6 +186,7 @@ describe("Client and Worker Integration", () => {
               },
             },
             expect.anything(), // rawMessage
+            expect.anything(), // middleware context
           );
         },
         { timeout: 5000 },
@@ -404,6 +405,7 @@ describe("Client and Worker Integration", () => {
               },
             },
             expect.anything(), // rawMessage
+            expect.anything(), // middleware context
           );
           expect(smsHandler).toHaveBeenCalledTimes(1);
           expect(smsHandler).toHaveBeenNthCalledWith(
@@ -415,6 +417,7 @@ describe("Client and Worker Integration", () => {
               },
             },
             expect.anything(), // rawMessage
+            expect.anything(), // middleware context
           );
         },
         { timeout: 5000 },

--- a/tests/src/middleware.spec.ts
+++ b/tests/src/middleware.spec.ts
@@ -1,0 +1,295 @@
+import { isRpcError, TypedAmqpClient, type PublishInterceptor } from "@amqp-contract/client";
+import {
+  ContractDefinition,
+  defineCommandConsumer,
+  defineCommandPublisher,
+  defineContract,
+  defineExchange,
+  defineMessage,
+  defineQueue,
+  defineRpc,
+} from "@amqp-contract/contract";
+import { it as baseIt } from "@amqp-contract/testing/extension";
+import {
+  composeMiddleware,
+  defineMiddleware,
+  nonRetryable,
+  rpcError,
+  TypedAmqpWorker,
+  type CreateWorkerOptions,
+  type EmptyContext,
+} from "@amqp-contract/worker";
+import { Err, Ok } from "unthrown";
+import { describe, expect } from "vitest";
+import { z } from "zod";
+
+const it = baseIt.extend<{
+  workerFactory: <
+    TContract extends ContractDefinition,
+    TContext extends Record<string, unknown> | EmptyContext,
+  >(
+    options: Omit<CreateWorkerOptions<TContract, TContext>, "urls">,
+  ) => Promise<TypedAmqpWorker<TContract>>;
+  clientFactory: <TContract extends ContractDefinition>(
+    options: Omit<Parameters<typeof TypedAmqpClient.create<TContract>>[0], "urls">,
+  ) => Promise<TypedAmqpClient<TContract>>;
+}>({
+  workerFactory: async ({ amqpConnectionUrl }, use) => {
+    const workers: Array<TypedAmqpWorker<ContractDefinition>> = [];
+    try {
+      await use(async (options) => {
+        const worker = (
+          await TypedAmqpWorker.create({ ...options, urls: [amqpConnectionUrl] })
+        ).unwrap();
+        workers.push(worker as TypedAmqpWorker<ContractDefinition>);
+        return worker;
+      });
+    } finally {
+      await Promise.all(
+        workers.map((w) =>
+          w
+            .close()
+            .then((r) => r.unwrap())
+            .catch(() => undefined),
+        ),
+      );
+    }
+  },
+  clientFactory: async ({ amqpConnectionUrl }, use) => {
+    const clients: Array<TypedAmqpClient<ContractDefinition>> = [];
+    try {
+      await use(async (options) => {
+        const client = (
+          await TypedAmqpClient.create({ ...options, urls: [amqpConnectionUrl] })
+        ).unwrap();
+        clients.push(client as TypedAmqpClient<ContractDefinition>);
+        return client;
+      });
+    } finally {
+      await Promise.all(
+        clients.map((c) =>
+          c
+            .close()
+            .then((r) => r.unwrap())
+            .catch(() => undefined),
+        ),
+      );
+    }
+  },
+});
+
+const buildConsumerContract = (suffix: string) => {
+  const exchange = defineExchange(`orders-${suffix}`, { type: "topic", durable: false });
+  const queue = defineQueue(`orders-${suffix}`, { type: "classic", durable: false });
+  const message = defineMessage(z.object({ orderId: z.string() }));
+  const processOrder = defineCommandConsumer(queue, exchange, message, {
+    routingKey: "order.process",
+  });
+  const createOrder = defineCommandPublisher(processOrder);
+  return defineContract({
+    publishers: { createOrder },
+    consumers: { processOrder },
+  });
+};
+
+const buildRpcContract = (suffix: string) => {
+  const queue = defineQueue(`rpc-${suffix}`, { type: "classic", durable: false });
+  const calculate = defineRpc(queue, {
+    request: defineMessage(z.object({ a: z.number(), b: z.number() })),
+    response: defineMessage(z.object({ sum: z.number() })),
+    errors: {
+      BLOCKED: defineMessage(z.object({ reason: z.string() })),
+    },
+  });
+  return defineContract({ rpcs: { calculate } });
+};
+
+describe("worker middleware", () => {
+  it("injects typed context that handlers receive as third argument", async ({
+    workerFactory,
+    clientFactory,
+  }) => {
+    const contract = buildConsumerContract("mw-context");
+
+    const middleware = composeMiddleware(
+      defineMiddleware<EmptyContext, { tenantId: string }>((args, next) => {
+        const tenantId = args.rawMessage.properties.headers?.["x-tenant-id"];
+        return next({ context: { tenantId: typeof tenantId === "string" ? tenantId : "unknown" } });
+      }),
+      defineMiddleware<{ tenantId: string }, { tenantId: string; greeting: string }>((args, next) =>
+        next({ context: { ...args.context, greeting: `hi ${args.context.tenantId}` } }),
+      ),
+    );
+
+    let resolveSeen!: (value: { tenantId: string; greeting: string }) => void;
+    const seen = new Promise<{ tenantId: string; greeting: string }>((res) => {
+      resolveSeen = res;
+    });
+
+    await workerFactory({
+      contract,
+      middleware,
+      handlers: {
+        processOrder: (_message, _raw, context) => {
+          resolveSeen(context);
+          return Ok(undefined).toAsync();
+        },
+      },
+    });
+    const client = await clientFactory({ contract });
+
+    (
+      await client.publish("createOrder", { orderId: "1" }, { headers: { "x-tenant-id": "acme" } })
+    ).unwrap();
+
+    await expect(seen).resolves.toEqual({ tenantId: "acme", greeting: "hi acme" });
+  });
+
+  it("short-circuits the handler when middleware returns an error", async ({
+    workerFactory,
+    clientFactory,
+  }) => {
+    const contract = buildConsumerContract("mw-short-circuit");
+
+    let handlerRan = false;
+    let resolveBlocked!: () => void;
+    const blocked = new Promise<void>((res) => {
+      resolveBlocked = res;
+    });
+
+    await workerFactory({
+      contract,
+      middleware: defineMiddleware((_args, _next) => {
+        resolveBlocked();
+        return Err(nonRetryable("blocked by middleware")).toAsync();
+      }),
+      handlers: {
+        processOrder: () => {
+          handlerRan = true;
+          return Ok(undefined).toAsync();
+        },
+      },
+    });
+    const client = await clientFactory({ contract });
+
+    (await client.publish("createOrder", { orderId: "1" })).unwrap();
+
+    await blocked;
+    // Give the dispatch loop a beat to (not) run the handler after the guard.
+    await new Promise((res) => setTimeout(res, 100));
+    expect(handlerRan).toBe(false);
+  });
+
+  it("middleware wraps RPC handlers and can short-circuit with a typed RPC error", async ({
+    workerFactory,
+    clientFactory,
+  }) => {
+    const contract = buildRpcContract("mw-rpc");
+
+    await workerFactory({
+      contract,
+      middleware: defineMiddleware((args, next) => {
+        if (args.rawMessage.properties.headers?.["x-blocked"] === "yes") {
+          return Err(rpcError("BLOCKED", { reason: "header said so" })).toAsync();
+        }
+        return next();
+      }),
+      handlers: {
+        calculate: ({ payload }) => Ok({ sum: payload.a + payload.b }).toAsync(),
+      },
+    });
+    const client = await clientFactory({ contract });
+
+    const ok = await client.call("calculate", { a: 1, b: 2 }, { timeoutMs: 5_000 });
+    expect(ok.isOk()).toBe(true);
+
+    const blocked = await client.call(
+      "calculate",
+      { a: 1, b: 2 },
+      { timeoutMs: 5_000, publishOptions: { headers: { "x-blocked": "yes" } } },
+    );
+    expect(blocked.isErr()).toBe(true);
+    if (blocked.isErr()) {
+      expect(isRpcError(blocked.error)).toBe(true);
+      if (isRpcError(blocked.error)) {
+        expect(blocked.error.code).toBe("BLOCKED");
+        expect(blocked.error.data).toEqual({ reason: "header said so" });
+      }
+    }
+  });
+});
+
+describe("client interceptors", () => {
+  it("publish interceptors stamp headers the consumer can observe", async ({
+    workerFactory,
+    clientFactory,
+  }) => {
+    const contract = buildConsumerContract("pub-interceptor");
+
+    let resolveHeaders!: (headers: Record<string, unknown> | undefined) => void;
+    const headersSeen = new Promise<Record<string, unknown> | undefined>((res) => {
+      resolveHeaders = res;
+    });
+
+    await workerFactory({
+      contract,
+      handlers: {
+        processOrder: (_message, raw) => {
+          resolveHeaders(raw.properties.headers);
+          return Ok(undefined).toAsync();
+        },
+      },
+    });
+
+    const stampTrace: PublishInterceptor = (args, next) =>
+      next({
+        options: {
+          ...args.options,
+          headers: { ...args.options.headers, traceparent: "00-abc-def-01" },
+        },
+      });
+
+    const client = await clientFactory({ contract, publishInterceptors: [stampTrace] });
+
+    (await client.publish("createOrder", { orderId: "1" })).unwrap();
+
+    await expect(headersSeen).resolves.toMatchObject({ traceparent: "00-abc-def-01" });
+  });
+
+  it("call interceptors wrap the RPC round trip and can patch the request", async ({
+    workerFactory,
+    clientFactory,
+  }) => {
+    const contract = buildRpcContract("call-interceptor");
+
+    await workerFactory({
+      contract,
+      handlers: {
+        calculate: ({ payload }) => Ok({ sum: payload.a + payload.b }).toAsync(),
+      },
+    });
+
+    const observed: string[] = [];
+    const client = await clientFactory({
+      contract,
+      callInterceptors: [
+        (args, next) => {
+          observed.push(`before:${args.rpcName}`);
+          // Patch the request: double both operands.
+          const request = args.request as { a: number; b: number };
+          return next({ request: { a: request.a * 2, b: request.b * 2 } }).tap(() =>
+            observed.push("after"),
+          );
+        },
+      ],
+    });
+
+    const result = await client.call("calculate", { a: 1, b: 2 }, { timeoutMs: 5_000 });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({ sum: 6 });
+    }
+    expect(observed).toEqual(["before:calculate", "after"]);
+  });
+});


### PR DESCRIPTION
## Summary

Feature ② of the oRPC-inspired roadmap (after #538): a composable middleware/interceptor layer for cross-cutting concerns — trace propagation, auth, idempotency, logging — without handler wrapping.

### Worker middleware (`@amqp-contract/worker`)

Wraps every handler invocation (consumers **and** RPCs) after message validation, with oRPC-style **typed context injection** (guard-and-narrow):

```typescript
const auth = defineMiddleware<EmptyContext, { tenantId: string }>((args, next) => {
  const tenantId = args.rawMessage.properties.headers?.["x-tenant-id"];
  if (typeof tenantId !== "string") return Err(nonRetryable("unauthenticated")).toAsync();
  return next({ context: { tenantId } });
});

TypedAmqpWorker.create({
  contract,
  middleware: composeMiddleware(auth, timing), // context types accumulate left-to-right
  handlers: {
    processOrder: ({ payload }, _raw, context) => ..., // context: { tenantId: string }
  },
  urls,
});
```

Short-circuit semantics are coherent with the existing error model: `Err(retryable/nonRetryable)` → retry/DLQ, `Err(rpcError(code, data))` → typed RPC error reply (#538), `Ok(value)` → skips the handler (RPC replies still schema-validated).

### Client interceptors (`@amqp-contract/client`)

- `publishInterceptors` wrap validation + publish — patched messages/options are re-validated; canonical use is stamping `traceparent` headers.
- `callInterceptors` wrap the full RPC round trip — patch requests/timeouts, observe typed errors, retry by calling `next` again.
- First array entry is outermost; telemetry spans stay outside both chains.

### Notes

- Handlers now always receive a third `context` argument (empty object without middleware). Two-parameter handlers are unaffected; only arity-exact test assertions needed a third `expect.anything()` (done in `tests/src/client-worker.spec.ts`).
- `call()` internals extracted into `executeCall` (uninstrumented terminal of the interceptor chain); `call()` keeps telemetry and the typed public signature.
- New docs page: `docs/guide/middleware-and-interceptors.md` (added to the sidebar), including the end-to-end trace-propagation recipe.

## Testing

- Unit: 10 new tests for `composeMiddleware` / `chainInterceptors` (ordering, context accumulation/merge, short-circuit, retry-via-next, metadata exposure).
- Integration (real RabbitMQ): 5 new round trips — typed context injection through two middleware, short-circuit blocking the handler, RPC middleware short-circuiting with a typed `RpcError` received by the caller, publish-interceptor header stamping observed by the consumer, call-interceptor request patching.
- Full `tests/`, client, and worker integration suites pass locally; `pnpm typecheck` 16/16; changeset included (minor, fixed group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)