### PR TITLE
the beetroot-in-envelope mark

### DIFF
--- a/docs/public/logo-dark.svg
+++ b/docs/public/logo-dark.svg
@@ -1,25 +1,24 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="28 6 88 128" width="106" height="122" fill="none">
-  <g transform="rotate(-24 58 76)">
-    <rect x="50" y="22" width="17" height="58" rx="8.5" fill="#FF6600"/>
-    <rect x="54.5" y="30" width="8" height="42" rx="4" fill="#FFB380"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="14 -12 112 152" width="104" height="141" fill="none">
+  <!-- open flap, folded back behind the beet -->
+  <path d="M27,80 L70,42 L113,80 Z" fill="#FFB380"/>
+  <!-- the beet popping out, arms up: surprise delivery -->
+  <g transform="translate(20,-4)">
+    <path d="M46,34 C44,26 44,18 47,10" stroke="#2C8B4E" stroke-width="3.4" stroke-linecap="round" fill="none"/>
+    <path d="M47,10 C40,7 37,-2 43,-6 C50,-10 56,-3 54,3 C53,7 51,9 47,10 Z" fill="#3DAE62"/>
+    <path d="M41,36 C34,31 26,30 21,34 C16,38 19,45 26,45 C32,45 38,41 41,36 Z" fill="#2C8B4E"/>
+    <path d="M57,34 C62,27 70,24 76,28 C81,32 78,39 71,40 C65,40 60,37 57,34 Z" fill="#3DAE62"/>
+    <g transform="rotate(-52 14 66)"><rect x="0" y="62" width="20" height="9" rx="4.5" fill="#CE3D80"/></g>
+    <g transform="rotate(52 86 66)"><rect x="78" y="62" width="20" height="9" rx="4.5" fill="#8E1A52"/></g>
+    <path d="M50,32 C28,31 14,45 14,62 C14,81 30,98 44,108 C47,111 48,114 50,116 C52,114 53,111 56,108 C70,98 86,81 86,62 C86,45 72,31 50,32 Z" fill="#CE3D80"/>
+    <path d="M63,35 C76,41 86,50 86,62 C86,79 73,94 58,106 C69,91 78,76 78,62 C78,51 72,42 63,35 Z" fill="#8E1A52" opacity="0.85"/>
+    <circle cx="38" cy="60" r="5.2" fill="#3A0D24"/>
+    <circle cx="39.7" cy="58.3" r="1.8" fill="#FFFFFF"/>
+    <circle cx="63" cy="60" r="5.2" fill="#3A0D24"/>
+    <circle cx="64.7" cy="58.3" r="1.8" fill="#FFFFFF"/>
+    <path d="M41,71 Q50.5,80 60,71" stroke="#3A0D24" stroke-width="3.4" stroke-linecap="round" fill="none"/>
+    <circle cx="29" cy="69" r="4.2" fill="#EE9CC4" opacity="0.75"/>
+    <circle cx="72" cy="69" r="4.2" fill="#EE9CC4" opacity="0.75"/>
   </g>
