### PR TITLE
chore(deps): bump unthrown to 5.0.0-beta.7

### DIFF
--- a/.changeset/bump-unthrown-beta-7.md
+++ b/.changeset/bump-unthrown-beta-7.md
@@ -1,0 +1,27 @@
+---
+"@amqp-contract/client": patch
+"@amqp-contract/core": patch
+"@amqp-contract/worker": patch
+---
+
+Bump `unthrown` to `5.0.0-beta.7` and raise the peer range to `^5.0.0-beta.7`.
+
+Two upstream changes, neither of which alters amqp-contract's own surface:
+
+- The built-in matcher gains `returnType<R>()`, pinning a match's output type so
+  every branch is checked against it rather than the result widening to the
+  union of the branch returns. It reaches every surface that hands out a
+  matcher, including `match`'s `errCases` handler and the five `*ErrCases`
+  combinators — so it is available on any amqp-contract result, but nothing here
+  requires it.
+- `tapErrCases` no longer silently drops a `defect(…)` branch: it now produces a
+  `Defect` carrying an `AggregateError` of `[the branch's cause, the observed
+error]`, matching what a `throw` in the same position already did. This
+  codebase has no `tapErrCases` call sites, so nothing changed here — but a
+  consumer relying on that branch being dropped will now see a `Defect` surface
+  where the pipeline previously carried on with the original `Err`.
+
+The peer floor is raised rather than left at `beta.6` (which the caret range
+would already have admitted) so consumers resolve the same beta these packages
+were built and tested against — behaviour has shifted between betas on this
+line, and a single shared copy is the point of the peer dependency.

--- a/.changeset/bump-unthrown-beta-7.md
+++ b/.changeset/bump-unthrown-beta-7.md
@@ -15,9 +15,9 @@ Two upstream changes, neither of which alters amqp-contract's own surface:
   combinators — so it is available on any amqp-contract result, but nothing here
   requires it.
 - `tapErrCases` no longer silently drops a `defect(…)` branch: it now produces a
