### PR TITLE
Apply the Beetroot Stack theme (1.6.0) + character logo

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -5,6 +5,13 @@
   --accent: #ff6600;
 }
 
+/* Hero name in the package accent — the BtravStack multi-accent rule: the
+ * canvas stays neutral, the product glows in its own color (AA via
+ * --text-accent, which darkens on light). */
+:root:root {
+  --vp-home-hero-name-color: var(--text-accent);
+}
+
 /* Home-hero background glyph — the project's motif behind the hero (a message
  * fanning out to bound queues). Painted in --accent through a mask, so it
  * always tracks the accent token; the SVG is base64-encoded so no CSS
@@ -15,12 +22,6 @@
      defined once so the glow and glyph stay anchored to the same column. */
   --btv-col: 1152px;
   --btv-gutter: max(0px, calc((100% - var(--btv-col)) / 2));
-}
-/* Anchor the shared theme's hero glow to the content column instead of the
- * viewport edge, so it doesn't drift into a stray halo by the header on wide
- * screens (it still bleeds ~120px past the content, as before). */
-.VPHome::before {
-  right: calc(var(--btv-gutter) - 120px);
 }
 .VPHome::after {
   content: "";

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,8 @@ hero:
   text: "Type-safe contracts for AMQP/RabbitMQ"
   tagline: End-to-end type safety · Runtime validation · Reliable retry patterns
   image:
-    src: /logo.svg
+    light: /logo-light.svg
+    dark: /logo-dark.svg
     alt: amqp-contract
   actions:
     - theme: brand

--- a/docs/public/logo-dark.svg
+++ b/docs/public/logo-dark.svg
@@ -1,1 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="40 44 120 120" width="120" height="120" fill="none"><defs><linearGradient id="beetBody" x1="0" y1="0" x2="1" y2="0.6"><stop offset="0%" stop-color="#E45A96"></stop><stop offset="55%" stop-color="#B82E6E"></stop><stop offset="100%" stop-color="#7A1646"></stop></linearGradient><linearGradient id="leaf" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#54C77B"></stop><stop offset="100%" stop-color="#2C8B4E"></stop></linearGradient><radialGradient id="beetHi" cx="35%" cy="28%" r="55%"><stop offset="0%" stop-color="#fff" stop-opacity="0.5"></stop><stop offset="100%" stop-color="#fff" stop-opacity="0"></stop></radialGradient></defs><g fill="#EFE7D8"><rect x="77" y="50" width="17" height="52" rx="8.5"></rect><rect x="106" y="50" width="17" height="52" rx="8.5"></rect><rect x="64" y="92" width="72" height="64" rx="22"></rect></g><rect x="83" y="112" width="11" height="11" rx="3.5" fill="#B82E6E"></rect><rect x="106" y="112" width="11" height="11" rx="3.5" fill="#B82E6E"></rect><line x1="92" y1="131" x2="108" y2="131" stroke="#B82E6E" stroke-width="3.4" stroke-linecap="round"></line><g transform="translate(100,133) scale(0.85) rotate(19)"><path d="M0,4 C-5.5,-6 -5.5,-18 0,-27 C5.5,-18 5.5,-6 0,4 Z" fill="url(#leaf)" transform="rotate(180)"></path><path d="M0,2 C-5,-6 -5,-16 0,-24 C5,-16 5,-6 0,2 Z" fill="url(#leaf)" transform="rotate(151)"></path><path d="M0,2 C-5,-6 -5,-16 0,-24 C5,-16 5,-6 0,2 Z" fill="url(#leaf)" transform="rotate(209)"></path></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="28 6 88 128" width="106" height="122" fill="none">
+  <g transform="rotate(-24 58 76)">
+    <rect x="50" y="22" width="17" height="58" rx="8.5" fill="#FF6600"/>
+    <rect x="54.5" y="30" width="8" height="42" rx="4" fill="#FFB380"/>
+  </g>
+  <rect x="82" y="16" width="17" height="60" rx="8.5" fill="#FF6600"/>
+  <rect x="86.5" y="24" width="8" height="44" rx="4" fill="#FFB380"/>
+  <rect x="40" y="68" width="66" height="56" rx="26" fill="#FF6600"/>
+  <circle cx="60" cy="92" r="4.6" fill="#4A1D00"/>
+  <circle cx="61.4" cy="90.6" r="1.6" fill="#FFFFFF"/>
+  <circle cx="86" cy="92" r="4.6" fill="#4A1D00"/>
+  <circle cx="87.4" cy="90.6" r="1.6" fill="#FFFFFF"/>
+  <path d="M69,100 L73,104 L77,100" stroke="#4A1D00" stroke-width="2.4" fill="none" stroke-linejoin="round" stroke-linecap="round"/>
+  <rect x="67" y="105" width="6" height="8" rx="1.8" fill="#FFFFFF"/>
+  <rect x="73.5" y="105" width="6" height="8" rx="1.8" fill="#FFFFFF"/>
+  <circle cx="49" cy="101" r="4" fill="#EE9CC4" opacity="0.8"/>
+  <circle cx="97" cy="101" r="4" fill="#EE9CC4" opacity="0.8"/>
+  <g stroke="#4A1D00" stroke-width="1.6" opacity="0.55" stroke-linecap="round">
+    <path d="M52,95 L40,92"/><path d="M52,100 L41,102"/>
+    <path d="M94,95 L106,92"/><path d="M94,100 L105,102"/>
+  </g>
+  <g transform="translate(82,112) rotate(30)">
+    <path d="M0,0 C-2,-6 -1,-12 3,-16" stroke="#2C8B4E" stroke-width="2.2" fill="none" stroke-linecap="round"/>
+    <path d="M3,-16 C-1,-19 -2,-25 2,-27 C7,-29 10,-24 9,-20 C8,-17 6,-16 3,-16 Z" fill="#3DAE62"/>
+  </g></svg>

--- a/docs/public/logo-light.svg
+++ b/docs/public/logo-light.svg
@@ -1,1 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="40 44 120 120" width="120" height="120" fill="none"><defs><linearGradient id="beetBody" x1="0" y1="0" x2="1" y2="0.6"><stop offset="0%" stop-color="#E45A96"></stop><stop offset="55%" stop-color="#B82E6E"></stop><stop offset="100%" stop-color="#7A1646"></stop></linearGradient><linearGradient id="leaf" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#54C77B"></stop><stop offset="100%" stop-color="#2C8B4E"></stop></linearGradient><radialGradient id="beetHi" cx="35%" cy="28%" r="55%"><stop offset="0%" stop-color="#fff" stop-opacity="0.5"></stop><stop offset="100%" stop-color="#fff" stop-opacity="0"></stop></radialGradient></defs><g fill="#B82E6E"><rect x="77" y="50" width="17" height="52" rx="8.5"></rect><rect x="106" y="50" width="17" height="52" rx="8.5"></rect><rect x="64" y="92" width="72" height="64" rx="22"></rect></g><rect x="83" y="112" width="11" height="11" rx="3.5" fill="#F6EEF2"></rect><rect x="106" y="112" width="11" height="11" rx="3.5" fill="#F6EEF2"></rect><line x1="92" y1="131" x2="108" y2="131" stroke="#F6EEF2" stroke-width="3.4" stroke-linecap="round"></line><g transform="translate(100,133) scale(0.85) rotate(19)"><path d="M0,4 C-5.5,-6 -5.5,-18 0,-27 C5.5,-18 5.5,-6 0,4 Z" fill="url(#leaf)" transform="rotate(180)"></path><path d="M0,2 C-5,-6 -5,-16 0,-24 C5,-16 5,-6 0,2 Z" fill="url(#leaf)" transform="rotate(151)"></path><path d="M0,2 C-5,-6 -5,-16 0,-24 C5,-16 5,-6 0,2 Z" fill="url(#leaf)" transform="rotate(209)"></path></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="28 6 88 128" width="106" height="122" fill="none">
+  <g transform="rotate(-24 58 76)">
+    <rect x="50" y="22" width="17" height="58" rx="8.5" fill="#C24E00"/>
+    <rect x="54.5" y="30" width="8" height="42" rx="4" fill="#F2B48C"/>
+  </g>
+  <rect x="82" y="16" width="17" height="60" rx="8.5" fill="#C24E00"/>
+  <rect x="86.5" y="24" width="8" height="44" rx="4" fill="#F2B48C"/>
+  <rect x="40" y="68" width="66" height="56" rx="26" fill="#C24E00"/>
+  <circle cx="60" cy="92" r="4.6" fill="#4A1D00"/>
+  <circle cx="61.4" cy="90.6" r="1.6" fill="#FFFFFF"/>
+  <circle cx="86" cy="92" r="4.6" fill="#4A1D00"/>
+  <circle cx="87.4" cy="90.6" r="1.6" fill="#FFFFFF"/>
+  <path d="M69,100 L73,104 L77,100" stroke="#4A1D00" stroke-width="2.4" fill="none" stroke-linejoin="round" stroke-linecap="round"/>
+  <rect x="67" y="105" width="6" height="8" rx="1.8" fill="#FFFFFF"/>
+  <rect x="73.5" y="105" width="6" height="8" rx="1.8" fill="#FFFFFF"/>
+  <circle cx="49" cy="101" r="4" fill="#EE9CC4" opacity="0.8"/>
+  <circle cx="97" cy="101" r="4" fill="#EE9CC4" opacity="0.8"/>
+  <g stroke="#4A1D00" stroke-width="1.6" opacity="0.55" stroke-linecap="round">
+    <path d="M52,95 L40,92"/><path d="M52,100 L41,102"/>
+    <path d="M94,95 L106,92"/><path d="M94,100 L105,102"/>
+  </g>
+  <g transform="translate(82,112) rotate(30)">
+    <path d="M0,0 C-2,-6 -1,-12 3,-16" stroke="#2C8B4E" stroke-width="2.2" fill="none" stroke-linecap="round"/>
+    <path d="M3,-16 C-1,-19 -2,-25 2,-27 C7,-29 10,-24 9,-20 C8,-17 6,-16 3,-16 Z" fill="#3DAE62"/>
+  </g></svg>

--- a/docs/public/logo.svg
+++ b/docs/public/logo.svg
@@ -1,1 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="40 44 120 120" width="64" height="64" fill="none"><style>.v-d{display:none}@media (prefers-color-scheme:dark){.v-l{display:none}.v-d{display:inline}}</style><g class="v-l"><defs><linearGradient id="beetBody-l" x1="0" y1="0" x2="1" y2="0.6"><stop offset="0%" stop-color="#E45A96"></stop><stop offset="55%" stop-color="#B82E6E"></stop><stop offset="100%" stop-color="#7A1646"></stop></linearGradient><linearGradient id="leaf-l" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#54C77B"></stop><stop offset="100%" stop-color="#2C8B4E"></stop></linearGradient><radialGradient id="beetHi-l" cx="35%" cy="28%" r="55%"><stop offset="0%" stop-color="#fff" stop-opacity="0.5"></stop><stop offset="100%" stop-color="#fff" stop-opacity="0"></stop></radialGradient></defs><g fill="#B82E6E"><rect x="77" y="50" width="17" height="52" rx="8.5"></rect><rect x="106" y="50" width="17" height="52" rx="8.5"></rect><rect x="64" y="92" width="72" height="64" rx="22"></rect></g><rect x="83" y="112" width="11" height="11" rx="3.5" fill="#F6EEF2"></rect><rect x="106" y="112" width="11" height="11" rx="3.5" fill="#F6EEF2"></rect><line x1="92" y1="131" x2="108" y2="131" stroke="#F6EEF2" stroke-width="3.4" stroke-linecap="round"></line><g transform="translate(100,133) scale(0.85) rotate(19)"><path d="M0,4 C-5.5,-6 -5.5,-18 0,-27 C5.5,-18 5.5,-6 0,4 Z" fill="url(#leaf-l)" transform="rotate(180)"></path><path d="M0,2 C-5,-6 -5,-16 0,-24 C5,-16 5,-6 0,2 Z" fill="url(#leaf-l)" transform="rotate(151)"></path><path d="M0,2 C-5,-6 -5,-16 0,-24 C5,-16 5,-6 0,2 Z" fill="url(#leaf-l)" transform="rotate(209)"></path></g></g><g class="v-d"><defs><linearGradient id="beetBody-d" x1="0" y1="0" x2="1" y2="0.6"><stop offset="0%" stop-color="#E45A96"></stop><stop offset="55%" stop-color="#B82E6E"></stop><stop offset="100%" stop-color="#7A1646"></stop></linearGradient><linearGradient id="leaf-d" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#54C77B"></stop><stop offset="100%" stop-color="#2C8B4E"></stop></linearGradient><radialGradient id="beetHi-d" cx="35%" cy="28%" r="55%"><stop offset="0%" stop-color="#fff" stop-opacity="0.5"></stop><stop offset="100%" stop-color="#fff" stop-opacity="0"></stop></radialGradient></defs><g fill="#EFE7D8"><rect x="77" y="50" width="17" height="52" rx="8.5"></rect><rect x="106" y="50" width="17" height="52" rx="8.5"></rect><rect x="64" y="92" width="72" height="64" rx="22"></rect></g><rect x="83" y="112" width="11" height="11" rx="3.5" fill="#B82E6E"></rect><rect x="106" y="112" width="11" height="11" rx="3.5" fill="#B82E6E"></rect><line x1="92" y1="131" x2="108" y2="131" stroke="#B82E6E" stroke-width="3.4" stroke-linecap="round"></line><g transform="translate(100,133) scale(0.85) rotate(19)"><path d="M0,4 C-5.5,-6 -5.5,-18 0,-27 C5.5,-18 5.5,-6 0,4 Z" fill="url(#leaf-d)" transform="rotate(180)"></path><path d="M0,2 C-5,-6 -5,-16 0,-24 C5,-16 5,-6 0,2 Z" fill="url(#leaf-d)" transform="rotate(151)"></path><path d="M0,2 C-5,-6 -5,-16 0,-24 C5,-16 5,-6 0,2 Z" fill="url(#leaf-d)" transform="rotate(209)"></path></g></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="28 6 88 128" width="106" height="122" fill="none">
+  <g transform="rotate(-24 58 76)">
+    <rect x="50" y="22" width="17" height="58" rx="8.5" fill="#FF6600"/>
+    <rect x="54.5" y="30" width="8" height="42" rx="4" fill="#FFB380"/>
+  </g>
+  <rect x="82" y="16" width="17" height="60" rx="8.5" fill="#FF6600"/>
+  <rect x="86.5" y="24" width="8" height="44" rx="4" fill="#FFB380"/>
+  <rect x="40" y="68" width="66" height="56" rx="26" fill="#FF6600"/>
+  <circle cx="60" cy="92" r="4.6" fill="#4A1D00"/>
+  <circle cx="61.4" cy="90.6" r="1.6" fill="#FFFFFF"/>
+  <circle cx="86" cy="92" r="4.6" fill="#4A1D00"/>
+  <circle cx="87.4" cy="90.6" r="1.6" fill="#FFFFFF"/>
+  <path d="M69,100 L73,104 L77,100" stroke="#4A1D00" stroke-width="2.4" fill="none" stroke-linejoin="round" stroke-linecap="round"/>
+  <rect x="67" y="105" width="6" height="8" rx="1.8" fill="#FFFFFF"/>
+  <rect x="73.5" y="105" width="6" height="8" rx="1.8" fill="#FFFFFF"/>
+  <circle cx="49" cy="101" r="4" fill="#EE9CC4" opacity="0.8"/>
+  <circle cx="97" cy="101" r="4" fill="#EE9CC4" opacity="0.8"/>
+  <g stroke="#4A1D00" stroke-width="1.6" opacity="0.55" stroke-linecap="round">
+    <path d="M52,95 L40,92"/><path d="M52,100 L41,102"/>
+    <path d="M94,95 L106,92"/><path d="M94,100 L105,102"/>
+  </g>
+  <g transform="translate(82,112) rotate(30)">
+    <path d="M0,0 C-2,-6 -1,-12 3,-16" stroke="#2C8B4E" stroke-width="2.2" fill="none" stroke-linecap="round"/>
+    <path d="M3,-16 C-1,-19 -2,-25 2,-27 C7,-29 10,-24 9,-20 C8,-17 6,-16 3,-16 Z" fill="#3DAE62"/>
+  </g></svg>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: 3.6.0
       version: 3.6.0
     '@btravstack/theme':
-      specifier: 1.5.0
-      version: 1.5.0
+      specifier: 1.6.0
+      version: 1.6.0
     '@changesets/cli':
       specifier: 2.31.0
       version: 2.31.0
@@ -188,7 +188,7 @@ importers:
         version: link:../tools/tsconfig
       '@btravstack/theme':
         specifier: 'catalog:'
-        version: 1.5.0(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.16)(typescript@6.0.3))
+        version: 1.6.0(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.16)(typescript@6.0.3))(vue@3.5.35(typescript@6.0.3))
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
@@ -872,10 +872,14 @@ packages:
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
-  '@btravstack/theme@1.5.0':
-    resolution: {integrity: sha512-tTTWDNarS0GOSeHk3GZ+GtrNfAFacZNvYMzG+X/gpyUa8irPGB8MT4f+uCbloJ2UFG6JNLNXnMF7KuAVtMaoAA==}
+  '@btravstack/theme@1.6.0':
+    resolution: {integrity: sha512-MwesCcWGhsPZSHjsoWE0gib7HqUAp5oGQEnKdZshRjnqg0xDh72TvrtY7f/YioimLKAx1RAagMlb53fexNjFFg==}
     peerDependencies:
       vitepress: ^1.6.0
