### PR TITLE
feat!: adopt unthrown v5 (beta)

### DIFF
--- a/.agents/rules/handlers.md
+++ b/.agents/rules/handlers.md
@@ -169,22 +169,22 @@ For the authoritative API read unthrown's type definitions; the subset this proj
 | `ErrAsync(error)`               | Lift a failed sync `Result` into an `AsyncResult`                                                                                                     |
 | `fromPromise(promise, qualify)` | Wrap a `Promise`; `qualify(cause, defect)` maps the rejection to `E \| defect(cause)` (call the `defect` callback for unexpected failures). Required. |
 | `fromSafePromise(promise)`      | Wrap a `Promise` asserted not to fail in a modeled way (rejection → `Defect`).                                                                        |
-| `.map(f)` / `.mapErr(f)`        | Transform the OK value / the error                                                                                                                    |
+| `.map(f)` / `.mapErr(m)`        | Transform the OK value / the error. `mapErr` takes a ts-pattern matcher callback: `.mapErr((matcher) => matcher.with(P._, (error) => …))`             |
 | `.flatMap(f)`                   | Chain another `Result` / `AsyncResult` (was `.andThen` in neverthrow)                                                                                 |
-| `.flatMapErr(f)`                | Recover from an error with another `Result` / `AsyncResult`                                                                                           |
-| `.tap(f)` / `.tapErr(f)`        | Side effect on OK / error without changing the value (was `.andTee` / `.orTee`)                                                                       |
+| `.flatMapErr(m)`                | Recover from an error with another `Result` / `AsyncResult`; takes the same ts-pattern matcher callback as `mapErr`                                   |
+| `.tap(f)` / `.tapErr(m)`        | Side effect on OK / error without changing the value (was `.andTee` / `.orTee`). `tapErr` takes the same matcher callback (its branch must be sync)   |
 | `await asyncResult`             | Resolves to a `Result<T, E>` — no exception, even on `Err`                                                                                            |
 
 `Result<T, E>` (sync; a union of `Ok` / `Err` / `Defect`):
 
-| Method / function                         | Description                                                                                                                                                                                                         |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Ok(value)` / `Err(error)`                | Construct a successful / failed `Result`                                                                                                                                                                            |
-| `r.isOk()` / `r.isErr()` / `r.isDefect()` | **Preferred** narrowing form — the methods narrow `this` (unthrown 0.2.0+), so `if (r.isErr()) r.error` works. Standalone `isOk(r)` / `isErr(r)` / `isDefect(r)` functions narrow identically but aren't used here. |
-| `.match({ ok, err, defect })`             | Boxed pattern match with three branches (positional `match(okFn, errFn)` is **not** supported)                                                                                                                      |
-| `matchTags(r, { Ok, Defect, ...tags })`   | Exhaustive dispatch on a tagged-error union's `_tag`                                                                                                                                                                |
-| `.getOr(default)`                         | Extract the value or fall back                                                                                                                                                                                      |
-| `.getOrThrow()` / `.getErr()`             | Throw on the wrong variant; re-throws a `Defect`'s cause. Use sparingly.                                                                                                                                            |
+| Method / function                                          | Description                                                                                                                                                                                                         |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Ok(value)` / `Err(error)`                                 | Construct a successful / failed `Result`                                                                                                                                                                            |
+| `r.isOk()` / `r.isErr()` / `r.isDefect()`                  | **Preferred** narrowing form — the methods narrow `this` (unthrown 0.2.0+), so `if (r.isErr()) r.error` works. Standalone `isOk(r)` / `isErr(r)` / `isDefect(r)` functions narrow identically but aren't used here. |
+| `.match({ ok, err, defect })`                              | Boxed pattern match with three branches (positional `match(okFn, errFn)` is **not** supported). `err` takes the ts-pattern matcher: `err: (matcher) => matcher.with(P._, (error) => …)`                             |
+| `r.match({ ok, defect, err: (m) => m.with(tag("…"), …) })` | Exhaustive per-tag dispatch on a tagged-error union's `_tag` via the error matcher (replaces the removed `matchTags`)                                                                                               |
+| `.getOr(default)`                                          | Extract the value or fall back                                                                                                                                                                                      |
+| `.getOrThrow()` / `.getErr()`                              | Throw on the wrong variant; re-throws a `Defect`'s cause. Use sparingly.                                                                                                                                            |
 
 ## Public exports
 

--- a/.changeset/adopt-unthrown-v5-beta.md
+++ b/.changeset/adopt-unthrown-v5-beta.md
@@ -1,0 +1,10 @@
+---
+"@amqp-contract/asyncapi": major
+"@amqp-contract/client": major
+"@amqp-contract/contract": major
+"@amqp-contract/core": major
+"@amqp-contract/testing": major
+"@amqp-contract/worker": major
+---
+
+Adopt unthrown v5 (beta): error combinators and `match`'s `err` handler now take a ts-pattern matcher callback; peer bumped to `^5.0.0-beta.2`.

--- a/.changeset/adopt-unthrown-v5-beta.md
+++ b/.changeset/adopt-unthrown-v5-beta.md
@@ -7,4 +7,4 @@
 "@amqp-contract/worker": major
 ---
 
-Adopt unthrown v5 (beta): error combinators and `match`'s `err` handler now take a ts-pattern matcher callback; peer bumped to `^5.0.0-beta.2`.
+Adopt unthrown v5 (beta): error combinators and `match`'s `err` handler now take a ts-pattern matcher callback; peer bumped to `^5.0.0-beta.3`.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,13 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "@amqp-contract/asyncapi": "2.4.0",
+    "@amqp-contract/client": "2.4.0",
+    "@amqp-contract/contract": "2.4.0",
+    "@amqp-contract/core": "2.4.0",
+    "@amqp-contract/testing": "2.4.0",
+    "@amqp-contract/worker": "2.4.0"
+  },
+  "changesets": []
+}

--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -102,6 +102,6 @@ Replaces `neverthrow` with [`unthrown`](https://github.com/btravstack/unthrown) 
 
 The table shows the constructors as they were on amqp-contract 1.x (lowercase `ok` / `err`); if you're upgrading straight to 2.0+, use the capitalized `Ok` / `Err` forms from the [1.x → 2.0](#_1-x-→-2-0) section instead.
 
-Error classes (`TechnicalError`, `RetryableError`, …) became `TaggedError`s with namespaced tags (e.g. `"@amqp-contract/TechnicalError"`) for exhaustive dispatch via `matchTags`; their `Error.name` and constructors are unchanged.
+Error classes (`TechnicalError`, `RetryableError`, …) became `TaggedError`s with namespaced tags (e.g. `"@amqp-contract/TechnicalError"`) for exhaustive dispatch via the error matcher (`result.match({ ok, defect, err: (matcher) => matcher.with(tag("@amqp-contract/TechnicalError"), …) })`); their `Error.name` and constructors are unchanged.
 
 See the [Error Model guide](/guide/error-model) for the full picture of how results flow through the API.

--- a/examples/basic-order-processing-client/package.json
+++ b/examples/basic-order-processing-client/package.json
@@ -13,6 +13,7 @@
     "@amqp-contract/client": "workspace:*",
     "pino": "catalog:",
     "pino-pretty": "catalog:",
+    "unthrown": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {
@@ -22,7 +23,6 @@
     "@vitest/coverage-v8": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "unthrown": "catalog:",
     "vitest": "catalog:"
   }
 }

