### PR TITLE
chore: consume @btravstack shared config packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -15,5 +15,6 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
-  "updateInternalDependencies": "patch"
+  "updateInternalDependencies": "patch",
+  "ignore": ["@amqp-contract/tsconfig", "@amqp-contract/typedoc"]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,7 +1,4 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "rules": {
-    "@typescript-eslint/no-explicit-any": "error",
-    "typescript/consistent-type-definitions": ["error", "type"]
-  }
+  "extends": ["./node_modules/@btravstack/oxlint/base.json"]
 }

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,1 @@
-export default { extends: ["@commitlint/config-conventional"] };
+export default { extends: ["@btravstack/commitlint"] };

--- a/knip.json
+++ b/knip.json
@@ -20,6 +20,8 @@
   "ignoreDependencies": [
     "typedoc-plugin-markdown",
     "@amqp-contract/typedoc",
-    "@amqp-contract/tsconfig"
+    "@amqp-contract/tsconfig",
+    "@btravstack/typedoc",
+    "@btravstack/oxlint"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
     "check:packages": "turbo run check:package"
   },
   "devDependencies": {
+    "@btravstack/commitlint": "catalog:",
+    "@btravstack/oxlint": "catalog:",
     "@changesets/cli": "catalog:",
     "@commitlint/cli": "catalog:",
-    "@commitlint/config-conventional": "catalog:",
     "knip": "catalog:",
     "lefthook": "catalog:",
     "oxfmt": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,18 +12,27 @@ catalogs:
     '@asyncapi/parser':
       specifier: 3.6.0
       version: 3.6.0
+    '@btravstack/commitlint':
+      specifier: 0.1.0
+      version: 0.1.0
+    '@btravstack/oxlint':
+      specifier: 0.1.0
+      version: 0.1.0
     '@btravstack/theme':
       specifier: 1.7.0
       version: 1.7.0
+    '@btravstack/tsconfig':
+      specifier: 0.1.0
+      version: 0.1.0
+    '@btravstack/typedoc':
+      specifier: 0.1.0
+      version: 0.1.0
     '@changesets/cli':
       specifier: 2.31.0
       version: 2.31.0
     '@commitlint/cli':
       specifier: 21.2.1
       version: 21.2.1
-    '@commitlint/config-conventional':
-      specifier: 21.2.0
-      version: 21.2.0
     '@opentelemetry/api':
       specifier: 1.9.1
       version: 1.9.1
@@ -128,6 +137,7 @@ catalogs:
       version: 4.4.3
 
 overrides:
+  fast-uri@<3.1.4: 3.1.4
   brace-expansion@1: 1.1.16
   brace-expansion@2: 2.1.2
   brace-expansion@5: 5.0.7
@@ -142,15 +152,18 @@ importers:
 
   .:
     devDependencies:
+      '@btravstack/commitlint':
+        specifier: 'catalog:'
+        version: 0.1.0(@commitlint/cli@21.2.1(@types/node@26.1.1)(conventional-commits-parser@7.0.1)(typescript@6.0.3))
+      '@btravstack/oxlint':
+        specifier: 'catalog:'
+        version: 0.1.0(oxlint@1.73.0)
       '@changesets/cli':
         specifier: 'catalog:'
         version: 2.31.0(@types/node@26.1.1)
       '@commitlint/cli':
         specifier: 'catalog:'
         version: 21.2.1(@types/node@26.1.1)(conventional-commits-parser@7.0.1)(typescript@6.0.3)
-      '@commitlint/config-conventional':
-        specifier: 'catalog:'
-        version: 21.2.0
       knip:
         specifier: 'catalog:'
         version: 6.26.0
@@ -706,9 +719,20 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
 
-  tools/tsconfig: {}
+  tools/tsconfig:
+    dependencies:
+      '@btravstack/tsconfig':
+        specifier: 'catalog:'
+        version: 0.1.0
 
-  tools/typedoc: {}
+  tools/typedoc:
+    dependencies:
+      '@btravstack/typedoc':
+        specifier: 'catalog:'
+        version: 0.1.0(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))(typedoc@0.28.20(typescript@6.0.3))
+      typedoc-plugin-markdown:
+        specifier: 'catalog:'
+        version: 4.12.0(typedoc@0.28.20(typescript@6.0.3))
 
 packages:
 
