### PR TITLE
fix: keep the hero glyph in the background

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -18,6 +18,7 @@
  * minifier can mangle it. */
 .VPHome {
   position: relative;
+  isolation: isolate;
   /* content-column width, and the gutter from the viewport edge in to it —
      defined once so the glow and glyph stay anchored to the same column. */
   --btv-col: 1152px;
@@ -37,7 +38,7 @@
     no-repeat top center / contain;
   opacity: 0.14;
   pointer-events: none;
-  z-index: 0;
+  z-index: -1;
 }
 @media (max-width: 768px) {
   .VPHome::after {


### PR DESCRIPTION
The `.VPHome::after` motif glyph was painting **over** the hero content: `.VPHome` used `position: relative` with no `z-index`, so it formed no stacking context, and the `z-index: 0` absolute pseudo-element rendered above the in-flow hero heading/logo/mascot. Fix isolates `.VPHome` (`isolation: isolate`) and drops the glyph to `z-index: -1`, so it sits behind the content as intended. Same fix applied across all five docs sites.