-  `Defect` carrying an `AggregateError` of `[the branch's cause, the observed
-error]`, matching what a `throw` in the same position already did. This
-  codebase has no `tapErrCases` call sites, so nothing changed here — but a
+  `Defect` whose cause is an `AggregateError` of the branch's cause and the
+  observed error, matching what a `throw` in the same position already did.
+  This codebase has no `tapErrCases` call sites, so nothing changed here — but a
   consumer relying on that branch being dropped will now see a `Defect` surface
   where the pipeline previously carried on with the original `Err`.
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -83,7 +83,7 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
-    "unthrown": "^5.0.0-beta.6"
+    "unthrown": "^5.0.0-beta.7"
   },
   "engines": {
     "node": ">=22.19"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -82,7 +82,7 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "unthrown": "^5.0.0-beta.6"
+    "unthrown": "^5.0.0-beta.7"
   },
   "peerDependenciesMeta": {
     "@opentelemetry/api": {

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -83,7 +83,7 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
-    "unthrown": "^5.0.0-beta.6"
+    "unthrown": "^5.0.0-beta.7"
   },
   "engines": {
     "node": ">=22.19"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ catalogs:
       specifier: 1.1.0
       version: 1.1.0
     '@unthrown/vitest':
-      specifier: 5.0.0-beta.6
-      version: 5.0.0-beta.6
+      specifier: 5.0.0-beta.7
+      version: 5.0.0-beta.7
     '@vitest/coverage-v8':
       specifier: 4.1.10
       version: 4.1.10
@@ -115,8 +115,8 @@ catalogs:
       specifier: 6.0.3
       version: 6.0.3
     unthrown:
-      specifier: 5.0.0-beta.6
-      version: 5.0.0-beta.6
+      specifier: 5.0.0-beta.7
+      version: 5.0.0-beta.7
     valibot:
       specifier: 1.4.2
       version: 1.4.2
@@ -239,7 +239,7 @@ importers:
         version: 13.1.3
       unthrown:
         specifier: 'catalog:'
-        version: 5.0.0-beta.6
+        version: 5.0.0-beta.7
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -316,7 +316,7 @@ importers:
         version: 13.1.3
       unthrown:
         specifier: 'catalog:'
-        version: 5.0.0-beta.6
+        version: 5.0.0-beta.7
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -439,7 +439,7 @@ importers:
         version: 26.1.1
       '@unthrown/vitest':
         specifier: 'catalog:'
-        version: 5.0.0-beta.6(unthrown@5.0.0-beta.6)(vitest@4.1.10)
+        version: 5.0.0-beta.7(unthrown@5.0.0-beta.7)(vitest@4.1.10)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.10(vitest@4.1.10)
@@ -466,7 +466,7 @@ importers:
         version: 6.0.3
       unthrown:
         specifier: 'catalog:'
-        version: 5.0.0-beta.6
+        version: 5.0.0-beta.7
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
@@ -549,7 +549,7 @@ importers:
         version: 26.1.1
       '@unthrown/vitest':
         specifier: 'catalog:'
-        version: 5.0.0-beta.6(unthrown@5.0.0-beta.6)(vitest@4.1.10)
+        version: 5.0.0-beta.7(unthrown@5.0.0-beta.7)(vitest@4.1.10)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.10(vitest@4.1.10)
@@ -567,7 +567,7 @@ importers:
         version: 6.0.3
       unthrown:
         specifier: 'catalog:'
-        version: 5.0.0-beta.6
+        version: 5.0.0-beta.7
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
@@ -644,7 +644,7 @@ importers:
         version: 26.1.1
       '@unthrown/vitest':
         specifier: 'catalog:'
-        version: 5.0.0-beta.6(unthrown@5.0.0-beta.6)(vitest@4.1.10)
+        version: 5.0.0-beta.7(unthrown@5.0.0-beta.7)(vitest@4.1.10)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.10(vitest@4.1.10)
@@ -671,7 +671,7 @@ importers:
         version: 6.0.3
       unthrown:
         specifier: 'catalog:'
-        version: 5.0.0-beta.6
+        version: 5.0.0-beta.7
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
@@ -698,7 +698,7 @@ importers:
         version: link:../packages/worker
       unthrown:
         specifier: 'catalog:'
-        version: 5.0.0-beta.6
+        version: 5.0.0-beta.7
     devDependencies:
       '@btravstack/tsconfig':
         specifier: 'catalog:'
@@ -2669,11 +2669,11 @@ packages:
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
-  '@unthrown/vitest@5.0.0-beta.6':
-    resolution: {integrity: sha512-FOByiJWRrqYYjP4Jtc1yz2KbR+R/Ra4xgKUJ3hbo5UzGxl4ngIEaYWA0WhQB4oNAgr9B0c7ZR6PC+D2dBlyYCQ==}
+  '@unthrown/vitest@5.0.0-beta.7':
+    resolution: {integrity: sha512-CXT3DwFc8b9Vj/NSF/0Tc7xlDi5syK9+2vVYWSf0U2lmt/Om2z7olP21e67mnvXVmdzEQ8+1RNSGSqRwCtPUOg==}
     engines: {node: '>=20'}
     peerDependencies:
-      unthrown: ^5.0.0-beta.6
+      unthrown: ^5.0.0-beta.7
       vitest: ^4
 
   '@upsetjs/venn.js@2.0.0':
@@ -5285,8 +5285,8 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
-  unthrown@5.0.0-beta.6:
-    resolution: {integrity: sha512-9100slIHO94qvPtCT9ISBpEXGOU8QN2amMtLCNBy6cVtGJQe7fwZHkSHsjPuNeqQGO/2MLFqRBJwSimAnceloA==}
+  unthrown@5.0.0-beta.7:
+    resolution: {integrity: sha512-/eLkvTAg21BwtCQydLLok2lWYTn0CwvU/QSxJ7ugacszL3GOjZEh/rvimAjlz5B7D47u3A55ZLykX06Zyp9TCg==}
     engines: {node: '>=20'}
 
   urijs@1.19.11:
@@ -7407,9 +7407,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@unthrown/vitest@5.0.0-beta.6(unthrown@5.0.0-beta.6)(vitest@4.1.10)':
+  '@unthrown/vitest@5.0.0-beta.7(unthrown@5.0.0-beta.7)(vitest@4.1.10)':
     dependencies:
-      unthrown: 5.0.0-beta.6
+      unthrown: 5.0.0-beta.7
       vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@upsetjs/venn.js@2.0.0':
@@ -10293,7 +10293,7 @@ snapshots:
 
   universalify@0.1.2: {}
 
-  unthrown@5.0.0-beta.6: {}
+  unthrown@5.0.0-beta.7: {}
 
   urijs@1.19.11: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,7 +28,7 @@ catalog:
   "@orpc/zod": 1.14.8
   "@standard-schema/spec": 1.1.0
   "@types/node": 26.1.1
-  "@unthrown/vitest": 5.0.0-beta.6
+  "@unthrown/vitest": 5.0.0-beta.7
   "@vitest/coverage-v8": 4.1.10
   amqp-connection-manager: 5.0.0
   amqplib: 2.0.1
@@ -48,7 +48,7 @@ catalog:
   typedoc: 0.28.20
   typedoc-plugin-markdown: 4.12.0
   typescript: 6.0.3
-  unthrown: 5.0.0-beta.6
+  unthrown: 5.0.0-beta.7
   valibot: 1.4.2
   vitepress: 1.6.4
   vitepress-plugin-mermaid: 2.0.17


### PR DESCRIPTION
## What

`unthrown` and `@unthrown/vitest` `5.0.0-beta.6` → `5.0.0-beta.7` (catalog), and the peer range on `client` / `core` / `worker` raised to `^5.0.0-beta.7`.

Note that npm's `latest` tag for `unthrown` is `4.3.0` — this repo tracks the v5 beta line, so `beta` (`5.0.0-beta.7`) is the upgrade target. `4.3.0` would be a downgrade.

## Upstream changes

Neither touches amqp-contract's own surface.

**`returnType<R>()` on the built-in matcher.** Pins a match's output type so every branch is checked against it, instead of the result widening to the union of branch returns. It reaches every surface that hands out a matcher — `match`'s `errCases` handler and the five `*ErrCases` combinators — so it is available on any amqp-contract result, but nothing here requires it.

**`tapErrCases` no longer silently drops a `defect(…)` branch.** It now produces a `Defect` carrying an `AggregateError` of `[branch cause, observed error]`, matching what a `throw` in the same position already did.

That second one is the only behavioural change, so I grepped for call sites before upgrading: **this codebase has none** — `tapErrCases` appears only in CHANGELOGs and one migration table in the docs. Nothing here changed. Consumers who *were* relying on that branch being dropped will now see a `Defect` surface where the pipeline previously carried on with the original `Err`; the changeset says so.

## Why raise the peer floor

`^5.0.0-beta.6` would already have admitted `beta.7`, so this is a deliberate choice rather than a necessity. Behaviour has shifted between betas on this line, and the point of the peer dependency is that consumers resolve the *same* copy these packages were built and tested against. It also matches how the beta.5 and beta.6 bumps were handled.

## Verification

Everything below was run, not inferred:

- **258 unit tests** pass.
- **59 integration tests** pass — Docker was available, so the suite genuinely ran against a real broker rather than being skipped.
- `pnpm build`, `typecheck`, `lint`, `knip`, `check:packages`, and the docs build all clean.
- `pnpm why unthrown -r` reports **"Found 1 version"** — a single shared copy, which is the peer-dependency invariant. (Two directories linger under `node_modules/.pnpm`; that is stale store content, not a live resolution.)

## Not changed

No docs update. `docs/how-to/upgrade.md` tells consumers `pnpm add unthrown@^5`, which stays correct, and pinning beta-specific floors into a user-facing upgrade guide would be wrong at 3.0 GA. The changeset carries the detail into the release notes, matching how beta.5 and beta.6 were handled.

I also did not document `returnType<R>()` in these docs — it is an `unthrown` matcher feature, and duplicating upstream API docs here would just create another thing to keep in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)