### PR TITLE
ci: node-floor -> node-versions matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     with:
       changeset: true
       integration-tests: true
-      node-floor: "22.19"
+      node-versions: '["", "22.19"]'
 
   package-check:
     name: Package


### PR DESCRIPTION
The reusable workflow dropped the separate `test-floor` job; the `test` job now runs as a Node-versions matrix. Switch this caller from `node-floor: "22.19"` to `node-versions: '["", "22.19"]'` (primary + engines floor).