@@ -856,6 +880,18 @@ packages:
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
+  '@btravstack/commitlint@0.1.0':
+    resolution: {integrity: sha512-fFSIJJd35VQsToBooQ6vtXmJdkCERDL9eNAyya5r98DgzEPybfuzpmN32WdDkB8TaQ8lpVuiBQ7Qf+4z6FlkRw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@commitlint/cli': '>=21'
+
+  '@btravstack/oxlint@0.1.0':
+    resolution: {integrity: sha512-/UIfVydE3nEExRqE03vUoAAQSdPqVNOzZl0QSa9ikXftezoLQfNgJcFCKW6+D2cJnM180JR0o0W7dmkQHhLogQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      oxlint: '>=1'
+
   '@btravstack/theme@1.7.0':
     resolution: {integrity: sha512-EcBvQruZdsiL/zuNsu7Y1r2FeMDv0J5LZJx7ikO6cFvNRzKCc63A7582gVmfJNQlGJIg0cUCjQXB4Tm1YHtyug==}
     peerDependencies:
@@ -864,6 +900,17 @@ packages:
     peerDependenciesMeta:
       vue:
         optional: true
+
+  '@btravstack/tsconfig@0.1.0':
+    resolution: {integrity: sha512-xRkISG6jY5vLpaDJCptyOjvmUeyH6M/i6shhoE6WFGBc+JToc/dyO/511Zi6NPYVTHamNbxOG/e6dpclBWIz2A==}
+    engines: {node: '>=20'}
+
+  '@btravstack/typedoc@0.1.0':
+    resolution: {integrity: sha512-cAhj15iqJwPQ+Z+I/Kc1Bafu9HqfS2D/uaU7czPecaCgZpH5F8LUfNRmTZppkvnTMpDX0La+UrdIUyNHHLqtIg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      typedoc: '>=0.28'
+      typedoc-plugin-markdown: '>=4'
 
   '@changesets/apply-release-plan@7.1.1':
     resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
@@ -3713,8 +3760,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -5700,11 +5747,27 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
+  '@btravstack/commitlint@0.1.0(@commitlint/cli@21.2.1(@types/node@26.1.1)(conventional-commits-parser@7.0.1)(typescript@6.0.3))':
+    dependencies:
+      '@commitlint/cli': 21.2.1(@types/node@26.1.1)(conventional-commits-parser@7.0.1)(typescript@6.0.3)
+      '@commitlint/config-conventional': 21.2.0
+
+  '@btravstack/oxlint@0.1.0(oxlint@1.73.0)':
+    dependencies:
+      oxlint: 1.73.0
+
   '@btravstack/theme@1.7.0(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@26.1.1)(jiti@2.7.0)(postcss@8.5.19)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       vitepress: 1.6.4(@algolia/client-search@5.53.0)(@types/node@26.1.1)(jiti@2.7.0)(postcss@8.5.19)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
     optionalDependencies:
       vue: 3.5.35(typescript@6.0.3)
+
+  '@btravstack/tsconfig@0.1.0': {}
+
+  '@btravstack/typedoc@0.1.0(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))(typedoc@0.28.20(typescript@6.0.3))':
+    dependencies:
+      typedoc: 0.28.20(typescript@6.0.3)
+      typedoc-plugin-markdown: 4.12.0(typedoc@0.28.20(typescript@6.0.3))
 
   '@changesets/apply-release-plan@7.1.1':
     dependencies:
@@ -7585,7 +7648,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -8494,7 +8557,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.4: {}
 
   fastq@1.20.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,10 +14,13 @@ packages:
 catalog:
   "@arethetypeswrong/cli": 0.18.5
   "@asyncapi/parser": 3.6.0
+  "@btravstack/commitlint": 0.1.0
+  "@btravstack/oxlint": 0.1.0
   "@btravstack/theme": 1.7.0
+  "@btravstack/tsconfig": 0.1.0
+  "@btravstack/typedoc": 0.1.0
   "@changesets/cli": 2.31.0
   "@commitlint/cli": 21.2.1
-  "@commitlint/config-conventional": 21.2.0
   "@opentelemetry/api": 1.9.1
   "@orpc/arktype": 1.14.8
   "@orpc/openapi": 1.14.8
@@ -64,6 +67,12 @@ peerDependencyRules:
 # without disturbing unrelated lines. All of these reach us only through
 # dev/build/test tooling.
 overrides:
+  # GHSA-v2hh-gcrm-f6hx (High): fast-uri host confusion via literal backslash
+  # authority delimiter. Only the vulnerable <3.1.4 line is present (transitive,
+  # via ajv under commitlint/prisma tooling); 3.1.4 is the first patched release.
+  # Newly disclosed; reaches us only through dev/build tooling. fast-uri is added
+  # to minimumReleaseAgeExclude below because 3.1.4 is younger than the 7-day cutoff.
+  "fast-uri@<3.1.4": "3.1.4"
   # GHSA-3jxr-9vmj-r5cp (High): brace-expansion ReDoS. Three distinct lines are
   # present: 1.x via @asyncapi/parser > spectral, 2.x via testcontainers >
   # archiver, and 5.x via typedoc > minimatch. Each is pulled to its patched
@@ -105,9 +114,16 @@ minimumReleaseAgeStrict: true
 # First-party (btravstack) packages are exempt from the maturity gate so freshly
 # published versions can be adopted immediately.
 minimumReleaseAgeExclude:
+  - "@btravstack/commitlint"
+  - "@btravstack/oxlint"
   - "@btravstack/theme"
+  - "@btravstack/tsconfig"
+  - "@btravstack/typedoc"
   - unthrown
   - "@unthrown/vitest"
+  # Temporary: fast-uri 3.1.4 (the GHSA-v2hh-gcrm-f6hx override above) is younger
+  # than the 7-day cutoff. Remove once 3.1.4 is 7 days old (published 2026-07-19).
+  - fast-uri
 
 allowBuilds:
   cpu-features: true

--- a/tools/tsconfig/base.json
+++ b/tools/tsconfig/base.json
@@ -1,34 +1,4 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-
-    "target": "ES2022",
-    "lib": ["ES2023"],
-    "types": ["node"],
-
-    "resolveJsonModule": true,
-    "allowJs": true,
-    "checkJs": false,
-    "noEmit": true,
-    "declaration": true,
-    "declarationMap": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "allowUnusedLabels": false,
-    "allowUnreachableCode": false,
-    "exactOptionalPropertyTypes": true,
-    "noImplicitOverride": true,
-    "noImplicitReturns": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noUncheckedIndexedAccess": true
-  },
-  "exclude": ["node_modules", "dist"]
+  "extends": "@btravstack/tsconfig/base.json"
 }

--- a/tools/tsconfig/package.json
+++ b/tools/tsconfig/package.json
@@ -11,5 +11,8 @@
   "type": "module",
   "exports": {
     "./base.json": "./base.json"
+  },
+  "dependencies": {
+    "@btravstack/tsconfig": "catalog:"
   }
 }