-  <rect x="82" y="16" width="17" height="60" rx="8.5" fill="#FF6600"/>
-  <rect x="86.5" y="24" width="8" height="44" rx="4" fill="#FFB380"/>
-  <rect x="40" y="68" width="66" height="56" rx="26" fill="#FF6600"/>
-  <circle cx="60" cy="92" r="4.6" fill="#4A1D00"/>
-  <circle cx="61.4" cy="90.6" r="1.6" fill="#FFFFFF"/>
-  <circle cx="86" cy="92" r="4.6" fill="#4A1D00"/>
-  <circle cx="87.4" cy="90.6" r="1.6" fill="#FFFFFF"/>
-  <path d="M69,100 L73,104 L77,100" stroke="#4A1D00" stroke-width="2.4" fill="none" stroke-linejoin="round" stroke-linecap="round"/>
-  <rect x="67" y="105" width="6" height="8" rx="1.8" fill="#FFFFFF"/>
-  <rect x="73.5" y="105" width="6" height="8" rx="1.8" fill="#FFFFFF"/>
-  <circle cx="49" cy="101" r="4" fill="#EE9CC4" opacity="0.8"/>
-  <circle cx="97" cy="101" r="4" fill="#EE9CC4" opacity="0.8"/>
-  <g stroke="#4A1D00" stroke-width="1.6" opacity="0.55" stroke-linecap="round">
-    <path d="M52,95 L40,92"/><path d="M52,100 L41,102"/>
-    <path d="M94,95 L106,92"/><path d="M94,100 L105,102"/>
-  </g>
-  <g transform="translate(82,112) rotate(30)">
-    <path d="M0,0 C-2,-6 -1,-12 3,-16" stroke="#2C8B4E" stroke-width="2.2" fill="none" stroke-linecap="round"/>
-    <path d="M3,-16 C-1,-19 -2,-25 2,-27 C7,-29 10,-24 9,-20 C8,-17 6,-16 3,-16 Z" fill="#3DAE62"/>
-  </g></svg>
+  <!-- envelope front -->
+  <rect x="25" y="80" width="90" height="54" rx="7" fill="#FF6600"/>
+  <path d="M28,84 L70,116 L112,84" stroke="#FFB380" stroke-width="3" fill="none" stroke-linejoin="round" stroke-linecap="round"/></svg>

--- a/docs/public/logo-light.svg
+++ b/docs/public/logo-light.svg
@@ -1,25 +1,24 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="28 6 88 128" width="106" height="122" fill="none">
-  <g transform="rotate(-24 58 76)">
-    <rect x="50" y="22" width="17" height="58" rx="8.5" fill="#C24E00"/>
-    <rect x="54.5" y="30" width="8" height="42" rx="4" fill="#F2B48C"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="14 -12 112 152" width="104" height="141" fill="none">
+  <!-- open flap, folded back behind the beet -->
+  <path d="M27,80 L70,42 L113,80 Z" fill="#F2B48C"/>
+  <!-- the beet popping out, arms up: surprise delivery -->
+  <g transform="translate(20,-4)">
+    <path d="M46,34 C44,26 44,18 47,10" stroke="#2C8B4E" stroke-width="3.4" stroke-linecap="round" fill="none"/>
+    <path d="M47,10 C40,7 37,-2 43,-6 C50,-10 56,-3 54,3 C53,7 51,9 47,10 Z" fill="#3DAE62"/>
+    <path d="M41,36 C34,31 26,30 21,34 C16,38 19,45 26,45 C32,45 38,41 41,36 Z" fill="#2C8B4E"/>
+    <path d="M57,34 C62,27 70,24 76,28 C81,32 78,39 71,40 C65,40 60,37 57,34 Z" fill="#3DAE62"/>
+    <g transform="rotate(-52 14 66)"><rect x="0" y="62" width="20" height="9" rx="4.5" fill="#CE3D80"/></g>
+    <g transform="rotate(52 86 66)"><rect x="78" y="62" width="20" height="9" rx="4.5" fill="#8E1A52"/></g>
+    <path d="M50,32 C28,31 14,45 14,62 C14,81 30,98 44,108 C47,111 48,114 50,116 C52,114 53,111 56,108 C70,98 86,81 86,62 C86,45 72,31 50,32 Z" fill="#CE3D80"/>
+    <path d="M63,35 C76,41 86,50 86,62 C86,79 73,94 58,106 C69,91 78,76 78,62 C78,51 72,42 63,35 Z" fill="#8E1A52" opacity="0.85"/>
+    <circle cx="38" cy="60" r="5.2" fill="#3A0D24"/>
+    <circle cx="39.7" cy="58.3" r="1.8" fill="#FFFFFF"/>
+    <circle cx="63" cy="60" r="5.2" fill="#3A0D24"/>
+    <circle cx="64.7" cy="58.3" r="1.8" fill="#FFFFFF"/>
+    <path d="M41,71 Q50.5,80 60,71" stroke="#3A0D24" stroke-width="3.4" stroke-linecap="round" fill="none"/>
+    <circle cx="29" cy="69" r="4.2" fill="#EE9CC4" opacity="0.75"/>
+    <circle cx="72" cy="69" r="4.2" fill="#EE9CC4" opacity="0.75"/>
   </g>
