### PR TITLE
ci: exempt the Version Packages PR from the changeset gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,8 +184,10 @@ jobs:
     runs-on: ubuntu-latest
     # Only on PRs: fail if a versioned package changed without a changeset
     # (docs/examples/tests are private and unversioned, they don't trigger it).
-    # `pnpm changeset add --empty` opts a PR out explicitly.
-    if: github.event_name == 'pull_request'
+    # `pnpm changeset add --empty` opts a PR out explicitly. The changesets
+    # "Version Packages" PR is exempt — it *consumes* the changesets while
+    # bumping every package, which is exactly the condition this gate rejects.
+    if: github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main'
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,12 @@ jobs:
     # `pnpm changeset add --empty` opts a PR out explicitly. The changesets
     # "Version Packages" PR is exempt — it *consumes* the changesets while
     # bumping every package, which is exactly the condition this gate rejects.
-    if: github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main'
+    # Fork PRs cannot claim the exemption by naming their branch
+    # changeset-release/main — the head repo must be this repository.
+    if: >-
+      github.event_name == 'pull_request' &&
+      !(github.head_ref == 'changeset-release/main' &&
+        github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
The Changeset gate added in #556 fails the changesets **Version Packages** PR (`changeset-release/main`): that PR consumes the changeset files while bumping every package — exactly the "versioned package changed without a changeset" condition the gate exists to reject. Seen on run 29159736409.

Fix: skip the job when `github.head_ref == 'changeset-release/main'`. Regular PRs keep the gate; the release PR is validated by the release pipeline itself.

No changeset (CI-only — and adding one would be recursively ironic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)