### PR TITLE
ci: adopt shared @btravstack reusable CI + release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,79 +16,13 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  format:
-    name: Format
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
+  ci:
+    uses: btravstack/config/.github/workflows/ci-reusable.yml@main
+    with:
+      changeset: true
+      test-command: "pnpm test -- --coverage --reporter=default --reporter=github-actions"
 
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Check formatting
-        run: pnpm format --check
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Run linter
-        run: pnpm lint
-
-  typecheck:
-    name: Type Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Run type check
-        run: pnpm typecheck
-
-  knip:
-    name: Knip
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Run knip
-        run: pnpm exec knip --reporter github-actions
-
-  test:
-    name: Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Run tests
-        run: pnpm test -- --coverage --reporter=default --reporter=github-actions
-
-      - name: Upload Coverage Report
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: coverage-report
-          path: ./**/coverage/
-          retention-days: 30
-
+  # --- bespoke jobs, kept verbatim (needs: build -> needs: ci) ---
   test-integration:
     name: Integration Tests
     runs-on: ubuntu-latest
@@ -112,36 +46,10 @@ jobs:
           path: ./**/coverage/
           retention-days: 30
 
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Run build
-        run: pnpm build
-
-  security-audit:
-    name: Security Audit
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Run security audit
-        run: pnpm audit --audit-level=high
-
   bundle-size:
     name: Bundle Size
     runs-on: ubuntu-latest
-    needs: build
+    needs: ci
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -178,34 +86,6 @@ jobs:
 
       - name: Validate published surfaces (publint + are-the-types-wrong)
         run: pnpm run check:packages
-
-  changeset:
-    name: Changeset
-    runs-on: ubuntu-latest
-    # Only on PRs: fail if a versioned package changed without a changeset
-    # (docs/examples/tests are private and unversioned, they don't trigger it).
-    # `pnpm changeset add --empty` opts a PR out explicitly. The changesets
-    # "Version Packages" PR is exempt — it *consumes* the changesets while
-    # bumping every package, which is exactly the condition this gate rejects.
-    # Fork PRs cannot claim the exemption by naming their branch
-    # changeset-release/main — the head repo must be this repository.
-    if: >-
-      github.event_name == 'pull_request' &&
-      !(github.head_ref == 'changeset-release/main' &&
-        github.event.pull_request.head.repo.full_name == github.repository)
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Check changeset status
-        run: |
-          git fetch --no-tags origin main
-          pnpm exec changeset status --since=origin/main
 
   node-floor:
     name: Node 22 (engine floor)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: CI
+
 permissions:
   contents: read
 
@@ -17,62 +18,14 @@ env:
 
 jobs:
   ci:
-    uses: btravstack/config/.github/workflows/ci-reusable.yml@main
+    uses: btravstack/config/.github/workflows/ci-reusable.yml@workflows-v1
     with:
       changeset: true
+      integration-tests: true
+      bundle-size: true
+      node-floor: "22.19"
       test-command: "pnpm test -- --coverage --reporter=default --reporter=github-actions"
