### PR TITLE
chore(deps): bump @btravstack/theme to 1.6.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: 3.6.0
       version: 3.6.0
     '@btravstack/theme':
-      specifier: 1.6.0
-      version: 1.6.0
+      specifier: 1.6.1
+      version: 1.6.1
     '@changesets/cli':
       specifier: 2.31.0
       version: 2.31.0
@@ -188,7 +188,7 @@ importers:
         version: link:../tools/tsconfig
       '@btravstack/theme':
         specifier: 'catalog:'
-        version: 1.6.0(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.16)(typescript@6.0.3))(vue@3.5.35(typescript@6.0.3))
+        version: 1.6.1(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.16)(typescript@6.0.3))(vue@3.5.35(typescript@6.0.3))
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
@@ -872,8 +872,8 @@ packages:
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
-  '@btravstack/theme@1.6.0':
-    resolution: {integrity: sha512-MwesCcWGhsPZSHjsoWE0gib7HqUAp5oGQEnKdZshRjnqg0xDh72TvrtY7f/YioimLKAx1RAagMlb53fexNjFFg==}
+  '@btravstack/theme@1.6.1':
+    resolution: {integrity: sha512-QsFHsT32D2xIwYm/bTO0+qdFt5YI4WmivyUJybr6QrWS6mmO538GuiP1BosrPGMEamHf8wnxW0nF5WY6IXc/pw==}
     peerDependencies:
       vitepress: ^1.6.0
       vue: ^3.3.0
@@ -5917,7 +5917,7 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
-  '@btravstack/theme@1.6.0(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.16)(typescript@6.0.3))(vue@3.5.35(typescript@6.0.3))':
+  '@btravstack/theme@1.6.1(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.16)(typescript@6.0.3))(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       vitepress: 1.6.4(@algolia/client-search@5.53.0)(@types/node@24.13.2)(lightningcss@1.32.0)(postcss@8.5.16)(typescript@6.0.3)
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ packages:
 
 catalog:
   "@asyncapi/parser": 3.6.0
-  "@btravstack/theme": 1.6.0
+  "@btravstack/theme": 1.6.1
   "@changesets/cli": 2.31.0
   "@commitlint/cli": 21.2.0
   "@commitlint/config-conventional": 21.2.0


### PR DESCRIPTION
Picks up the fixed "Part of BtravStack" footer strip (waving mascot + BtravStack casing) from theme 1.6.1. Docs build verified locally; merging redeploys the site via the push-paths trigger.