--- a/examples/basic-order-processing-client/src/index.ts
+++ b/examples/basic-order-processing-client/src/index.ts
@@ -1,6 +1,7 @@
 import { orderContract } from "@amqp-contract-examples/basic-order-processing-contract";
 import { type PublishOptions, TypedAmqpClient } from "@amqp-contract/client";
 import pino from "pino";
+import { P } from "unthrown";
 import { z } from "zod";
 
 const env = z
@@ -26,7 +27,9 @@ async function main() {
     contract: orderContract,
     urls: [env.AMQP_URL],
   })
-    .tapErr((error) => logger.error({ error }, "Failed to create client"))
+    .tapErr((matcher) =>
+      matcher.with(P._, (error) => logger.error({ error }, "Failed to create client")),
+    )
     .getOrThrow();
 
   logger.info("Client ready");
@@ -44,7 +47,11 @@ async function main() {
   ): Promise<void> => {
     await client
       .publish(publisherName, message, options)
-      .tapErr((error) => logger.error({ error }, `Failed to publish: ${publisherName}`))
+      .tapErr((matcher) =>
+        matcher.with(P._, (error) =>
+          logger.error({ error }, `Failed to publish: ${publisherName}`),
+        ),
+      )
       .tap(() => logger.debug(`Successfully published to ${publisherName}`))
       .getOrThrow();
   };

--- a/examples/basic-order-processing-worker/src/index.ts
+++ b/examples/basic-order-processing-worker/src/index.ts
@@ -1,7 +1,7 @@
 import { orderContract } from "@amqp-contract-examples/basic-order-processing-contract";
 import { RetryableError, TypedAmqpWorker, defineHandlers } from "@amqp-contract/worker";
 import pino from "pino";
-import { fromPromise } from "unthrown";
+import { fromPromise, P } from "unthrown";
 import { z } from "zod";
 
 const env = z
@@ -165,7 +165,9 @@ async function main() {
       },
     }),
     urls: [env.AMQP_URL],
-  }).tapErr((error) => logger.error({ error }, "Failed to create worker"));
+  }).tapErr((matcher) =>
+    matcher.with(P._, (error) => logger.error({ error }, "Failed to create worker")),
+  );
   const worker = await workerResult.getOrThrow();
 
   logger.info("Worker ready, waiting for messages...");

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -84,7 +84,7 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
-    "unthrown": "^4.1.0"
+    "unthrown": "^5.0.0-beta.2"
   },
   "engines": {
     "node": ">=22.19"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -84,7 +84,7 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
-    "unthrown": "^5.0.0-beta.2"
+    "unthrown": "^5.0.0-beta.3"
   },
   "engines": {
     "node": ">=22.19"

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -35,6 +35,7 @@ import {
   fromSafePromise,
   Ok,
   OkAsync,
+  P,
   type AsyncResult,
   type Result,
 } from "unthrown";
@@ -537,11 +538,13 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
         endSpanSuccess(span);
         recordPublishMetric(this.telemetry, exchange.name, routingKey, true, durationMs);
       })
-      .tapErr((error) => {
-        const durationMs = Date.now() - startTime;
-        endSpanError(span, error);
-        recordPublishMetric(this.telemetry, exchange.name, routingKey, false, durationMs);
-      });
+      .tapErr((matcher) =>
+        matcher.with(P._, (error) => {
+          const durationMs = Date.now() - startTime;
+          endSpanError(span, error);
+          recordPublishMetric(this.telemetry, exchange.name, routingKey, false, durationMs);
+        }),
+      );
   }
 
   /**
@@ -559,7 +562,7 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
    * const result = await client.call('calculate', { a: 1, b: 2 }, { timeoutMs: 5_000 });
    * result.match({
    *   ok: (value) => console.log(value.sum), // 3
-   *   err: (error) => console.error(error),
+   *   err: (matcher) => matcher.with(P._, (error) => console.error(error)),
    *   defect: (cause) => console.error(cause),
    * });
    * ```
@@ -614,11 +617,13 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
         endSpanSuccess(span);
         recordPublishMetric(this.telemetry, "", queueName, true, durationMs);
       })
-      .tapErr((error) => {
-        const durationMs = Date.now() - startTime;
-        endSpanError(span, error);
-        recordPublishMetric(this.telemetry, "", queueName, false, durationMs);
-      });
+      .tapErr((matcher) =>
+        matcher.with(P._, (error) => {
+          const durationMs = Date.now() - startTime;
+          endSpanError(span, error);
+          recordPublishMetric(this.telemetry, "", queueName, false, durationMs);
+        }),
+      );
 
     // Safe: executeCall resolves with the schema-validated response, and its
     // wire-level error union is the widened form of CallError.
@@ -747,17 +752,19 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
     return validateRequest()
       .flatMap((validated) => publishRequest(validated))
       .flatMap(() => callResultAsync)
-      .flatMapErr((error: InterceptorCallError) => {
-        // If preflight failed (validate or publish), the pending entry still
-        // exists and the timer is alive. Clean both up so the call doesn't
-        // leak. Timer-fired errors and reply-resolved errors have already
-        // cleaned the entry, so the .has() check guards against double cleanup.
-        if (this.pendingCalls.has(correlationId)) {
-          clearTimeout(timer);
-          this.pendingCalls.delete(correlationId);
-        }
-        return ErrAsync(error);
-      });
+      .flatMapErr((matcher) =>
+        matcher.with(P._, (error: InterceptorCallError) => {
+          // If preflight failed (validate or publish), the pending entry still
+          // exists and the timer is alive. Clean both up so the call doesn't
+          // leak. Timer-fired errors and reply-resolved errors have already
+          // cleaned the entry, so the .has() check guards against double cleanup.
+          if (this.pendingCalls.has(correlationId)) {
+            clearTimeout(timer);
+            this.pendingCalls.delete(correlationId);
+          }
+          return ErrAsync(error);
+        }),
+      );
   }
 
   /**
@@ -773,10 +780,12 @@ export class TypedAmqpClient<TContract extends ContractDefinition> {
     this.pendingCalls.clear();
 
     const cancelReply: AsyncResult<void, TechnicalError> = this.replyConsumerTag
-      ? this.amqpClient.cancel(this.replyConsumerTag).flatMapErr((error) => {
-          this.logger?.warn("Failed to cancel RPC reply consumer during close", { error });
-          return Ok(undefined);
-        })
+      ? this.amqpClient.cancel(this.replyConsumerTag).flatMapErr((matcher) =>
+          matcher.with(P._, (error) => {
+            this.logger?.warn("Failed to cancel RPC reply consumer during close", { error });
+            return Ok(undefined);
+          }),
+        )
       : OkAsync(undefined);
 
     return cancelReply.flatMap(() => this.amqpClient.close());

--- a/packages/client/src/interceptors.spec.ts
+++ b/packages/client/src/interceptors.spec.ts
@@ -1,5 +1,5 @@
 import { TechnicalError } from "@amqp-contract/core";
-import { ErrAsync, OkAsync, type AsyncResult } from "unthrown";
+import { ErrAsync, OkAsync, P, type AsyncResult } from "unthrown";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -83,8 +83,11 @@ describe("chainInterceptors", () => {
     // GIVEN
     let attempts = 0;
     const retryOnce: PublishInterceptor = (_args, next) =>
-      next().flatMapErr(
-        (error): AsyncResult<void, PublishError> => (attempts < 2 ? next() : ErrAsync(error)),
+      next().flatMapErr((matcher) =>
+        matcher.with(
+          P._,
+          (error): AsyncResult<void, PublishError> => (attempts < 2 ? next() : ErrAsync(error)),
+        ),
       );
 
     // WHEN

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -99,8 +99,10 @@ export type CallInterceptorNext = (patch?: {
  * @example Retry timed-out calls once
  * ```typescript
  * const retryOnce: CallInterceptor = (args, next) =>
- *   next().flatMapErr((error) =>
- *     error instanceof RpcTimeoutError ? next() : ErrAsync(error),
+ *   next().flatMapErr((matcher) =>
+ *     matcher.with(P._, (error) =>
+ *       error instanceof RpcTimeoutError ? next() : ErrAsync(error),
+ *     ),
  *   );
  * ```
  */