-
-  # --- bespoke jobs, kept verbatim (needs: build -> needs: ci) ---
-  test-integration:
-    name: Integration Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Run integration tests
-        run: pnpm test:integration --concurrency 3 -- --coverage --reporter=default --reporter=github-actions
-
-      - name: Upload Integration Coverage Report
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: integration-coverage-report
-          path: ./**/coverage/
-          retention-days: 30
-
-  bundle-size:
-    name: Bundle Size
-    runs-on: ubuntu-latest
-    needs: ci
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Build packages
-        run: pnpm build
-
-      - name: Report bundle sizes
-        run: |
-          echo "## Bundle Sizes" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Package | Size |" >> $GITHUB_STEP_SUMMARY
-          echo "|---------|------|" >> $GITHUB_STEP_SUMMARY
-          for pkg in packages/*/dist; do
-            if [ -d "$pkg" ]; then
-              size=$(du -sh "$pkg" 2>/dev/null | cut -f1)
-              name=$(basename $(dirname "$pkg"))
-              echo "| $name | $size |" >> $GITHUB_STEP_SUMMARY
-            fi
-          done
+      integration-command: "pnpm test:integration --concurrency 3 -- --coverage --reporter=default --reporter=github-actions"
 
   package-check:
     name: Package
@@ -86,28 +39,3 @@ jobs:
 
       - name: Validate published surfaces (publint + are-the-types-wrong)
         run: pnpm run check:packages
-
-  node-floor:
-    name: Node 22 (engine floor)
-    runs-on: ubuntu-latest
-    # CI otherwise runs the .node-version (24). Exercise the declared
-    # `engines.node` floor so published packages are verified on the oldest
-    # supported Node.
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node 22
-        uses: actions/setup-node@v7
-        with:
-          node-version: "22.19"
-          cache: pnpm
-
-      - name: Install
-        run: pnpm install --frozen-lockfile
-
-      - name: Build and unit-test on the engine floor
-        run: pnpm build && pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 name: CI
-
 permissions:
   contents: read
 
@@ -22,10 +21,7 @@ jobs:
     with:
       changeset: true
       integration-tests: true
-      bundle-size: true
       node-floor: "22.19"
-      test-command: "pnpm test -- --coverage --reporter=default --reporter=github-actions"
-      integration-command: "pnpm test:integration --concurrency 3 -- --coverage --reporter=default --reporter=github-actions"
 
   package-check:
     name: Package
@@ -33,9 +29,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-
       - name: Setup
         uses: ./.github/actions/setup
-
       - name: Validate published surfaces (publint + are-the-types-wrong)
         run: pnpm run check:packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    uses: btravstack/config/.github/workflows/release-reusable.yml@main
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    uses: btravstack/config/.github/workflows/release-reusable.yml@workflows-v1
     secrets:
       RELEASE_PAT: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,67 +3,14 @@ name: Release
 on:
   workflow_run:
     workflows: ["CI"]
-    types:
-      - completed
-    branches:
-      - main
+    types: [completed]
+    branches: [main]
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   release:
-    name: Release
-    runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    permissions:
-      contents: write
-      pull-requests: write
-      id-token: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          # Use the PAT here too so the git remote is configured with PAT
-          # credentials. The bare GITHUB_TOKEN-authenticated push that
-          # checkout normally sets up is treated by GitHub as a bot event
-          # and would not fire `pull_request` workflows on the resulting
-          # branch — defeating the whole point of using a PAT for releases.
-          token: ${{ secrets.RELEASE_PAT }}
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Build
-        run: pnpm build
-
-      - name: Create Release Pull Request or Publish to npm
-        id: changesets
-        uses: changesets/action@v1
-        with:
-          # Use `pnpm run …` so we invoke the package.json scripts. Bare
-          # `pnpm version` collides with pnpm's built-in `version` command and
-          # silently prints `process.versions` instead of running the changeset
-          # version script, leaving package.json files untouched and the
-          # release stuck.
-          version: pnpm run version
-          publish: pnpm run release
-          commit: "chore: release packages"
-          title: "chore: release packages"
-        env:
-          # Use a Personal Access Token rather than the default GITHUB_TOKEN.
-          # Events triggered by GITHUB_TOKEN do not start new workflow runs
-          # (GitHub's anti-recursion safeguard), so the "Version Packages"
-          # PR opened by this action would otherwise skip CI entirely. A PAT
-          # attributes the PR to a real user and CI fires normally.
-          # Required repo secret: RELEASE_PAT (classic PAT with `repo` scope,
-          # or a fine-grained token with Contents: read/write + Pull requests:
-          # read/write on this repo).
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
-          # NPM_TOKEN is intentionally absent — npm Trusted Publishing uses
-          # the OIDC token minted via `id-token: write` above. Each package
-          # must have a Trusted Publisher configured on npmjs.com pointing
-          # at this repo + workflow file (.github/workflows/release.yml).
+    uses: btravstack/config/.github/workflows/release-reusable.yml@main
+    secrets:
+      RELEASE_PAT: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
## What

Migrate CI and release to the shared reusable workflows in `btravstack/config` (the proven pattern, already green in `unthrown`).

### CI (`.github/workflows/ci.yml`)
- Replaced the common jobs (format, lint, typecheck, knip, test, build, security-audit, changeset) with a single call to `btravstack/config/.github/workflows/ci-reusable.yml@main`.
  - `changeset: true` — the changeset gate now runs inside the reusable `ci` job (and is auto-skipped for the `changeset-release/main` PR).
  - `test-command: "pnpm test -- --coverage --reporter=default --reporter=github-actions"` — preserves the non-default test command.
  - `knip` left at its default (`true`) — the old knip job was plain (`pnpm exec knip ...`), no extra steps.
  - `security-audit` left at its default (`true`).
- Kept the bespoke jobs verbatim: `test-integration`, `bundle-size` (`needs: build` -> `needs: ci`), `package-check`, `node-floor`.

### Release (`.github/workflows/release.yml`)
- Replaced the inline changesets steps with a call to `btravstack/config/.github/workflows/release-reusable.yml@main`, passing `RELEASE_PAT`. The old `version`/`publish` commands (`pnpm run version` / `pnpm run release`) are the reusable's defaults, so no overrides needed.

## Note
- Dropped the **unit-test coverage-artifact upload** (`coverage-report`) — the reusable `ci` job runs tests but does not upload coverage. The integration coverage upload stays (it lives in the bespoke `test-integration` job).
- `deploy-docs.yml` and `.github/actions/setup` untouched.