-  <rect x="82" y="16" width="17" height="60" rx="8.5" fill="#C24E00"/>
-  <rect x="86.5" y="24" width="8" height="44" rx="4" fill="#F2B48C"/>
-  <rect x="40" y="68" width="66" height="56" rx="26" fill="#C24E00"/>
-  <circle cx="60" cy="92" r="4.6" fill="#4A1D00"/>
-  <circle cx="61.4" cy="90.6" r="1.6" fill="#FFFFFF"/>
-  <circle cx="86" cy="92" r="4.6" fill="#4A1D00"/>
-  <circle cx="87.4" cy="90.6" r="1.6" fill="#FFFFFF"/>
-  <path d="M69,100 L73,104 L77,100" stroke="#4A1D00" stroke-width="2.4" fill="none" stroke-linejoin="round" stroke-linecap="round"/>
-  <rect x="67" y="105" width="6" height="8" rx="1.8" fill="#FFFFFF"/>
-  <rect x="73.5" y="105" width="6" height="8" rx="1.8" fill="#FFFFFF"/>
-  <circle cx="49" cy="101" r="4" fill="#EE9CC4" opacity="0.8"/>
-  <circle cx="97" cy="101" r="4" fill="#EE9CC4" opacity="0.8"/>
-  <g stroke="#4A1D00" stroke-width="1.6" opacity="0.55" stroke-linecap="round">
-    <path d="M52,95 L40,92"/><path d="M52,100 L41,102"/>
-    <path d="M94,95 L106,92"/><path d="M94,100 L105,102"/>
-  </g>
-  <g transform="translate(82,112) rotate(30)">
-    <path d="M0,0 C-2,-6 -1,-12 3,-16" stroke="#2C8B4E" stroke-width="2.2" fill="none" stroke-linecap="round"/>
-    <path d="M3,-16 C-1,-19 -2,-25 2,-27 C7,-29 10,-24 9,-20 C8,-17 6,-16 3,-16 Z" fill="#3DAE62"/>
-  </g></svg>
+  <!-- envelope front -->
+  <rect x="25" y="80" width="90" height="54" rx="7" fill="#C24E00"/>
+  <path d="M28,84 L70,116 L112,84" stroke="#F2B48C" stroke-width="3" fill="none" stroke-linejoin="round" stroke-linecap="round"/></svg>

--- a/docs/public/logo.svg
+++ b/docs/public/logo.svg
@@ -1,25 +1,24 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="28 6 88 128" width="106" height="122" fill="none">
-  <g transform="rotate(-24 58 76)">
-    <rect x="50" y="22" width="17" height="58" rx="8.5" fill="#FF6600"/>
-    <rect x="54.5" y="30" width="8" height="42" rx="4" fill="#FFB380"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="14 -12 112 152" width="104" height="141" fill="none">
+  <!-- open flap, folded back behind the beet -->
+  <path d="M27,80 L70,42 L113,80 Z" fill="#FFB380"/>
+  <!-- the beet popping out, arms up: surprise delivery -->
+  <g transform="translate(20,-4)">
+    <path d="M46,34 C44,26 44,18 47,10" stroke="#2C8B4E" stroke-width="3.4" stroke-linecap="round" fill="none"/>
+    <path d="M47,10 C40,7 37,-2 43,-6 C50,-10 56,-3 54,3 C53,7 51,9 47,10 Z" fill="#3DAE62"/>
+    <path d="M41,36 C34,31 26,30 21,34 C16,38 19,45 26,45 C32,45 38,41 41,36 Z" fill="#2C8B4E"/>
+    <path d="M57,34 C62,27 70,24 76,28 C81,32 78,39 71,40 C65,40 60,37 57,34 Z" fill="#3DAE62"/>
+    <g transform="rotate(-52 14 66)"><rect x="0" y="62" width="20" height="9" rx="4.5" fill="#CE3D80"/></g>
+    <g transform="rotate(52 86 66)"><rect x="78" y="62" width="20" height="9" rx="4.5" fill="#8E1A52"/></g>
+    <path d="M50,32 C28,31 14,45 14,62 C14,81 30,98 44,108 C47,111 48,114 50,116 C52,114 53,111 56,108 C70,98 86,81 86,62 C86,45 72,31 50,32 Z" fill="#CE3D80"/>
+    <path d="M63,35 C76,41 86,50 86,62 C86,79 73,94 58,106 C69,91 78,76 78,62 C78,51 72,42 63,35 Z" fill="#8E1A52" opacity="0.85"/>
+    <circle cx="38" cy="60" r="5.2" fill="#3A0D24"/>
+    <circle cx="39.7" cy="58.3" r="1.8" fill="#FFFFFF"/>
+    <circle cx="63" cy="60" r="5.2" fill="#3A0D24"/>
+    <circle cx="64.7" cy="58.3" r="1.8" fill="#FFFFFF"/>
+    <path d="M41,71 Q50.5,80 60,71" stroke="#3A0D24" stroke-width="3.4" stroke-linecap="round" fill="none"/>
+    <circle cx="29" cy="69" r="4.2" fill="#EE9CC4" opacity="0.75"/>
+    <circle cx="72" cy="69" r="4.2" fill="#EE9CC4" opacity="0.75"/>
   </g>