+      vue: ^3.3.0
+    peerDependenciesMeta:
+      vue:
+        optional: true
 
   '@changesets/apply-release-plan@7.1.1':
     resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
@@ -5913,9 +5917,11 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
-  '@btravstack/theme@1.5.0(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.16)(typescript@6.0.3))':
+  '@btravstack/theme@1.6.0(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.16)(typescript@6.0.3))(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       vitepress: 1.6.4(@algolia/client-search@5.53.0)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.16)(typescript@6.0.3)
+    optionalDependencies:
+      vue: 3.5.35(typescript@6.0.3)
 
   '@changesets/apply-release-plan@7.1.1':
     dependencies:
@@ -7817,7 +7823,7 @@ snapshots:
       '@vue/shared': 3.5.35
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.15
+      postcss: 8.5.16
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.35':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ packages:
 
 catalog:
   "@asyncapi/parser": 3.6.0
-  "@btravstack/theme": 1.5.0
+  "@btravstack/theme": 1.6.0
   "@changesets/cli": 2.31.0
   "@commitlint/cli": 21.2.0
   "@commitlint/config-conventional": 21.2.0


### PR DESCRIPTION
Rolls out the new BtravStack design system (btravstack/btravstack.github.io#30, published as @btravstack/theme 1.6.0): near-black canvas, Geist typography, the amqp-orange accent driving everything via the one-knob contract, and the new playful character mark (cheeky rabbit with a flopped ear, nibbling a beet leaf) as scheme-aware hero + nav logo. Hero name now wears the package accent. Docs build verified locally.