### PR TITLE
ci: deploy docs on docs changes to main

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,10 +1,18 @@
 name: Deploy Documentation
 
 # Publish docs when a version is released (changesets creates a GitHub Release on publish), so the
-# site documents the latest *released* library rather than every commit on main.
+# site documents the latest *released* library — and also when the docs themselves change on main
+# (theme bumps, content edits), since those need no library release to be worth shipping.
 on:
   release:
     types: [published]
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/deploy-docs.yml"
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Docs-only merges (like today's Beetroot Stack theme rollout) never shipped — the Pages deploy only triggers on `release: published`. This adds a path-filtered `push` trigger for `docs/**` + `pnpm-workspace.yaml` and restores `workflow_dispatch` for manual deploys. Once merged, the pending theme deploy fires automatically (this workflow file is in its own paths filter).