--- a/tools/typedoc/base.json
+++ b/tools/typedoc/base.json
@@ -1,21 +1,4 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "plugin": ["typedoc-plugin-markdown"],
-  "outputFileStrategy": "modules",
-  "flattenOutputFiles": true,
-  "entryFileName": "index.md",
-  "hideGenerator": true,
-  "excludePrivate": true,
-  "excludeProtected": true,
-  "excludeInternal": true,
-  "readme": "none",
-  "githubPages": false,
-  "useCodeBlocks": true,
-  "useHTMLEncodedBrackets": true,
-  "sanitizeComments": true,
-  "parametersFormat": "table",
-  "propertiesFormat": "table",
-  "enumMembersFormat": "table",
-  "typeDeclarationFormat": "table",
-  "skipErrorChecking": true
+  "extends": "@btravstack/typedoc/base.json"
 }

--- a/tools/typedoc/package.json
+++ b/tools/typedoc/package.json
@@ -6,5 +6,9 @@
   "license": "MIT",
   "exports": {
     "./base.json": "./base.json"
+  },
+  "dependencies": {
+    "@btravstack/typedoc": "catalog:",
+    "typedoc-plugin-markdown": "catalog:"
   }
 }


### PR DESCRIPTION
Migrates amqp-contract to consume the published `@btravstack/*` shared config packages (part of the org-wide rollout, btravstack/amqp-contract#555).

## Migrated
- **tsconfig / typedoc** — `tools/*/base.json` now thin-extend `@btravstack/tsconfig` / `@btravstack/typedoc` (consumer packages' `extends` unchanged; local override seam kept per #555)
- **oxlint** — `.oxlintrc.json` extends `@btravstack/oxlint`
- **commitlint** — extends `@btravstack/commitlint` (drops the direct `@commitlint/config-conventional` devDep + catalog entry — now transitive)
- **oxfmt fix** — `.oxfmtrc.json` used `organizeImports`, a key oxfmt 0.58 no longer recognizes, so import sorting was silently **off**. Switched to `sortImports: true`; running `pnpm format` reordered imports in 54 files (pure ordering, no behavior change).
- catalog + `minimumReleaseAgeExclude` + `knip.json` ignores updated for the first-party `@btravstack` scope.

**Not migrated:** oxfmt (no `extends` mechanism) and lefthook (handled separately once `@btravstack/lefthook@0.1.1` is republished).

## Gate
`pnpm install`, build, typecheck, lint, format, knip, and test (**69 tests pass**) all green.