### PR TITLE
chore: adopt @btravstack config 0.2.x

### DIFF
--- a/.changeset/adopt-btravstack-0.2.md
+++ b/.changeset/adopt-btravstack-0.2.md
@@ -1,0 +1,5 @@
+---
+"@amqp-contract/core": patch
+---
+
+Adopt @btravstack/tsconfig@0.2.0 (verbatimModuleSyntax), @btravstack/oxlint@0.2.1 (consistent-type-imports), @btravstack/lefthook, and the oxfmt sortImports fix.

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,8 +1,5 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
   "ignorePatterns": ["pnpm-lock.yaml"],
-  "organizeImports": {
-    "sortImports": true,
-    "separateGroups": true
-  }
+  "sortImports": true
 }

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,4 +1,5 @@
 import Theme from "@btravstack/theme";
+
 import "./custom.css";
 
 export default Theme;

--- a/docs/scripts/copy-docs.ts
+++ b/docs/scripts/copy-docs.ts
@@ -6,7 +6,6 @@ import "@amqp-contract/contract";
 import "@amqp-contract/core";
 import "@amqp-contract/testing/global-setup";
 import "@amqp-contract/worker";
-
 import { cp, mkdir, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/examples/basic-order-processing-client/src/index.spec.ts
+++ b/examples/basic-order-processing-client/src/index.spec.ts
@@ -1,8 +1,8 @@
-import { describe, expect } from "vitest";
-import { Ok } from "unthrown";
+import { orderContract } from "@amqp-contract-examples/basic-order-processing-contract";
 import { TypedAmqpClient } from "@amqp-contract/client";
 import { it } from "@amqp-contract/testing/extension";
-import { orderContract } from "@amqp-contract-examples/basic-order-processing-contract";
+import { Ok } from "unthrown";
+import { describe, expect } from "vitest";
 
 describe("Basic Order Processing Client Integration", () => {
   it("should publish a new order successfully", async ({ amqpConnectionUrl }) => {

--- a/examples/basic-order-processing-client/src/index.ts
+++ b/examples/basic-order-processing-client/src/index.ts
@@ -1,5 +1,5 @@
 import { orderContract } from "@amqp-contract-examples/basic-order-processing-contract";
-import { PublishOptions, TypedAmqpClient } from "@amqp-contract/client";
+import { type PublishOptions, TypedAmqpClient } from "@amqp-contract/client";
 import pino from "pino";
 import { z } from "zod";
 

--- a/examples/basic-order-processing-client/tsconfig.json
+++ b/examples/basic-order-processing-client/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@btravstack/tsconfig/base.json",
   "compilerOptions": {
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["node"]
   },
   "include": ["src/**/*"]
 }

--- a/examples/basic-order-processing-contract/scripts/generate-asyncapi-json.ts
+++ b/examples/basic-order-processing-contract/scripts/generate-asyncapi-json.ts
@@ -1,5 +1,6 @@
-import { spec } from "./generate-spec.js";
 import { writeFileSync } from "node:fs";
+
+import { spec } from "./generate-spec.js";
 
 const outputPath = "asyncapi.json";
 writeFileSync(outputPath, JSON.stringify(spec, null, 2));

--- a/examples/basic-order-processing-contract/scripts/generate-asyncapi-yaml.ts
+++ b/examples/basic-order-processing-contract/scripts/generate-asyncapi-yaml.ts
@@ -1,6 +1,8 @@
-import YAML from "yaml";
-import { spec } from "./generate-spec.js";
 import { writeFileSync } from "node:fs";
+
+import YAML from "yaml";
+
+import { spec } from "./generate-spec.js";
 
 const outputPath = "asyncapi.yaml";
 writeFileSync(outputPath, YAML.stringify(spec));

--- a/examples/basic-order-processing-contract/scripts/generate-spec.ts
+++ b/examples/basic-order-processing-contract/scripts/generate-spec.ts
@@ -1,5 +1,6 @@
 import { AsyncAPIGenerator } from "@amqp-contract/asyncapi";
 import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
+
 import { orderContract } from "../src/index.js";
 
 const generator = new AsyncAPIGenerator({

--- a/examples/basic-order-processing-contract/tsconfig.json
+++ b/examples/basic-order-processing-contract/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@btravstack/tsconfig/base.json",
   "compilerOptions": {
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]

--- a/examples/basic-order-processing-worker/src/index.spec.ts
+++ b/examples/basic-order-processing-worker/src/index.spec.ts
@@ -1,8 +1,8 @@
-import { OkAsync } from "unthrown";
-import { TypedAmqpWorker, defineHandlers } from "@amqp-contract/worker";
-import { describe, expect, vi } from "vitest";
-import { it } from "@amqp-contract/testing/extension";
 import { orderContract } from "@amqp-contract-examples/basic-order-processing-contract";
+import { it } from "@amqp-contract/testing/extension";
+import { TypedAmqpWorker, defineHandlers } from "@amqp-contract/worker";
+import { OkAsync } from "unthrown";
+import { describe, expect, vi } from "vitest";
 
 describe("Basic Order Processing Worker Integration", () => {
   it("should process new orders from order.created queue", async ({

--- a/examples/basic-order-processing-worker/src/index.ts
+++ b/examples/basic-order-processing-worker/src/index.ts
@@ -1,7 +1,7 @@
 import { orderContract } from "@amqp-contract-examples/basic-order-processing-contract";
 import { RetryableError, TypedAmqpWorker, defineHandlers } from "@amqp-contract/worker";
-import { fromPromise } from "unthrown";
 import pino from "pino";
+import { fromPromise } from "unthrown";
 import { z } from "zod";
 
 const env = z

--- a/examples/basic-order-processing-worker/tsconfig.json
+++ b/examples/basic-order-processing-worker/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@btravstack/tsconfig/base.json",
   "compilerOptions": {
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["node"]
   },
   "include": ["src/**/*"]
 }

--- a/knip.json
+++ b/knip.json
@@ -17,5 +17,10 @@
       "project": ["scripts/**/*.ts"]
     }
   },
-  "ignoreDependencies": ["typedoc-plugin-markdown", "@btravstack/typedoc", "@btravstack/oxlint"]
+  "ignoreDependencies": [
+    "typedoc-plugin-markdown",
+    "@btravstack/typedoc",
+    "@btravstack/oxlint",
+    "@btravstack/lefthook"
+  ]
 }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,16 +1,10 @@
+# Shared hooks come from @btravstack/lefthook (format + lint + commit-msg).
+extends:
+  - node_modules/@btravstack/lefthook/lefthook.yml
+
+# Repo-specific excludes (the shared base sets none so they merge in here).
 pre-commit:
-  parallel: true
   commands:
     format:
-      glob: "**/*.{ts,tsx,js,jsx,json,yaml,yml,md}"
-      exclude: "pnpm-lock.yaml"
-      run: pnpm oxfmt {staged_files}
-      stage_fixed: true
-    lint:
-      glob: "**/*.{ts,tsx,js,jsx}"
-      run: pnpm oxlint {staged_files}
-
-commit-msg:
-  commands:
-    commitlint:
-      run: pnpm exec commitlint --edit {1}
+      exclude:
+        - "pnpm-lock.yaml"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@btravstack/commitlint": "catalog:",
+    "@btravstack/lefthook": "catalog:",
     "@btravstack/oxlint": "catalog:",
     "@changesets/cli": "catalog:",
     "@commitlint/cli": "catalog:",

--- a/packages/asyncapi/src/index.spec.ts
+++ b/packages/asyncapi/src/index.spec.ts
@@ -15,6 +15,7 @@ import { type } from "arktype";
 import * as v from "valibot";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
+
 import { AsyncAPIGenerator } from "./index.js";
 
 describe("AsyncAPIGenerator", () => {

--- a/packages/asyncapi/src/index.ts
+++ b/packages/asyncapi/src/index.ts
@@ -1,12 +1,3 @@
-import {
-  AsyncAPIObject,
-  ChannelObject,
-  ChannelsObject,
-  MessageObject,
-  MessagesObject,
-  OperationsObject,
-} from "@asyncapi/parser/esm/spec-types/v3.js";
-import { ConditionalSchemaConverter, JSONSchema } from "@orpc/openapi";
 import type {
   BindingDefinition,
   ContractDefinition,
@@ -17,6 +8,15 @@ import type {
   QueueDefinition,
 } from "@amqp-contract/contract";
 import { extractConsumer, extractQueue } from "@amqp-contract/contract";
+import {
+  type AsyncAPIObject,
+  type ChannelObject,
+  type ChannelsObject,
+  type MessageObject,
+  type MessagesObject,
+  type OperationsObject,
+} from "@asyncapi/parser/esm/spec-types/v3.js";
+import { type ConditionalSchemaConverter, type JSONSchema } from "@orpc/openapi";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 
 /**

--- a/packages/asyncapi/tsconfig.json
+++ b/packages/asyncapi/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@btravstack/tsconfig/base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["node"]
   },
   "include": ["src/**/*"]
 }

--- a/packages/client/src/__tests__/client.spec.ts
+++ b/packages/client/src/__tests__/client.spec.ts
@@ -1,5 +1,5 @@
 import {
-  ContractDefinition,
+  type ContractDefinition,
   defineContract,
   defineEventConsumer,
   defineEventPublisher,
@@ -11,7 +11,8 @@ import {
 import { it as baseIt } from "@amqp-contract/testing/extension";
 import { describe, expect } from "vitest";
 import { z } from "zod";
-import { CreateClientOptions, TypedAmqpClient } from "../client.js";
+
+import { type CreateClientOptions, TypedAmqpClient } from "../client.js";
 
 const it = baseIt.extend<{
   clientFactory: <TContract extends ContractDefinition>(

--- a/packages/client/src/client-cleanup.spec.ts
+++ b/packages/client/src/client-cleanup.spec.ts
@@ -1,6 +1,7 @@
 import type { ContractDefinition } from "@amqp-contract/contract";
 import { _internal_getConnectionCount, _internal_resetConnections } from "@amqp-contract/core";
 import { beforeEach, describe, expect, it } from "vitest";
+
 import { TypedAmqpClient } from "./client.js";
 
 describe("TypedAmqpClient.create cleanup", () => {

--- a/packages/client/src/client.test-d.ts
+++ b/packages/client/src/client.test-d.ts
@@ -16,6 +16,7 @@ import type { TechnicalError } from "@amqp-contract/core";
 import type { AsyncResult } from "unthrown";
 import { describe, expectTypeOf, test } from "vitest";
 import { z } from "zod";
+
 import type { TypedAmqpClient } from "./client.js";
 import type { MessageValidationError } from "./errors.js";
 import type { ClientInferPublisherInput } from "./types.js";

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import {
   extractQueue,
   type CompressionAlgorithm,
@@ -9,7 +11,7 @@ import {
 } from "@amqp-contract/contract";
 import {
   AmqpClient,
-  PublishOptions as AmqpClientPublishOptions,
+  type PublishOptions as AmqpClientPublishOptions,
   type Logger,
   MessagingSemanticConventions,
   RPC_ERROR_CODE_HEADER,
@@ -36,7 +38,7 @@ import {
   type AsyncResult,
   type Result,
 } from "unthrown";
-import { randomUUID } from "node:crypto";
+
 import { compressBuffer } from "./compression.js";
 import { MessageValidationError, RpcCancelledError, RpcTimeoutError } from "./errors.js";
 import { chainInterceptors } from "./interceptors.js";

--- a/packages/client/src/compression.ts
+++ b/packages/client/src/compression.ts
@@ -1,9 +1,10 @@
+import { promisify } from "node:util";
+import { deflate, gzip } from "node:zlib";
+
 import type { CompressionAlgorithm } from "@amqp-contract/contract";
 import { TechnicalError } from "@amqp-contract/core";
-import { fromPromise, type AsyncResult } from "unthrown";
-import { deflate, gzip } from "node:zlib";
-import { promisify } from "node:util";
 import { match } from "ts-pattern";
+import { fromPromise, type AsyncResult } from "unthrown";
 
 const gzipAsync = promisify(gzip);
 const deflateAsync = promisify(deflate);

--- a/packages/client/src/interceptors.spec.ts
+++ b/packages/client/src/interceptors.spec.ts
@@ -1,6 +1,7 @@
 import { TechnicalError } from "@amqp-contract/core";
 import { ErrAsync, OkAsync, type AsyncResult } from "unthrown";
 import { describe, expect, it } from "vitest";
+
 import {
   chainInterceptors,
   type PublishError,

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -1,5 +1,6 @@
 import type { MessageValidationError, RpcError, TechnicalError } from "@amqp-contract/core";
 import type { AsyncResult } from "unthrown";
+
 import type { CallOptions, PublishOptions } from "./client.js";
 import type { RpcCancelledError, RpcTimeoutError } from "./errors.js";
 

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@btravstack/tsconfig/base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["node"]
   },
   "include": ["src/**/*"]
 }

--- a/packages/contract/src/builder.spec.ts
+++ b/packages/contract/src/builder.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
+
 import {
   defineCommandConsumer,
   defineCommandPublisher,

--- a/packages/contract/src/builder.test-d.ts
+++ b/packages/contract/src/builder.test-d.ts
@@ -5,6 +5,7 @@
 
 import { describe, expectTypeOf, test } from "vitest";
 import { z } from "zod";
+
 import type { BindingPattern, MatchingRoutingKey, RoutingKey } from "./builder.js";
 import {
   defineCommandConsumer,

--- a/packages/contract/src/builder/message.ts
+++ b/packages/contract/src/builder/message.ts
@@ -1,6 +1,7 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+
 import type { MessageDefinition } from "../types.js";
 import { _internal_assertKnownKeys, _internal_assertStandardSchema } from "./validate.js";
-import type { StandardSchemaV1 } from "@standard-schema/spec";
 
 /**
  * Define a message definition with payload and optional headers/metadata.

--- a/packages/contract/src/builder/queue.ts
+++ b/packages/contract/src/builder/queue.ts
@@ -12,8 +12,8 @@ import type {
   ResolvedTtlBackoffRetryOptions,
   TtlBackoffRetryOptions,
 } from "../types.js";
-import { _internal_assertKnownKeys, _internal_assertNonEmptyName } from "./validate.js";
 import { wrapWithTtlBackoffInfrastructure } from "./ttl-backoff.js";
+import { _internal_assertKnownKeys, _internal_assertNonEmptyName } from "./validate.js";
 
 /**
  * Resolve immediate-requeue retry options with defaults.

--- a/packages/contract/src/builder/rpc.spec.ts
+++ b/packages/contract/src/builder/rpc.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
+
 import { defineContract } from "./contract.js";
 import { defineMessage } from "./message.js";
 import { defineQueue } from "./queue.js";

--- a/packages/contract/src/builder/validate.spec.ts
+++ b/packages/contract/src/builder/validate.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
+
 import { defineExchange } from "./exchange.js";
 import { defineMessage } from "./message.js";
 import { defineQueue } from "./queue.js";

--- a/packages/contract/src/issues.spec.ts
+++ b/packages/contract/src/issues.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { formatIssue, summarizeIssues } from "./issues.js";
 
 describe("formatIssue", () => {

--- a/packages/contract/tsconfig.json
+++ b/packages/contract/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@btravstack/tsconfig/base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["node"]
   },
   "include": ["src/**/*"]
 }

--- a/packages/core/src/__tests__/amqp-client.spec.ts
+++ b/packages/core/src/__tests__/amqp-client.spec.ts
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect } from "vitest";
 import type { ContractDefinition } from "@amqp-contract/contract";
 import {
   defineContract,
@@ -10,9 +9,11 @@ import {
   defineQueue,
   defineQueueBinding,
 } from "@amqp-contract/contract";
-import { z } from "zod";
-import { AmqpClient } from "../amqp-client.js";
 import { it } from "@amqp-contract/testing/extension";
+import { beforeEach, describe, expect } from "vitest";
+import { z } from "zod";
+
+import { AmqpClient } from "../amqp-client.js";
 
 describe("AmqpClient Integration", () => {
   beforeEach(async () => {

--- a/packages/core/src/__tests__/channel-config.spec.ts
+++ b/packages/core/src/__tests__/channel-config.spec.ts
@@ -1,9 +1,10 @@
-import { beforeEach, describe, expect, vi } from "vitest";
 import type { ContractDefinition } from "@amqp-contract/contract";
 import { defineExchange } from "@amqp-contract/contract";
-import { AmqpClient } from "../amqp-client.js";
-import type { Channel } from "amqplib";
 import { it } from "@amqp-contract/testing/extension";
+import type { Channel } from "amqplib";
+import { beforeEach, describe, expect, vi } from "vitest";
+
+import { AmqpClient } from "../amqp-client.js";
 
 describe("AmqpClient Channel Configuration", () => {
   beforeEach(async () => {

--- a/packages/core/src/__tests__/connection-sharing.spec.ts
+++ b/packages/core/src/__tests__/connection-sharing.spec.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, expect } from "vitest";
 import type { ContractDefinition } from "@amqp-contract/contract";
 import { defineExchange } from "@amqp-contract/contract";
-import { AmqpClient } from "../amqp-client.js";
 import { it } from "@amqp-contract/testing/extension";
+import { beforeEach, describe, expect } from "vitest";
+
+import { AmqpClient } from "../amqp-client.js";
 
 describe("AmqpClient Connection Sharing Integration", () => {
   beforeEach(async () => {

--- a/packages/core/src/__tests__/dead-letter.spec.ts
+++ b/packages/core/src/__tests__/dead-letter.spec.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, expect } from "vitest";
 import type { ContractDefinition } from "@amqp-contract/contract";
 import { defineExchange, defineQueue } from "@amqp-contract/contract";
-import { AmqpClient } from "../amqp-client.js";
 import { it } from "@amqp-contract/testing/extension";
+import { beforeEach, describe, expect } from "vitest";
+
+import { AmqpClient } from "../amqp-client.js";
 
 describe("Dead Letter Exchange Support", () => {
   beforeEach(async () => {

--- a/packages/core/src/__tests__/prefetch.spec.ts
+++ b/packages/core/src/__tests__/prefetch.spec.ts
@@ -2,6 +2,7 @@ import { defineExchange, defineQueue, defineQueueBinding } from "@amqp-contract/
 import type { ContractDefinition } from "@amqp-contract/contract";
 import { it } from "@amqp-contract/testing/extension";
 import { beforeEach, describe, expect, vi } from "vitest";
+
 import { AmqpClient } from "../amqp-client.js";
 
 /**

--- a/packages/core/src/__tests__/priority-queue.spec.ts
+++ b/packages/core/src/__tests__/priority-queue.spec.ts
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect } from "vitest";
 import type { ContractDefinition } from "@amqp-contract/contract";
 import {
   defineConsumer,
@@ -9,10 +8,12 @@ import {
   defineQueueBinding,
   extractQueue,
 } from "@amqp-contract/contract";
-import { AmqpClient } from "../amqp-client.js";
-import type { ConsumeMessage } from "amqplib";
 import { it } from "@amqp-contract/testing/extension";
+import type { ConsumeMessage } from "amqplib";
+import { beforeEach, describe, expect } from "vitest";
 import { z } from "zod";
+
+import { AmqpClient } from "../amqp-client.js";
 
 describe("Priority Queue", () => {
   beforeEach(async () => {

--- a/packages/core/src/amqp-client.ts
+++ b/packages/core/src/amqp-client.ts
@@ -16,6 +16,7 @@ import {
   type AsyncResult,
   type Result,
 } from "unthrown";
+
 import { ConnectionManagerSingleton } from "./connection-manager.js";
 import { TechnicalError } from "./errors.js";
 import { setupAmqpTopology } from "./setup.js";

--- a/packages/core/src/connection-manager.ts
+++ b/packages/core/src/connection-manager.ts
@@ -1,7 +1,7 @@
 import amqp, {
-  AmqpConnectionManager,
-  AmqpConnectionManagerOptions,
-  ConnectionUrl,
+  type AmqpConnectionManager,
+  type AmqpConnectionManagerOptions,
+  type ConnectionUrl,
 } from "amqp-connection-manager";
 
 /**

--- a/packages/core/src/parsing.spec.ts
+++ b/packages/core/src/parsing.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { TechnicalError } from "./errors.js";
 import { safeJsonParse } from "./parsing.js";
 

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -1,6 +1,7 @@
 import type { ContractDefinition } from "@amqp-contract/contract";
 import { extractQueue } from "@amqp-contract/contract";
 import type { Channel } from "amqplib";
+
 import { TechnicalError } from "./errors.js";
 
 /**

--- a/packages/core/src/telemetry.spec.ts
+++ b/packages/core/src/telemetry.spec.ts
@@ -1,3 +1,5 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
 import {
   type TelemetryProvider,
   _internal_resetTelemetryCache,
@@ -9,7 +11,6 @@ import {
   startConsumeSpan,
   startPublishSpan,
 } from "./telemetry.js";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /** Provider where all instruments are unavailable */
 const noopProvider: TelemetryProvider = {

--- a/packages/core/src/telemetry.ts
+++ b/packages/core/src/telemetry.ts
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+
 import {
   type Attributes,
   type Counter,

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@btravstack/tsconfig/base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["node"]
   },
   "include": ["src/**/*"]
 }

--- a/packages/testing/src/extension.ts
+++ b/packages/testing/src/extension.ts
@@ -9,8 +9,9 @@
  * @packageDocumentation
  */
 
-import amqpLib, { Options, type Channel, type ChannelModel } from "amqplib";
 import { randomUUID } from "node:crypto";
+
+import amqpLib, { type Options, type Channel, type ChannelModel } from "amqplib";
 import { inject, vi, it as vitestIt } from "vitest";
 
 export const it = vitestIt.extend<{

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@btravstack/tsconfig/base.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "types": ["node"]
   },
   "include": ["src/**/*"]
 }

--- a/packages/worker/src/__tests__/fixture.ts
+++ b/packages/worker/src/__tests__/fixture.ts
@@ -1,7 +1,8 @@
 import type { ContractDefinition } from "@amqp-contract/contract";
-import { TypedAmqpWorker } from "../worker.js";
-import type { WorkerInferHandlers } from "../types.js";
 import { it as baseIt } from "@amqp-contract/testing/extension";
+
+import type { WorkerInferHandlers } from "../types.js";
+import { TypedAmqpWorker } from "../worker.js";
 
 export const it = baseIt.extend<{
   workerFactory: <TContract extends ContractDefinition>(

--- a/packages/worker/src/__tests__/worker-double-ack.spec.ts
+++ b/packages/worker/src/__tests__/worker-double-ack.spec.ts
@@ -10,6 +10,7 @@ import type { TelemetryProvider } from "@amqp-contract/core";
 import { OkAsync } from "unthrown";
 import { describe, expect, vi } from "vitest";
 import { z } from "zod";
+
 import { TypedAmqpWorker } from "../worker.js";
 import { it } from "./fixture.js";
 

--- a/packages/worker/src/__tests__/worker-retry.spec.ts
+++ b/packages/worker/src/__tests__/worker-retry.spec.ts
@@ -9,6 +9,7 @@ import {
 import { ErrAsync, OkAsync } from "unthrown";
 import { describe, expect, vi } from "vitest";
 import { z } from "zod";
+
 import { RetryableError } from "../errors.js";
 import { it } from "./fixture.js";
 

--- a/packages/worker/src/__tests__/worker.spec.ts
+++ b/packages/worker/src/__tests__/worker.spec.ts
@@ -10,6 +10,7 @@ import {
 import { ErrAsync, OkAsync } from "unthrown";
 import { describe, expect, vi } from "vitest";
 import { z } from "zod";
+
 import { RetryableError } from "../errors.js";
 import { defineHandler, defineHandlers } from "../handlers.js";
 import { TypedAmqpWorker } from "../worker.js";

--- a/packages/worker/src/decompression.spec.ts
+++ b/packages/worker/src/decompression.spec.ts
@@ -1,7 +1,9 @@
-import { deflate, gzip } from "node:zlib";
-import { describe, expect, it } from "vitest";
-import { decompressBuffer } from "./decompression.js";
 import { promisify } from "node:util";
+import { deflate, gzip } from "node:zlib";
+
+import { describe, expect, it } from "vitest";
+
+import { decompressBuffer } from "./decompression.js";
 
 const gzipAsync = promisify(gzip);
 const deflateAsync = promisify(deflate);

--- a/packages/worker/src/decompression.ts
+++ b/packages/worker/src/decompression.ts
@@ -1,7 +1,8 @@
+import { promisify } from "node:util";
+import { gunzip, inflate } from "node:zlib";
+
 import { TechnicalError } from "@amqp-contract/core";
 import { ErrAsync, fromPromise, OkAsync, type AsyncResult } from "unthrown";
-import { gunzip, inflate } from "node:zlib";
-import { promisify } from "node:util";
 
 const gunzipAsync = promisify(gunzip);
 const inflateAsync = promisify(inflate);

--- a/packages/worker/src/errors.spec.ts
+++ b/packages/worker/src/errors.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "vitest";
+
 import {
   NonRetryableError,
   RetryableError,
@@ -10,7 +12,6 @@ import {
   retryable,
 } from "./errors.js";
 import type { HandlerError } from "./errors.js";
-import { describe, expect, it } from "vitest";
 
 describe("Type Guards", () => {
   describe("isRetryableError", () => {

--- a/packages/worker/src/handlers.spec.ts
+++ b/packages/worker/src/handlers.spec.ts
@@ -1,5 +1,3 @@
-import { ErrAsync, OkAsync } from "unthrown";
-import { NonRetryableError, RetryableError } from "./errors.js";
 import {
   defineConsumer,
   defineContract,
@@ -7,10 +5,13 @@ import {
   defineQueue,
   defineRpc,
 } from "@amqp-contract/contract";
-import { defineHandler, defineHandlers } from "./handlers.js";
-import { describe, expect, it } from "vitest";
 import type { ConsumeMessage } from "amqplib";
+import { ErrAsync, OkAsync } from "unthrown";
+import { describe, expect, it } from "vitest";
 import { z } from "zod";
+
+import { NonRetryableError, RetryableError } from "./errors.js";
+import { defineHandler, defineHandlers } from "./handlers.js";
 
 /**
  * Creates a mock ConsumeMessage for testing purposes.

--- a/packages/worker/src/handlers.test-d.ts
+++ b/packages/worker/src/handlers.test-d.ts
@@ -15,6 +15,7 @@ import {
 import { OkAsync } from "unthrown";
 import { describe, expectTypeOf, test } from "vitest";
 import { z } from "zod";
+
 import { defineHandlers } from "./handlers.js";
 import type { WorkerInferConsumedMessage } from "./types.js";
 

--- a/packages/worker/src/handlers.ts
+++ b/packages/worker/src/handlers.ts
@@ -3,6 +3,7 @@ import type {
   InferConsumerNames,
   InferRpcNames,
 } from "@amqp-contract/contract";
+
 import type { EmptyContext } from "./middleware.js";
 import type {
   WorkerInferConsumerHandler,
@@ -11,7 +12,7 @@ import type {
   WorkerInferRpcHandler,
   WorkerInferRpcHandlerEntry,
 } from "./types.js";
-import { ConsumerOptions } from "./worker.js";
+import { type ConsumerOptions } from "./worker.js";
 
 // =============================================================================
 // Helper Functions

--- a/packages/worker/src/invariants.spec.ts
+++ b/packages/worker/src/invariants.spec.ts
@@ -11,6 +11,7 @@ import type { ConsumeMessage } from "amqplib";
 import { OkAsync } from "unthrown";
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
+
 import { NonRetryableError, RetryableError } from "./errors.js";
 import { handleError } from "./retry.js";
 

--- a/packages/worker/src/middleware.spec.ts
+++ b/packages/worker/src/middleware.spec.ts
@@ -1,6 +1,7 @@
 import type { ConsumeMessage } from "amqplib";
 import { ErrAsync, OkAsync } from "unthrown";
 import { describe, expect, it } from "vitest";
+
 import { nonRetryable } from "./errors.js";
 import { composeMiddleware, defineMiddleware, type WorkerMiddlewareArgs } from "./middleware.js";
 

--- a/packages/worker/src/middleware.ts
+++ b/packages/worker/src/middleware.ts
@@ -1,6 +1,7 @@
 import type { RpcError } from "@amqp-contract/core";
 import type { ConsumeMessage } from "amqplib";
 import type { AsyncResult } from "unthrown";
+
 import type { HandlerError } from "./errors.js";
 
 /**

--- a/packages/worker/src/retry.spec.ts
+++ b/packages/worker/src/retry.spec.ts
@@ -3,6 +3,7 @@ import type { AmqpClient } from "@amqp-contract/core";
 import type { ConsumeMessage } from "amqplib";
 import { ErrAsync, OkAsync } from "unthrown";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { _internalForTesting } from "./retry.js";
 
 const { calculateRetryDelay, publishForRetry } = _internalForTesting;

--- a/packages/worker/src/retry.ts
+++ b/packages/worker/src/retry.ts
@@ -8,6 +8,7 @@ import {
 import { type AmqpClient, type Logger, TechnicalError } from "@amqp-contract/core";
 import type { ConsumeMessage } from "amqplib";
 import { Err, ErrAsync, Ok, OkAsync, type AsyncResult } from "unthrown";
+
 import { NonRetryableError } from "./errors.js";
 
 type RetryContext = {

--- a/packages/worker/src/types.ts
+++ b/packages/worker/src/types.ts
@@ -13,9 +13,10 @@ import type { RpcError } from "@amqp-contract/core";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import type { ConsumeMessage } from "amqplib";
 import type { AsyncResult } from "unthrown";
+
 import type { HandlerError } from "./errors.js";
 import type { EmptyContext } from "./middleware.js";
-import { ConsumerOptions } from "./worker.js";
+import { type ConsumerOptions } from "./worker.js";
 
 /**
  * Infer the output type from a schema (used by consumers after validation)

--- a/packages/worker/src/worker-cleanup.spec.ts
+++ b/packages/worker/src/worker-cleanup.spec.ts
@@ -8,6 +8,7 @@ import {
 import { _internal_getConnectionCount, _internal_resetConnections } from "@amqp-contract/core";
 import { beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
+
 import { TypedAmqpWorker } from "./worker.js";
 
 describe("TypedAmqpWorker.create cleanup", () => {

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -9,7 +9,7 @@ import {
 } from "@amqp-contract/contract";
 import {
   AmqpClient,
-  ConsumerOptions as AmqpClientConsumerOptions,
+  type ConsumerOptions as AmqpClientConsumerOptions,
   type Logger,
   RPC_ERROR_CODE_HEADER,
   RpcError,
@@ -37,6 +37,7 @@ import {
   type AsyncResult,
   type Result,
 } from "unthrown";
+
 import { decompressBuffer } from "./decompression.js";
 import type { HandlerError } from "./errors.js";
 import { MessageValidationError, NonRetryableError } from "./errors.js";

--- a/packages/worker/tsconfig.json
+++ b/packages/worker/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@btravstack/tsconfig/base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["node"]
   },
   "include": ["src/**/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,15 +15,18 @@ catalogs:
     '@btravstack/commitlint':
       specifier: 0.1.0
       version: 0.1.0
+    '@btravstack/lefthook':
+      specifier: 0.1.1
+      version: 0.1.1
     '@btravstack/oxlint':
-      specifier: 0.1.0
-      version: 0.1.0
+      specifier: 0.2.1
+      version: 0.2.1
     '@btravstack/theme':
       specifier: 1.7.0
       version: 1.7.0
     '@btravstack/tsconfig':
-      specifier: 0.1.0
-      version: 0.1.0
+      specifier: 0.2.0
+      version: 0.2.0
     '@btravstack/typedoc':
       specifier: 0.1.0
       version: 0.1.0
@@ -155,9 +158,12 @@ importers:
       '@btravstack/commitlint':
         specifier: 'catalog:'
         version: 0.1.0(@commitlint/cli@21.2.1(@types/node@26.1.1)(conventional-commits-parser@7.0.1)(typescript@6.0.3))
+      '@btravstack/lefthook':
+        specifier: 'catalog:'
+        version: 0.1.1(lefthook@2.1.10)
       '@btravstack/oxlint':
         specifier: 'catalog:'
-        version: 0.1.0(oxlint@1.73.0)
+        version: 0.2.1(oxlint@1.73.0)
       '@changesets/cli':
         specifier: 'catalog:'
         version: 2.31.0(@types/node@26.1.1)
@@ -243,7 +249,7 @@ importers:
         version: link:../../packages/testing
       '@btravstack/tsconfig':
         specifier: 'catalog:'
-        version: 0.1.0
+        version: 0.2.0
       '@types/node':
         specifier: 26.1.1
         version: 26.1.1
@@ -277,7 +283,7 @@ importers:
         version: link:../../packages/asyncapi
       '@btravstack/tsconfig':
         specifier: 'catalog:'
-        version: 0.1.0
+        version: 0.2.0
       '@orpc/zod':
         specifier: 'catalog:'
         version: 1.14.8(@opentelemetry/api@1.9.1)(@orpc/contract@1.14.8(@opentelemetry/api@1.9.1))(@orpc/server@1.14.8(@opentelemetry/api@1.9.1))(zod@4.4.3)
@@ -323,7 +329,7 @@ importers:
         version: link:../../packages/testing
       '@btravstack/tsconfig':
         specifier: 'catalog:'
-        version: 0.1.0
+        version: 0.2.0
       '@types/node':
         specifier: 26.1.1
         version: 26.1.1
@@ -360,7 +366,7 @@ importers:
         version: 3.6.0
       '@btravstack/tsconfig':
         specifier: 'catalog:'
-        version: 0.1.0
+        version: 0.2.0
       '@btravstack/typedoc':
         specifier: 'catalog:'
         version: 0.1.0(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))(typedoc@0.28.20(typescript@6.0.3))
@@ -430,7 +436,7 @@ importers:
         version: 0.18.5
       '@btravstack/tsconfig':
         specifier: 'catalog:'
-        version: 0.1.0
+        version: 0.2.0
       '@btravstack/typedoc':
         specifier: 'catalog:'
         version: 0.1.0(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))(typedoc@0.28.20(typescript@6.0.3))
@@ -485,7 +491,7 @@ importers:
         version: 0.18.5
       '@btravstack/tsconfig':
         specifier: 'catalog:'
-        version: 0.1.0
+        version: 0.2.0
       '@btravstack/typedoc':
         specifier: 'catalog:'
         version: 0.1.0(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))(typedoc@0.28.20(typescript@6.0.3))
@@ -537,7 +543,7 @@ importers:
         version: 0.18.5
       '@btravstack/tsconfig':
         specifier: 'catalog:'
-        version: 0.1.0
+        version: 0.2.0
       '@btravstack/typedoc':
         specifier: 'catalog:'
         version: 0.1.0(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))(typedoc@0.28.20(typescript@6.0.3))
@@ -589,7 +595,7 @@ importers:
         version: 0.18.5
       '@btravstack/tsconfig':
         specifier: 'catalog:'
-        version: 0.1.0
+        version: 0.2.0
       '@btravstack/typedoc':
         specifier: 'catalog:'
         version: 0.1.0(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))(typedoc@0.28.20(typescript@6.0.3))
@@ -635,7 +641,7 @@ importers:
         version: 0.18.5
       '@btravstack/tsconfig':
         specifier: 'catalog:'
-        version: 0.1.0
+        version: 0.2.0
       '@btravstack/typedoc':
         specifier: 'catalog:'
         version: 0.1.0(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))(typedoc@0.28.20(typescript@6.0.3))
@@ -702,7 +708,7 @@ importers:
     devDependencies:
       '@btravstack/tsconfig':
         specifier: 'catalog:'
-        version: 0.1.0
+        version: 0.2.0
       '@types/node':
         specifier: 26.1.1
         version: 26.1.1
@@ -871,8 +877,14 @@ packages:
     peerDependencies:
       '@commitlint/cli': '>=21'
 
-  '@btravstack/oxlint@0.1.0':
-    resolution: {integrity: sha512-/UIfVydE3nEExRqE03vUoAAQSdPqVNOzZl0QSa9ikXftezoLQfNgJcFCKW6+D2cJnM180JR0o0W7dmkQHhLogQ==}
+  '@btravstack/lefthook@0.1.1':
+    resolution: {integrity: sha512-5KFOHHrJzHm5xqtxVtsVWfm862h7ivAlRGWngtSteEZxn3aNdEwIxchts0NBX1ICg+TNL5XcIRmiPIRCyOOOvQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      lefthook: '>=2'
+
+  '@btravstack/oxlint@0.2.1':
+    resolution: {integrity: sha512-BflvYgQL67f0SVlgorKCC9tAZMor0vBpN0wkuO/SSsNsiOYMXlFEVJuUaL/ULwZYsDbeoSrzBblg1LLaIAMnHA==}
     engines: {node: '>=20'}
     peerDependencies:
       oxlint: '>=1'
@@ -886,8 +898,8 @@ packages:
       vue:
         optional: true
 
-  '@btravstack/tsconfig@0.1.0':
-    resolution: {integrity: sha512-xRkISG6jY5vLpaDJCptyOjvmUeyH6M/i6shhoE6WFGBc+JToc/dyO/511Zi6NPYVTHamNbxOG/e6dpclBWIz2A==}
+  '@btravstack/tsconfig@0.2.0':
+    resolution: {integrity: sha512-0VZt4DNJlY+XgAeCS4HybgsG0kdWDGjRwBiDdQZ6pYPUo1ayjM4AIH1oPatL5+YQvICTqrSaXTHSa8DnP+GXbg==}
     engines: {node: '>=20'}
 
   '@btravstack/typedoc@0.1.0':
@@ -5737,7 +5749,11 @@ snapshots:
       '@commitlint/cli': 21.2.1(@types/node@26.1.1)(conventional-commits-parser@7.0.1)(typescript@6.0.3)
       '@commitlint/config-conventional': 21.2.0
 
-  '@btravstack/oxlint@0.1.0(oxlint@1.73.0)':
+  '@btravstack/lefthook@0.1.1(lefthook@2.1.10)':
+    dependencies:
+      lefthook: 2.1.10
+
+  '@btravstack/oxlint@0.2.1(oxlint@1.73.0)':
     dependencies:
       oxlint: 1.73.0
 
@@ -5747,7 +5763,7 @@ snapshots:
     optionalDependencies:
       vue: 3.5.35(typescript@6.0.3)
 
-  '@btravstack/tsconfig@0.1.0': {}
+  '@btravstack/tsconfig@0.2.0': {}
 
   '@btravstack/typedoc@0.1.0(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))(typedoc@0.28.20(typescript@6.0.3))':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,9 +14,10 @@ catalog:
   "@arethetypeswrong/cli": 0.18.5
   "@asyncapi/parser": 3.6.0
   "@btravstack/commitlint": 0.1.0
-  "@btravstack/oxlint": 0.1.0
+  "@btravstack/lefthook": 0.1.1
+  "@btravstack/oxlint": 0.2.1
   "@btravstack/theme": 1.7.0
-  "@btravstack/tsconfig": 0.1.0
+  "@btravstack/tsconfig": 0.2.0
   "@btravstack/typedoc": 0.1.0
   "@changesets/cli": 2.31.0
   "@commitlint/cli": 21.2.1
@@ -114,6 +115,7 @@ minimumReleaseAgeStrict: true
 # published versions can be adopted immediately.
 minimumReleaseAgeExclude:
   - "@btravstack/commitlint"
+  - "@btravstack/lefthook"
   - "@btravstack/oxlint"
   - "@btravstack/theme"
   - "@btravstack/tsconfig"

--- a/tests/src/client-worker.spec.ts
+++ b/tests/src/client-worker.spec.ts
@@ -1,6 +1,6 @@
 import { TypedAmqpClient } from "@amqp-contract/client";
 import {
-  ContractDefinition,
+  type ContractDefinition,
   defineContract,
   defineEventConsumer,
   defineEventPublisher,

--- a/tests/src/middleware.spec.ts
+++ b/tests/src/middleware.spec.ts
@@ -1,6 +1,6 @@
 import { isRpcError, TypedAmqpClient, type PublishInterceptor } from "@amqp-contract/client";
 import {
-  ContractDefinition,
+  type ContractDefinition,
   defineCommandConsumer,
   defineCommandPublisher,
   defineContract,

--- a/tests/src/rpc.spec.ts
+++ b/tests/src/rpc.spec.ts
@@ -2,12 +2,12 @@ import {
   isRpcError,
   MessageValidationError,
   RpcCancelledError,
-  RpcError,
+  type RpcError,
   RpcTimeoutError,
   TypedAmqpClient,
 } from "@amqp-contract/client";
 import {
-  ContractDefinition,
+  type ContractDefinition,
   defineContract,
   defineMessage,
   defineQueue,

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@btravstack/tsconfig/base.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## What changed

Adopts the latest `@btravstack` shared config across the monorepo.

### Config bumps (`pnpm-workspace.yaml` catalog + root `package.json`)
- `@btravstack/tsconfig` `0.1.0` → `0.2.0` (adds `verbatimModuleSyntax`, `moduleDetection: "force"`; **drops** the base `types: ["node"]`)
- `@btravstack/oxlint` `0.1.0` → `0.2.1` (adds `consistent-type-imports`)
- **new** `@btravstack/lefthook` `0.1.1` (shared pre-commit/commit-msg hooks) — added to the catalog, root devDependencies, `minimumReleaseAgeExclude`, and knip `ignoreDependencies`

### `lefthook.yml`
Replaced with an `extends` of `node_modules/@btravstack/lefthook/lefthook.yml`, preserving the one repo-specific `format.exclude` (`pnpm-lock.yaml`). The old file had no `lint.exclude`, so no lint override was added.

### `.oxfmtrc.json`
Replaced the `organizeImports` block with `sortImports: true` (oxfmt drift fix). Triggered a large one-time import reorder across source files (expected).

### Type-only import fixes (`oxlint . --fix`)
`consistent-type-imports` + `verbatimModuleSyntax` require `import type` for type-only imports. `oxlint --fix` added the `type` modifiers across ~13 source files.

### `types: ["node"]` per-package tsconfig (required by the bump)
`@btravstack/tsconfig@0.2.0` intentionally removed `types: ["node"]` from the base. Combined with `moduleDetection: "force"` and `@types/node@26`, Node globals (`Buffer`, `setTimeout`, `console`, `node:*` builtins) no longer resolve via auto-`@types` scan, so **every** workspace failed `tsc` with `Cannot find name 'Buffer'`/`setTimeout`. Restored resolution by adding `"types": ["node"]` to each consuming tsconfig (6 packages, 3 examples, `tests`) — the fix TS's own error hint recommends. `@types/node` was already a direct devDependency in each.

## Gate results (all green)
| Check | Result |
| --- | --- |
| `pnpm build` | ✅ 14/14 tasks |
| `pnpm typecheck` | ✅ 16/16, 0 errors |
| `pnpm lint` | ✅ |
| `pnpm format --check` | ✅ |
| `pnpm knip` | ✅ |
| `pnpm audit --audit-level=high` | ✅ (1 low, below threshold) |
| `pnpm test` | ✅ 12/12 (unit; no docker) |
| `changeset status --since=origin/main` | ✅ exit 0 |

## Changeset
`.changeset/adopt-btravstack-0.2.md` — `@amqp-contract/core: patch`; the `fixed` group bumps all six published packages (asyncapi, client, contract, core, testing, worker) together. All changed private packages were already in the changeset `ignore` list.