-  <rect x="82" y="16" width="17" height="60" rx="8.5" fill="#FF6600"/>
-  <rect x="86.5" y="24" width="8" height="44" rx="4" fill="#FFB380"/>
-  <rect x="40" y="68" width="66" height="56" rx="26" fill="#FF6600"/>
-  <circle cx="60" cy="92" r="4.6" fill="#4A1D00"/>
-  <circle cx="61.4" cy="90.6" r="1.6" fill="#FFFFFF"/>
-  <circle cx="86" cy="92" r="4.6" fill="#4A1D00"/>
-  <circle cx="87.4" cy="90.6" r="1.6" fill="#FFFFFF"/>
-  <path d="M69,100 L73,104 L77,100" stroke="#4A1D00" stroke-width="2.4" fill="none" stroke-linejoin="round" stroke-linecap="round"/>
-  <rect x="67" y="105" width="6" height="8" rx="1.8" fill="#FFFFFF"/>
-  <rect x="73.5" y="105" width="6" height="8" rx="1.8" fill="#FFFFFF"/>
-  <circle cx="49" cy="101" r="4" fill="#EE9CC4" opacity="0.8"/>
-  <circle cx="97" cy="101" r="4" fill="#EE9CC4" opacity="0.8"/>
-  <g stroke="#4A1D00" stroke-width="1.6" opacity="0.55" stroke-linecap="round">
-    <path d="M52,95 L40,92"/><path d="M52,100 L41,102"/>
-    <path d="M94,95 L106,92"/><path d="M94,100 L105,102"/>
-  </g>
-  <g transform="translate(82,112) rotate(30)">
-    <path d="M0,0 C-2,-6 -1,-12 3,-16" stroke="#2C8B4E" stroke-width="2.2" fill="none" stroke-linecap="round"/>
-    <path d="M3,-16 C-1,-19 -2,-25 2,-27 C7,-29 10,-24 9,-20 C8,-17 6,-16 3,-16 Z" fill="#3DAE62"/>
-  </g></svg>
+  <!-- envelope front -->
+  <rect x="25" y="80" width="90" height="54" rx="7" fill="#FF6600"/>
+  <path d="M28,84 L70,116 L112,84" stroke="#FFB380" stroke-width="3" fill="none" stroke-linejoin="round" stroke-linecap="round"/></svg>


### PR DESCRIPTION
Applies the final amqp-contract logo — a happy chibi beet popping out of an open amqp-orange envelope (the beetroot IS the message) — to the docs site: logo.svg / logo-dark.svg / logo-light.svg plus a regenerated social card. The original commit landed on `fix/og-image` just after #573 merged, so it's cherry-picked onto a fresh branch here.