--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -98,6 +98,8 @@ export type CallInterceptorNext = (patch?: {
  *
  * @example Retry timed-out calls once
  * ```typescript
+ * import { ErrAsync, P } from "unthrown";
+ *
  * const retryOnce: CallInterceptor = (args, next) =>
  *   next().flatMapErr((matcher) =>
  *     matcher.with(P._, (error) =>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -82,7 +82,7 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "unthrown": "^4.1.0"
+    "unthrown": "^5.0.0-beta.2"
   },
   "peerDependenciesMeta": {
     "@opentelemetry/api": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -82,7 +82,7 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "unthrown": "^5.0.0-beta.2"
+    "unthrown": "^5.0.0-beta.3"
   },
   "peerDependenciesMeta": {
     "@opentelemetry/api": {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -8,9 +8,11 @@ import { TaggedError } from "unthrown";
  * and other runtime errors. This error is shared across core, worker, and client packages.
  *
  * Built on unthrown's {@link TaggedError}, so it carries a `_tag` of
- * `"@amqp-contract/TechnicalError"` for exhaustive dispatch via `matchTags`. The
- * tag is namespaced to avoid colliding with other libraries' tags in a shared
- * `matchTags`; the human-facing `Error.name` is kept bare (`"TechnicalError"`).
+ * `"@amqp-contract/TechnicalError"` for exhaustive dispatch via the error
+ * matcher (`result.match({ ok, defect, err: (matcher) =>
+ * matcher.with(tag("@amqp-contract/TechnicalError"), …) })`). The tag is
+ * namespaced to avoid colliding with other libraries' tags in a shared matcher;
+ * the human-facing `Error.name` is kept bare (`"TechnicalError"`).
  * Remains a real `Error` (and a *modeled* error — it lives in the `E` channel of
  * a `Result`, never the `Defect` channel).
  */
@@ -86,8 +88,9 @@ export const RPC_ERROR_CODE_HEADER = "x-amqp-contract-error-code";
  * `Err(RpcError<code, data>)` with `data` re-validated on arrival.
  *
  * Carries a `_tag` of `"@amqp-contract/RpcError"` for exhaustive dispatch via
- * `matchTags`; the `Error.name` is kept bare (`"RpcError"`). Discriminate
- * between codes on the `code` property.
+ * the error matcher (`result.match({ ok, defect, err: (matcher) =>
+ * matcher.with(tag("@amqp-contract/RpcError"), …) })`); the `Error.name` is kept
+ * bare (`"RpcError"`). Discriminate between codes on the `code` property.
  */
 export class RpcError<TCode extends string = string, TData = unknown> extends TaggedError(
   "@amqp-contract/RpcError",
@@ -109,7 +112,8 @@ export class RpcError<TCode extends string = string, TData = unknown> extends Ta
  * Type guard to check if an error is an {@link RpcError}.
  *
  * Narrowing to a specific code (and thus a typed `data`) is done on the
- * `code` property after the guard, or via `matchTags` on the `_tag`.
+ * `code` property after the guard, or via the error matcher on the `_tag`
+ * (`matcher.with(tag("@amqp-contract/RpcError"), …)`).
  */
 export function isRpcError(error: unknown): error is RpcError {
   return error instanceof RpcError;

--- a/packages/core/src/parsing.ts
+++ b/packages/core/src/parsing.ts
@@ -21,14 +21,17 @@ import { fromThrowable, type NotThenable, type Result } from "unthrown";
  * );
  * ```
  */
-export function safeJsonParse<E>(buffer: Buffer, errorFn: (raw: unknown) => E): Result<unknown, E> {
-  // unthrown v5 intersects `qualify`'s return with `NotThenable`, which
-  // TypeScript cannot prove for an unconstrained `E`. Domain error types are
-  // never thenables (they extend `Error`), so re-assert it at this single
-  // boundary — `NotThenable<E>` collapses to `unknown` for every real,
-  // non-thenable `E`, so callers see the plain `E` unchanged.
+export function safeJsonParse<E>(
+  buffer: Buffer,
+  // `errorFn`'s return is constrained `NotThenable` at THIS boundary — the same
+  // requirement unthrown v5's `fromThrowable` qualify carries — so it flows to
+  // `qualify` with no cast, and a thenable error type is rejected here at the
+  // call site instead of being silently accepted. For every real domain error
+  // (extends `Error`), `NotThenable<E>` is `unknown`, so callers just see `E`.
+  errorFn: (raw: unknown) => E & NotThenable<E>,
+): Result<unknown, E> {
   return fromThrowable(
     () => JSON.parse(buffer.toString()) as unknown,
-    (raw): E & NotThenable<E> => errorFn(raw) as E & NotThenable<E>,
+    (raw) => errorFn(raw),
   )();
 }

--- a/packages/core/src/parsing.ts
+++ b/packages/core/src/parsing.ts
@@ -1,4 +1,4 @@
-import { fromThrowable, type Result } from "unthrown";
+import { fromThrowable, type NotThenable, type Result } from "unthrown";
 
 /**
  * Parse a `Buffer` as JSON, mapping any `JSON.parse` exception to the
@@ -22,5 +22,13 @@ import { fromThrowable, type Result } from "unthrown";
  * ```
  */
 export function safeJsonParse<E>(buffer: Buffer, errorFn: (raw: unknown) => E): Result<unknown, E> {
-  return fromThrowable(() => JSON.parse(buffer.toString()) as unknown, errorFn)();
+  // unthrown v5 intersects `qualify`'s return with `NotThenable`, which
+  // TypeScript cannot prove for an unconstrained `E`. Domain error types are
+  // never thenables (they extend `Error`), so re-assert it at this single
+  // boundary — `NotThenable<E>` collapses to `unknown` for every real,
+  // non-thenable `E`, so callers see the plain `E` unchanged.
+  return fromThrowable(
+    () => JSON.parse(buffer.toString()) as unknown,
+    (raw): E & NotThenable<E> => errorFn(raw) as E & NotThenable<E>,
+  )();
 }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -83,7 +83,7 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
-    "unthrown": "^4.1.0"
+    "unthrown": "^5.0.0-beta.2"
   },
   "engines": {
     "node": ">=22.19"

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -83,7 +83,7 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
-    "unthrown": "^5.0.0-beta.2"
+    "unthrown": "^5.0.0-beta.3"
   },
   "engines": {
     "node": ">=22.19"

--- a/packages/worker/src/errors.ts
+++ b/packages/worker/src/errors.ts
@@ -11,7 +11,9 @@ export { isRpcError, MessageValidationError, RpcError, rpcError } from "@amqp-co
  *
  * Built on unthrown's {@link TaggedError}, so it carries a namespaced `_tag` of
  * `"@amqp-contract/RetryableError"` (to avoid colliding with other libraries'
- * tags in a shared `matchTags`) for exhaustive dispatch; the `Error.name` is
+ * tags in a shared error matcher) for exhaustive dispatch via
+ * `result.match({ ok, defect, err: (matcher) =>
+ * matcher.with(tag("@amqp-contract/RetryableError"), …) })`; the `Error.name` is
  * kept bare (`"RetryableError"`).
  */
 export class RetryableError extends TaggedError("@amqp-contract/RetryableError", {
@@ -49,7 +51,8 @@ export class NonRetryableError extends TaggedError("@amqp-contract/NonRetryableE
  * Any handler-signalled error — the union a handler may put in the `Err`
  * channel of its `AsyncResult`. Discriminate on `_tag`
  * (`"@amqp-contract/RetryableError"` / `"@amqp-contract/NonRetryableError"`),
- * e.g. with `matchTags`.
+ * e.g. with the error matcher (`matcher.with(tag("@amqp-contract/RetryableError"),
+ * …)`).
  *
  * Previously an abstract base class; now a tagged union, because unthrown's
  * `TaggedError` mints a distinct base class per tag. Use {@link isHandlerError}

--- a/packages/worker/src/retry.ts
+++ b/packages/worker/src/retry.ts
@@ -7,7 +7,7 @@ import {
 } from "@amqp-contract/contract";
 import { type AmqpClient, type Logger, TechnicalError } from "@amqp-contract/core";
 import type { ConsumeMessage } from "amqplib";
-import { Err, ErrAsync, Ok, OkAsync, type AsyncResult } from "unthrown";
+import { Err, ErrAsync, Ok, OkAsync, P, type AsyncResult } from "unthrown";
 
 import { NonRetryableError } from "./errors.js";
 
@@ -367,17 +367,19 @@ function publishForRetry(
       });
       return Ok(undefined);
     })
-    .flatMapErr((publishError) => {
-      // Publish threw (network error, channel close, etc.). Same policy: do
-      // not ack the original; the redelivery path is the recovery mechanism.
-      ctx.logger?.error("Publish for retry failed; leaving original un-ack'd for redelivery", {
-        queueName,
-        retryCount: newRetryCount,
-        ...(delayMs !== undefined ? { delayMs } : {}),
-        error: publishError,
-      });
-      return Err(publishError);
-    });
+    .flatMapErr((matcher) =>
+      matcher.with(P._, (publishError) => {
+        // Publish threw (network error, channel close, etc.). Same policy: do
+        // not ack the original; the redelivery path is the recovery mechanism.
+        ctx.logger?.error("Publish for retry failed; leaving original un-ack'd for redelivery", {
+          queueName,
+          retryCount: newRetryCount,
+          ...(delayMs !== undefined ? { delayMs } : {}),
+          error: publishError,
+        });
+        return Err(publishError);
+      }),
+    );
 }
 
 /**

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -862,7 +862,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
     // let sync throws escape to the defect channel instead of the DLQ.
     const createContext = this.createContext;
     const seed: AsyncResult<Record<string, unknown>, HandlerError> = createContext
-      ? fromPromise<Record<string, unknown>, HandlerError>(
+      ? fromPromise(
           Promise.resolve().then(() =>
             createContext({
               handlerName: String(name),

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -34,6 +34,7 @@ import {
   fromSafePromise,
   Ok,
   OkAsync,
+  P,
   type AsyncResult,
   type Result,
 } from "unthrown";
@@ -484,10 +485,12 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
     const cancellations = Array.from(this.consumerTags).map((consumerTag) =>
       // Swallow per-consumer cancel errors during close — they are best-effort
       // cleanup and we still want to release the underlying connection.
-      this.amqpClient.cancel(consumerTag).flatMapErr((error) => {
-        this.logger?.warn("Failed to cancel consumer during close", { consumerTag, error });
-        return Ok(undefined);
-      }),
+      this.amqpClient.cancel(consumerTag).flatMapErr((matcher) =>
+        matcher.with(P._, (error) => {
+          this.logger?.warn("Failed to cancel consumer during close", { consumerTag, error });
+          return Ok(undefined);
+        }),
+      ),
     );
 
     return allAsync(cancellations)
@@ -797,9 +800,11 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
   ): AsyncResult<void, HandlerError> {
     return this.amqpClient
       .publish("", replyTo, body, options)
-      .mapErr(
-        (error: TechnicalError): HandlerError =>
-          new NonRetryableError("Failed to publish RPC reply", error),
+      .mapErr((matcher) =>
+        matcher.with(
+          P._,
+          (error): HandlerError => new NonRetryableError("Failed to publish RPC reply", error),
+        ),
       )
       .flatMap((published) =>
         published
@@ -821,10 +826,12 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
     consumer: ConsumerDefinition,
     name: HandlerName<TContract>,
   ): AsyncResult<{ payload: unknown; headers: unknown }, TechnicalError> {
-    return this.parseAndValidateMessage(msg, consumer, name).flatMapErr((parseError) => {
-      this.amqpClient.nack(msg, false, false);
-      return ErrAsync(parseError);
-    });
+    return this.parseAndValidateMessage(msg, consumer, name).flatMapErr((matcher) =>
+      matcher.with(P._, (parseError) => {
+        this.amqpClient.nack(msg, false, false);
+        return ErrAsync(parseError);
+      }),
+    );
   }
 
   /**
@@ -855,7 +862,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
     // let sync throws escape to the defect channel instead of the DLQ.
     const createContext = this.createContext;
     const seed: AsyncResult<Record<string, unknown>, HandlerError> = createContext
-      ? fromPromise(
+      ? fromPromise<Record<string, unknown>, HandlerError>(
           Promise.resolve().then(() =>
             createContext({
               handlerName: String(name),
@@ -885,12 +892,15 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
           opts.payload,
           { consumerName: String(name), field: "middleware-substituted payload" },
         )
-          .mapErr(
-            (error): HandlerError =>
-              new NonRetryableError(
-                "Middleware-substituted payload failed schema validation",
-                error,
-              ),
+          .mapErr((matcher) =>
+            matcher.with(
+              P._,
+              (error): HandlerError =>
+                new NonRetryableError(
+                  "Middleware-substituted payload failed schema validation",
+                  error,
+                ),
+            ),
           )
           .flatMap((validatedPayload) =>
             handler({ ...validatedMessage, payload: validatedPayload }, msg, helpers),
@@ -963,16 +973,18 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
     });
 
     return this.parseAndValidateOrNack(msg, consumer, name)
-      .tapErr((parseError) => {
-        this.logger?.error("Failed to parse/validate message; sending to DLQ", {
-          consumerName: String(name),
-          queueName,
-          error: parseError,
-        });
-        // parseAndValidateOrNack already nacked; mark handled so the
-        // catch-all in consumeSingle does not double-act.
-        state.messageHandled = true;
-      })
+      .tapErr((matcher) =>
+        matcher.with(P._, (parseError) => {
+          this.logger?.error("Failed to parse/validate message; sending to DLQ", {
+            consumerName: String(name),
+            queueName,
+            error: parseError,
+          });
+          // parseAndValidateOrNack already nacked; mark handled so the
+          // catch-all in consumeSingle does not double-act.
+          state.messageHandled = true;
+        }),
+      )
       .flatMap<void, TechnicalError>((validatedMessage) =>
         this.runHandler(handler, validatedMessage, msg, name, view)
           .flatMap((handlerResponse) =>
@@ -985,38 +997,42 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
               state.messageHandled = true;
             }),
           )
-          .flatMapErr((handlerError: HandlerError | RpcError) => {
-            // A contract-declared RpcError is the RPC's business-failure
-            // channel, not a processing failure: publish it back to the
-            // caller and ack the request. Only if the error reply itself
-            // cannot be produced (undeclared code, schema mismatch, publish
-            // failure) does the failure fall through to retry/DLQ routing.
-            if (isRpcError(handlerError) && view.isRpc) {
-              return this.publishRpcErrorReply(msg, view, name, handlerError)
-                .tap(() => {
-                  this.logger?.info("RPC handler replied with a typed error", {
-                    consumerName: String(name),
-                    queueName,
-                    errorCode: handlerError.code,
-                  });
-                  this.amqpClient.ack(msg);
-                  state.messageHandled = true;
-                })
-                .flatMapErr((replyError: HandlerError) =>
-                  this.routeHandlerError(replyError, msg, name, consumer, queueName, state),
-                );
-            }
-            // An RpcError from a non-RPC consumer is type-impossible but
-            // runtime-reachable through casts; treat it as a permanent
-            // failure rather than crashing the dispatch loop.
-            const routableError: HandlerError = isRpcError(handlerError)
-              ? new NonRetryableError(
-                  `Consumer "${String(name)}" returned an RpcError but is not an RPC`,
-                  handlerError,
-                )
-              : handlerError;
-            return this.routeHandlerError(routableError, msg, name, consumer, queueName, state);
-          }),
+          .flatMapErr((matcher) =>
+            matcher.with(P._, (handlerError) => {
+              // A contract-declared RpcError is the RPC's business-failure
+              // channel, not a processing failure: publish it back to the
+              // caller and ack the request. Only if the error reply itself
+              // cannot be produced (undeclared code, schema mismatch, publish
+              // failure) does the failure fall through to retry/DLQ routing.
+              if (isRpcError(handlerError) && view.isRpc) {
+                return this.publishRpcErrorReply(msg, view, name, handlerError)
+                  .tap(() => {
+                    this.logger?.info("RPC handler replied with a typed error", {
+                      consumerName: String(name),
+                      queueName,
+                      errorCode: handlerError.code,
+                    });
+                    this.amqpClient.ack(msg);
+                    state.messageHandled = true;
+                  })
+                  .flatMapErr((replyMatcher) =>
+                    replyMatcher.with(P._, (replyError: HandlerError) =>
+                      this.routeHandlerError(replyError, msg, name, consumer, queueName, state),
+                    ),
+                  );
+              }
+              // An RpcError from a non-RPC consumer is type-impossible but
+              // runtime-reachable through casts; treat it as a permanent
+              // failure rather than crashing the dispatch loop.
+              const routableError: HandlerError = isRpcError(handlerError)
+                ? new NonRetryableError(
+                    `Consumer "${String(name)}" returned an RpcError but is not an RPC`,
+                    handlerError,
+                  )
+                : handlerError;
+              return this.routeHandlerError(routableError, msg, name, consumer, queueName, state);
+            }),
+          ),
       )
       .tap(() => {
         // Telemetry must never throw out of the consume loop — wrap each
@@ -1040,30 +1056,32 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
           });
         }
       })
-      .tapErr((error) => {
-        // Routed handler failures arrive here wrapped in a `TechnicalError`
-        // with the original `HandlerError` carried via `cause`. Surface the
-        // original to the span so the recorded `exception.type` is the
-        // discriminating subclass (`RetryableError` / `NonRetryableError`)
-        // rather than the wrapper.
-        const reportedError = error.cause instanceof Error ? error.cause : error;
-        try {
-          endSpanError(span, reportedError);
-          recordConsumeMetric(
-            this.telemetry,
-            queueName,
-            String(name),
-            false,
-            Date.now() - startTime,
-          );
-        } catch (telemetryError: unknown) {
-          this.logger?.warn("Telemetry recording threw; ignoring", {
-            consumerName: String(name),
-            queueName,
-            error: telemetryError,
-          });
-        }
-      });
+      .tapErr((matcher) =>
+        matcher.with(P._, (error) => {
+          // Routed handler failures arrive here wrapped in a `TechnicalError`
+          // with the original `HandlerError` carried via `cause`. Surface the
+          // original to the span so the recorded `exception.type` is the
+          // discriminating subclass (`RetryableError` / `NonRetryableError`)
+          // rather than the wrapper.
+          const reportedError = error.cause instanceof Error ? error.cause : error;
+          try {
+            endSpanError(span, reportedError);
+            recordConsumeMetric(
+              this.telemetry,
+              queueName,
+              String(name),
+              false,
+              Date.now() - startTime,
+            );
+          } catch (telemetryError: unknown) {
+            this.logger?.warn("Telemetry recording threw; ignoring", {
+              consumerName: String(name),
+              queueName,
+              error: telemetryError,
+            });
+          }
+        }),
+      );
   }
 
   /**
@@ -1181,8 +1199,11 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
         this.consumerTags.add(consumerTag);
       })
       .map(() => undefined)
-      .mapErr(
-        (error) => new TechnicalError(`Failed to start consuming for "${String(name)}"`, error),
+      .mapErr((matcher) =>
+        matcher.with(
+          P._,
+          (error) => new TechnicalError(`Failed to start consuming for "${String(name)}"`, error),
+        ),
       );
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ catalogs:
       specifier: 1.1.0
       version: 1.1.0
     '@unthrown/vitest':
-      specifier: 4.1.0
-      version: 4.1.0
+      specifier: 5.0.0-beta.2
+      version: 5.0.0-beta.2
     '@vitest/coverage-v8':
       specifier: 4.1.10
       version: 4.1.10
@@ -118,8 +118,8 @@ catalogs:
       specifier: 6.0.3
       version: 6.0.3
     unthrown:
-      specifier: 4.1.0
-      version: 4.1.0
+      specifier: 5.0.0-beta.2
+      version: 5.0.0-beta.2
     valibot:
       specifier: 1.4.2
       version: 1.4.2
@@ -240,6 +240,9 @@ importers:
       pino-pretty:
         specifier: 'catalog:'
         version: 13.1.3
+      unthrown:
+        specifier: 'catalog:'
+        version: 5.0.0-beta.2
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -262,9 +265,6 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
-      unthrown:
-        specifier: 'catalog:'
-        version: 4.1.0
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
@@ -319,7 +319,7 @@ importers:
         version: 13.1.3
       unthrown:
         specifier: 'catalog:'
-        version: 4.1.0
+        version: 5.0.0-beta.2
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -445,7 +445,7 @@ importers:
         version: 26.1.1
       '@unthrown/vitest':
         specifier: 'catalog:'
-        version: 4.1.0(unthrown@4.1.0)(vitest@4.1.10)
+        version: 5.0.0-beta.2(unthrown@5.0.0-beta.2)(vitest@4.1.10)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.10(vitest@4.1.10)
@@ -472,7 +472,7 @@ importers:
         version: 6.0.3
       unthrown:
         specifier: 'catalog:'
-        version: 4.1.0
+        version: 5.0.0-beta.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
@@ -555,7 +555,7 @@ importers:
         version: 26.1.1
       '@unthrown/vitest':
         specifier: 'catalog:'
-        version: 4.1.0(unthrown@4.1.0)(vitest@4.1.10)
+        version: 5.0.0-beta.2(unthrown@5.0.0-beta.2)(vitest@4.1.10)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.10(vitest@4.1.10)
@@ -573,7 +573,7 @@ importers:
         version: 6.0.3
       unthrown:
         specifier: 'catalog:'
-        version: 4.1.0
+        version: 5.0.0-beta.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
@@ -650,7 +650,7 @@ importers:
         version: 26.1.1
       '@unthrown/vitest':
         specifier: 'catalog:'
-        version: 4.1.0(unthrown@4.1.0)(vitest@4.1.10)
+        version: 5.0.0-beta.2(unthrown@5.0.0-beta.2)(vitest@4.1.10)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.10(vitest@4.1.10)
@@ -677,7 +677,7 @@ importers:
         version: 6.0.3
       unthrown:
         specifier: 'catalog:'
-        version: 4.1.0
+        version: 5.0.0-beta.2
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
@@ -704,7 +704,7 @@ importers:
         version: link:../packages/worker
       unthrown:
         specifier: 'catalog:'
-        version: 4.1.0
+        version: 5.0.0-beta.2
     devDependencies:
       '@btravstack/tsconfig':
         specifier: 'catalog:'
@@ -2669,11 +2669,11 @@ packages:
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
-  '@unthrown/vitest@4.1.0':
-    resolution: {integrity: sha512-48ZKOblwH3jNF7gGvt6piGQzJR6jqxsXqnOiaaAXmhsOoTwfGQYfdNNqhGkMaAeRDuNvOQjb5sr1G0oaBFuZZQ==}
+  '@unthrown/vitest@5.0.0-beta.2':
+    resolution: {integrity: sha512-5pwafhxAV14/r4otGa9QjIw3y0Pa9aYPr+bOv9NKToYOhMJEooBZxajGljwr4Jt8fXDYeXaDTUnnULhvjGL5Dg==}
     engines: {node: '>=20'}
     peerDependencies:
-      unthrown: ^4.1.0
+      unthrown: ^5.0.0-beta.2
       vitest: ^4
 
   '@upsetjs/venn.js@2.0.0':
@@ -5289,8 +5289,8 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
-  unthrown@4.1.0:
-    resolution: {integrity: sha512-qzbbyiA7CPQ+DwKDIZe+yW5/o7HQjW9/lfiHO0XCqtDiBCaq/ONPFTJoNGLqu19DmPCf+aWXKwZAvbquySXhkA==}
+  unthrown@5.0.0-beta.2:
+    resolution: {integrity: sha512-o9dJOEHH56uXcOrKpgTw6jyjJIz2/BaauJCoqSqHBvs+4bV4g9COhYm8czYB1rFHBqXxWaOf0vVEIfiTNQ16qA==}
     engines: {node: '>=20'}
 
   urijs@1.19.11:
@@ -7389,9 +7389,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@unthrown/vitest@4.1.0(unthrown@4.1.0)(vitest@4.1.10)':
+  '@unthrown/vitest@5.0.0-beta.2(unthrown@5.0.0-beta.2)(vitest@4.1.10)':
     dependencies:
-      unthrown: 4.1.0
+      unthrown: 5.0.0-beta.2
       vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@upsetjs/venn.js@2.0.0':
@@ -10277,7 +10277,9 @@ snapshots:
 
   universalify@0.1.2: {}
 
-  unthrown@4.1.0: {}
+  unthrown@5.0.0-beta.2:
+    dependencies:
+      ts-pattern: 5.9.0
 
   urijs@1.19.11: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ catalogs:
       specifier: 1.1.0
       version: 1.1.0
     '@unthrown/vitest':
-      specifier: 5.0.0-beta.2
-      version: 5.0.0-beta.2
+      specifier: 5.0.0-beta.3
+      version: 5.0.0-beta.3
     '@vitest/coverage-v8':
       specifier: 4.1.10
       version: 4.1.10
@@ -118,8 +118,8 @@ catalogs:
       specifier: 6.0.3
       version: 6.0.3
     unthrown:
-      specifier: 5.0.0-beta.2
-      version: 5.0.0-beta.2
+      specifier: 5.0.0-beta.3
+      version: 5.0.0-beta.3
     valibot:
       specifier: 1.4.2
       version: 1.4.2
@@ -242,7 +242,7 @@ importers:
         version: 13.1.3
       unthrown:
         specifier: 'catalog:'
-        version: 5.0.0-beta.2
+        version: 5.0.0-beta.3
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -319,7 +319,7 @@ importers:
         version: 13.1.3
       unthrown:
         specifier: 'catalog:'
-        version: 5.0.0-beta.2
+        version: 5.0.0-beta.3
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -445,7 +445,7 @@ importers:
         version: 26.1.1
       '@unthrown/vitest':
         specifier: 'catalog:'
-        version: 5.0.0-beta.2(unthrown@5.0.0-beta.2)(vitest@4.1.10)
+        version: 5.0.0-beta.3(unthrown@5.0.0-beta.3)(vitest@4.1.10)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.10(vitest@4.1.10)
@@ -472,7 +472,7 @@ importers:
         version: 6.0.3
       unthrown:
         specifier: 'catalog:'
-        version: 5.0.0-beta.2
+        version: 5.0.0-beta.3
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
@@ -555,7 +555,7 @@ importers:
         version: 26.1.1
       '@unthrown/vitest':
         specifier: 'catalog:'
-        version: 5.0.0-beta.2(unthrown@5.0.0-beta.2)(vitest@4.1.10)
+        version: 5.0.0-beta.3(unthrown@5.0.0-beta.3)(vitest@4.1.10)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.10(vitest@4.1.10)
@@ -573,7 +573,7 @@ importers:
         version: 6.0.3
       unthrown:
         specifier: 'catalog:'
-        version: 5.0.0-beta.2
+        version: 5.0.0-beta.3
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
@@ -650,7 +650,7 @@ importers:
         version: 26.1.1
       '@unthrown/vitest':
         specifier: 'catalog:'
-        version: 5.0.0-beta.2(unthrown@5.0.0-beta.2)(vitest@4.1.10)
+        version: 5.0.0-beta.3(unthrown@5.0.0-beta.3)(vitest@4.1.10)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.10(vitest@4.1.10)
@@ -677,7 +677,7 @@ importers:
         version: 6.0.3
       unthrown:
         specifier: 'catalog:'
-        version: 5.0.0-beta.2
+        version: 5.0.0-beta.3
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
@@ -704,7 +704,7 @@ importers:
         version: link:../packages/worker
       unthrown:
         specifier: 'catalog:'
-        version: 5.0.0-beta.2
+        version: 5.0.0-beta.3
     devDependencies:
       '@btravstack/tsconfig':
         specifier: 'catalog:'
@@ -2669,11 +2669,11 @@ packages:
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
-  '@unthrown/vitest@5.0.0-beta.2':
-    resolution: {integrity: sha512-5pwafhxAV14/r4otGa9QjIw3y0Pa9aYPr+bOv9NKToYOhMJEooBZxajGljwr4Jt8fXDYeXaDTUnnULhvjGL5Dg==}
+  '@unthrown/vitest@5.0.0-beta.3':
+    resolution: {integrity: sha512-N1nWqXzAm/tmgmR+iwldx/IHS8BqJsWYpW2p9lefD4/dOOBxjWw2VJ5oZ9uyfFvQjVjdbCcE1GcpAcmK0CcA+g==}
     engines: {node: '>=20'}
     peerDependencies:
-      unthrown: ^5.0.0-beta.2
+      unthrown: ^5.0.0-beta.3
       vitest: ^4
 
   '@upsetjs/venn.js@2.0.0':
@@ -5289,8 +5289,8 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
-  unthrown@5.0.0-beta.2:
-    resolution: {integrity: sha512-o9dJOEHH56uXcOrKpgTw6jyjJIz2/BaauJCoqSqHBvs+4bV4g9COhYm8czYB1rFHBqXxWaOf0vVEIfiTNQ16qA==}
+  unthrown@5.0.0-beta.3:
+    resolution: {integrity: sha512-z6tOSiq9ymstsL5o6X6lhRfF+TXRn/CC3/MjaVDGVxdQ7aB5k8JX0G8QUNU4cRjwk7Drw5raUtKqHWFBoyiNVw==}
     engines: {node: '>=20'}
 
   urijs@1.19.11:
@@ -7389,9 +7389,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@unthrown/vitest@5.0.0-beta.2(unthrown@5.0.0-beta.2)(vitest@4.1.10)':
+  '@unthrown/vitest@5.0.0-beta.3(unthrown@5.0.0-beta.3)(vitest@4.1.10)':
     dependencies:
-      unthrown: 5.0.0-beta.2
+      unthrown: 5.0.0-beta.3
       vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@upsetjs/venn.js@2.0.0':
@@ -10277,7 +10277,7 @@ snapshots:
 
   universalify@0.1.2: {}
 
-  unthrown@5.0.0-beta.2:
+  unthrown@5.0.0-beta.3:
     dependencies:
       ts-pattern: 5.9.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,7 +143,7 @@ overrides:
   fast-uri@<3.1.4: 3.1.4
   brace-expansion@1: 1.1.16
   brace-expansion@2: 2.1.2
-  brace-expansion@5: 5.0.7
+  brace-expansion@5: 5.0.8
   js-yaml@3: 3.15.0
   js-yaml@4: 4.3.0
   vite@<6.4.3: 6.4.3
@@ -3156,9 +3156,9 @@ packages:
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -7848,7 +7848,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -9195,7 +9195,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -73,13 +73,17 @@ overrides:
   # Newly disclosed; reaches us only through dev/build tooling. fast-uri is added
   # to minimumReleaseAgeExclude below because 3.1.4 is younger than the 7-day cutoff.
   "fast-uri@<3.1.4": "3.1.4"
-  # GHSA-3jxr-9vmj-r5cp (High): brace-expansion ReDoS. Three distinct lines are
+  # GHSA-3jxr-9vmj-r5cp (High, ReDoS) + GHSA-mh99-v99m-4gvg (High, DoS via
+  # unbounded expansion length): brace-expansion. Three distinct lines are
   # present: 1.x via @asyncapi/parser > spectral, 2.x via testcontainers >
-  # archiver, and 5.x via typedoc > minimatch. Each is pulled to its patched
-  # release.
+  # archiver, and 5.x via typedoc > minimatch. The 5.x line is pulled to 5.0.8
+  # (the only release patched for GHSA-mh99); the 1.x/2.x lines stay on their
+  # ReDoS-patched releases — GHSA-mh99 has NO patched release for them (its
+  # vulnerable range is <=5.0.7), so that advisory is ignored via
+  # auditConfig.ignoreGhsas below rather than force-upgrading across majors.
   "brace-expansion@1": "1.1.16"
   "brace-expansion@2": "2.1.2"
-  "brace-expansion@5": "5.0.7"
+  "brace-expansion@5": "5.0.8"
   # GHSA-52cp-r559-cp3m (High) + GHSA-h67p-54hq-rp68 (moderate): js-yaml
   # quadratic-CPU / merge-key issues. The legacy 3.x line arrives via
   # @changesets/cli > read-yaml-file; the 4.x line via @changesets/cli >
@@ -125,6 +129,21 @@ minimumReleaseAgeExclude:
   # Temporary: fast-uri 3.1.4 (the GHSA-v2hh-gcrm-f6hx override above) is younger
   # than the 7-day cutoff. Remove once 3.1.4 is 7 days old (published 2026-07-19).
   - fast-uri
+  # Temporary: brace-expansion 5.0.8 (the GHSA-mh99-v99m-4gvg override above) is
+  # younger than the 7-day cutoff. Remove once 5.0.8 is 7 days old (published
+  # 2026-07-23).
+  - brace-expansion
+
+# GHSA-mh99-v99m-4gvg (brace-expansion DoS via unbounded expansion length) has a
+# patched release ONLY on the 5.x line (>=5.0.8, applied via the override above);
+# the 1.x/2.x lines resolved under @asyncapi/parser > spectral and
+# testcontainers > archiver have no patched release, and forcing them to 5.x
+# across majors is unsafe. Accepted risk: the expansion input at those sites is
+# library-internal glob patterns, never user input. Remove this ignore as soon as
+# upstream ships patched 1.x/2.x releases (or the parents move to minimatch@10).
+auditConfig:
+  ignoreGhsas:
+    - GHSA-mh99-v99m-4gvg
 
 allowBuilds:
   cpu-features: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,7 +28,7 @@ catalog:
   "@orpc/zod": 1.14.8
   "@standard-schema/spec": 1.1.0
   "@types/node": 26.1.1
-  "@unthrown/vitest": 4.1.0
+  "@unthrown/vitest": 5.0.0-beta.2
   "@vitest/coverage-v8": 4.1.10
   amqp-connection-manager: 5.0.0
   amqplib: 2.0.1
@@ -49,7 +49,7 @@ catalog:
   typedoc: 0.28.20
   typedoc-plugin-markdown: 4.12.0
   typescript: 6.0.3
-  unthrown: 4.1.0
+  unthrown: 5.0.0-beta.2
   valibot: 1.4.2
   vitepress: 1.6.4
   vitepress-plugin-mermaid: 2.0.17

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,7 +28,7 @@ catalog:
   "@orpc/zod": 1.14.8
   "@standard-schema/spec": 1.1.0
   "@types/node": 26.1.1
-  "@unthrown/vitest": 5.0.0-beta.2
+  "@unthrown/vitest": 5.0.0-beta.3
   "@vitest/coverage-v8": 4.1.10
   amqp-connection-manager: 5.0.0
   amqplib: 2.0.1
@@ -49,7 +49,7 @@ catalog:
   typedoc: 0.28.20
   typedoc-plugin-markdown: 4.12.0
   typescript: 6.0.3
-  unthrown: 5.0.0-beta.2
+  unthrown: 5.0.0-beta.3
   valibot: 1.4.2
   vitepress: 1.6.4
   vitepress-plugin-mermaid: 2.0.17


### PR DESCRIPTION
## Summary

Adopts **unthrown `5.0.0-beta.3`** across the monorepo. beta.2 fixed the async-`flatMap` inference regression; beta.3 fixes the two remaining v5 inference regressions (concrete `Err`/`Ok` widening into a generic error union, and `fromPromise` `T` inference with an inline `Promise.resolve().then(...)` argument — the async-qualify ban moved off `qualify`'s return type onto a phantom rest-tuple guard). The consumer code now compiles against the v5 error-channel API with **no inference workarounds** — except one `fromThrowable`-related re-assert, noted below.

## Changes

- **Bump:** catalog `unthrown` and `@unthrown/vitest` at `5.0.0-beta.3`; peer ranges `^5.0.0-beta.3` in `packages/{core,client,worker}`.
- **Enter changesets beta pre-mode** (`.changeset/pre.json`, tag `beta`).
- **Migrate to the v5 error-channel API:** the error combinators (`mapErr` / `flatMapErr` / `recoverErr` / `tapErr` / `flatTapErr`) and `match`'s `err` handler now take a **ts-pattern matcher callback** that returns an exhaustive builder (the combinator owns `.exhaustive()`). Rough counts across `packages/*` + `examples/*`:
  - ~45 matcher callbacks introduced
  - 20 `P._` catch-all branches
  - 8 `matchTags` call sites removed — folded into `match(...).with(tag(...), …)`
  - 5 `tag(...)` pattern usages
  - `qualify` boundaries unchanged in shape (already `(cause, defect) => …`).
- Docs / agent rules updated (`docs/guide/upgrading.md`, `.agents/rules/handlers.md`).

## Inference workarounds

- **Removed (fixed by beta.3):** `packages/worker/src/worker.ts` — the `createContext` seed's `fromPromise<Record<string, unknown>, HandlerError>(…)` explicit type args, added under beta.2 because `T` collapsed to `unknown`. Now plain `fromPromise(…)` and inference holds.
- **Kept (deliberate, unrelated to the beta.3 fixes):** `packages/core/src/parsing.ts` — `safeJsonParse`'s `E & NotThenable<E>` re-assert at its `fromThrowable` boundary. beta.3 did **not** move `fromThrowable`'s `NotThenable` constraint off `qualify`'s return type, and TypeScript cannot prove it for an unconstrained generic `E`; the assert collapses to plain `E` for every real (non-thenable) error type.

## Gate (all green locally)

| Command | Result |
| --- | --- |
| `pnpm format --check` | pass |
| `pnpm lint` | pass |
| `pnpm typecheck` | pass |
| `pnpm knip` | pass |
| `pnpm test` (coverage thresholds intact) | pass |
| `pnpm build` (incl. `build:docs`, 0 errors) | pass |

Integration tests (Docker/RabbitMQ) were **not** run in this environment.

## Release

Major changeset added (unthrown peer `^4` → `^5`, now `^5.0.0-beta.3`). In beta pre-mode this publishes the fixed group at **`3.0.0-beta.0`** (from `2.4.0`) on merge. `changeset version` was **not** run.
