### PR TITLE
feat(contract)!: reject publishers that can reach no queue

### DIFF
--- a/.changeset/routable-routing-key-type.md
+++ b/.changeset/routable-routing-key-type.md
@@ -1,0 +1,16 @@
+---
+"@amqp-contract/contract": minor
+---
+
+Add the `RoutableRoutingKey<Key, Patterns>` type. It resolves to `Key` when the
+routing key matches at least one of the declared binding patterns and to a
+readable `` `Error: routing key '…' matches none of the declared binding
+patterns; …` `` string type otherwise — the same convention as
+`MatchingBindingPattern`. Non-literal inputs and an empty pattern union skip the
+check and resolve to `Key`, so nothing valid is ever rejected at compile time.
+
+The type is exported for direct use; `defineContract`'s signature is
+deliberately not constrained by it (binding patterns are widened to `string` by
+the time they reach `defineContract`, so the constraint would be a no-op). The
+define-time check added in the same release covers the full binding graph at
+runtime.

--- a/.changeset/routable-routing-key-type.md
+++ b/.changeset/routable-routing-key-type.md
@@ -7,7 +7,12 @@ routing key matches at least one of the declared binding patterns and to a
 readable `` `Error: routing key '…' matches none of the declared binding
 patterns; …` `` string type otherwise — the same convention as
 `MatchingBindingPattern`. Non-literal inputs and an empty pattern union skip the
-check and resolve to `Key`, so nothing valid is ever rejected at compile time.
+check and resolve to `Key`.
+
+Matching is over literal segments only: a pattern built from a template literal
+(`` `order.${string}` ``) is not recognised as matching, so a key it would
+accept at runtime still resolves to the error string. Use concrete literal
+patterns, or leave the key unconstrained and rely on the define-time check.
 
 The type is exported for direct use; `defineContract`'s signature is
 deliberately not constrained by it (binding patterns are widened to `string` by

--- a/.changeset/unroutable-publisher-define-time.md
+++ b/.changeset/unroutable-publisher-define-time.md
@@ -6,4 +6,5 @@
 RabbitMQ confirms an unroutable message and then discards it, so a mistyped
 binding pattern silently dropped every message while `publish()` returned
 `Ok`. Publishers whose consumers live in another service opt out with
-`externalConsumers: true`.
+`externalConsumers: true`, accepted by `definePublisher`,
+`defineEventPublisher`, and `defineCommandPublisher` alike.

--- a/.changeset/unroutable-publisher-define-time.md
+++ b/.changeset/unroutable-publisher-define-time.md
@@ -7,4 +7,10 @@ RabbitMQ confirms an unroutable message and then discards it, so a mistyped
 binding pattern silently dropped every message while `publish()` returned
 `Ok`. Publishers whose consumers live in another service opt out with
 `externalConsumers: true`, accepted by `definePublisher`,
-`defineEventPublisher`, and `defineCommandPublisher` alike.
+`defineEventPublisher`, and `defineCommandPublisher` alike. An exchange
+declaring an `alternate-exchange` argument is always routable — the broker
+catches its unmatched keys.
+
+The check runs on the bindings passed to `defineContract`: mutating
+`contract.bindings` afterwards no longer makes a publisher routable, since the
+verdict was already reached. Declare every binding in the `defineContract` call.

--- a/.changeset/unroutable-publisher-define-time.md
+++ b/.changeset/unroutable-publisher-define-time.md
@@ -1,0 +1,9 @@
+---
+"@amqp-contract/contract": major
+---
+
+`defineContract` now throws when a publisher's routing key reaches no queue.
+RabbitMQ confirms an unroutable message and then discards it, so a mistyped
+binding pattern silently dropped every message while `publish()` returned
+`Ok`. Publishers whose consumers live in another service opt out with
+`externalConsumers: true`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ Each invariant maps to a named guarding test — extend the mapping when you add
 16. **Telemetry never throws into the data path** (a buggy provider degrades to "no telemetry") — `packages/core/src/telemetry.spec.ts` ("throwing telemetry providers") + `packages/client/src/interceptors.spec.ts` (sync-throwing interceptor → Defect).
 17. **A short-delay ttl-backoff retry is never blocked by a long-delay retry parked ahead of it** (per-delay-tier wait queues; RabbitMQ only expires at the queue head) — `packages/worker/src/__tests__/worker-retry-head-of-line.spec.ts`.
 18. **`defineContract`'s runtime output has exactly the keys `ContractOutput` types** (no runtime-injected topology invisible to the type level) — `packages/contract/src/contract-output-parity.spec.ts`.
+19. **A publisher whose routing key reaches no queue is rejected at define time** (RabbitMQ confirms an unroutable message and discards it, so the runtime signal is indistinguishable from success) — `tests/src/unroutable-publish.spec.ts` (the paired prove-the-loss / prove-the-guard tests) + `packages/contract/src/builder/routability-define-time.spec.ts`.
 
 ## Workflow rules for agents
 

--- a/docs/how-to/define-a-contract.md
+++ b/docs/how-to/define-a-contract.md
@@ -197,6 +197,21 @@ Keys are dot-separated segments of alphanumerics, hyphens and underscores. The `
 
 TypeScript's recursion limit means very long keys fall back to `string`. That affects compile-time checking only, never runtime behaviour.
 
+## Publish to a consumer you do not own
+
+`defineContract` throws if a publisher's routing key reaches no queue in the contract. The broker would confirm those messages and then discard them, so the failure has to surface here — at runtime it looks like success.
+
+A publish-only service has no local queue by design. Say so:
+
+```typescript
+const orderCreated = definePublisher(orders, orderMessage, {
+  routingKey: "order.created",
+  externalConsumers: true,
+});
+```
+
+Reach for it only when another service really does own the binding. If the consumer is in this contract and the check still fires, the routing key and the binding pattern have drifted — fix the mismatch instead. See [troubleshoot](/how-to/troubleshoot#publisher-is-unroutable-at-define-time).
+
 ## Share a contract between services
 
 Put the contract in its own package that both the publishing and consuming services depend on:

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -123,7 +123,7 @@ Work down this list in order.
 
 **Is the consumer running?** A queue with no consumer accumulates messages. `rabbitmqctl list_queues name messages consumers`.
 
-**Is the queue bound?** In the management UI, open the queue and check its bindings. No binding means the exchange has nowhere to route to, and RabbitMQ drops unroutable messages silently.
+**Is the queue bound?** In the management UI, open the queue and check its bindings. No binding means the exchange has nowhere to route to, and RabbitMQ drops unroutable messages silently. If the binding is missing from the contract itself, `defineContract` says so — see below.
 
 **Do the routing keys match?** `order.*` matches `order.created` but _not_ `order.created.urgent` — `*` is exactly one segment, `#` is zero or more. This is the single most common cause.
 
@@ -132,6 +132,31 @@ Work down this list in order.
 **Are two consumers sharing a queue?** Then they compete, and each message goes to one of them. For broadcast, give each consumer its own queue.
 
 **Did you publish before the consumer existed?** In tests especially — `initConsumer` must be awaited before publishing, or the message is routed nowhere. See [test with RabbitMQ](/how-to/test-with-rabbitmq#assert-on-raw-messages).
+
+### `Publisher is unroutable` at define time
+
+`defineContract` throws `Publisher "orderCreated" is unroutable` when a publisher's routing key reaches no queue anywhere in the contract's binding graph — directly, or through exchange-to-exchange forwards. The error names the key, the exchange it stopped on, and the patterns actually declared there.
+
+This is a define-time error precisely because it cannot be caught at runtime. A publisher confirm means "the broker took responsibility", not "a queue received it": RabbitMQ confirms a message that matched no binding and then discards it, so `publish()` returns `Ok` while every message is lost. Nothing downstream ever reports the loss.
+
+Two remedies, and they are not interchangeable:
+
+**Add a binding that matches.** Correct when this contract owns the consumer. Usually the routing key and the binding pattern have drifted apart — `order.*` does not match `order.created.urgent`. Fix whichever one is wrong.
+
+**Set `externalConsumers: true` on the publisher.** Correct when the binding genuinely lives elsewhere: another service owns the queue, or you publish into a shared exchange whose topology you do not declare. It is an assertion that the loss is somebody else's contract to guarantee, so use it only when that is true — it disables the check for that publisher permanently.
+
+```typescript
+const orderCreated = definePublisher(orders, orderMessage, {
+  routingKey: "order.created",
+  externalConsumers: true,
+});
+```
+
+Accepted by `definePublisher`, `defineEventPublisher` and `defineCommandPublisher` alike.
+
+An exchange declaring an `alternate-exchange` argument never triggers this — the broker routes its unmatched messages there instead of discarding them, so no key on it is unroutable.
+
+The check reads the bindings passed to `defineContract`. Mutating `contract.bindings` after it returns does not re-run it; declare every binding in the call.
 
 ## Topology conflicts
 

--- a/docs/reference/topology-options.md
+++ b/docs/reference/topology-options.md
@@ -159,6 +159,8 @@ With no `headers` schema, a handler's `headers` is `undefined`.
 
 `defineEventPublisher` adds compile-time routing-key validation and is what event consumers attach to. `defineCommandPublisher` derives everything from the command consumer.
 
+All three also accept `externalConsumers?: boolean`. `defineContract` throws when a publisher's routing key reaches no queue in the contract's binding graph — the broker would confirm those messages and discard them. Set it to `true` when another service owns the binding. An exchange declaring `alternate-exchange` is exempt. See [troubleshoot](/how-to/troubleshoot#publisher-is-unroutable-at-define-time).
+
 There is no per-call routing-key override — `publish` always uses the publisher's key.
 
 ## Consumers

--- a/docs/superpowers/plans/2026-08-01-h1-unroutable-publish.md
+++ b/docs/superpowers/plans/2026-08-01-h1-unroutable-publish.md
@@ -1,0 +1,1276 @@
+# H1 — Unroutable Publish Detection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make it impossible to ship a contract whose publisher routes to nowhere, and make a runtime-unroutable publish a modeled error instead of a silent `Ok`.
+
+**Architecture:** A pure runtime topic matcher feeds a routability resolver that walks the contract's binding graph (queue bindings plus exchange-to-exchange forwards, with cycle detection). `defineContract` calls the resolver and throws for unroutable publishers (rung 2). A parallel type-level check rejects the single-hop case at compile time with a readable error-message type (rung 1). Rung 3 (broker-level `mandatory` + `basic.return`) is gated behind a spike because the correlation mechanism is unproven.
+
+**Tech Stack:** TypeScript ESM, vitest (+ `expectTypeOf` for type tests), fast-check for property tests, testcontainers RabbitMQ for real-broker proofs.
+
+**Source spec:** `docs/superpowers/specs/2026-08-01-robustness-hardening-design.md`
+
+## Global Constraints
+
+- No `any` — use `unknown` and narrow. Enforced by oxlint.
+- Type aliases over interfaces (`type Foo = {}`).
+- `.js` extensions required in all imports (ESM).
+- Internal cross-module helpers use the `_internal_` prefix (no semver guarantee), matching `packages/contract/src/builder/validate.ts`.
+- Define-time failures `throw` and need `// oxlint-disable-next-line unthrown/no-throw -- fail-fast declaration-time config error` above them.
+- Conventional commits (`feat`, `fix`, `test`, `docs`, `refactor`, `chore`). Enforced by commitlint.
+- Dependencies go through `pnpm-workspace.yaml` catalog — never hardcode a version in a `package.json`.
+- Public API changes need a changeset (`pnpm changeset`). The six publishable packages bump together.
+- Run `pnpm typecheck` before declaring a task done; it is not in the pre-commit hook.
+- This work lands **before** 3.0 stable ships. Breaking changes are expected and desired.
+
+## Design decisions locked in during planning
+
+Two refinements to the spec, both discovered by reading the type definitions:
+
+1. **Routability is a graph, not a single hop.** `ExchangeBindingDefinition` lets an exchange forward to another exchange (`defineBridgedPublisher`). A publisher is routable if any path from its exchange reaches a queue binding. A single-hop check would falsely reject every bridged contract.
+
+2. **Publish-only contracts are legitimate.** A service publishing to an exchange whose consumers deploy separately has zero bindings in its own contract. Throwing on those would break a valid, common pattern. Per the spec's fail-fast-with-explicit-opt-out policy, this requires an explicit marker on the publisher: `externalConsumers: true`. No heuristic — a heuristic would silently miss the typo case this whole feature exists to catch.
+
+---
+
+## File Structure
+
+| File                                                         | Responsibility                                                       |
+| ------------------------------------------------------------ | -------------------------------------------------------------------- |
+| `packages/contract/src/builder/topic-match.ts` (create)      | Pure runtime AMQP topic-pattern matching. No deps.                   |
+| `packages/contract/src/builder/topic-match.spec.ts` (create) | Unit + property tests for the matcher.                               |
+| `packages/contract/src/builder/routability.ts` (create)      | Binding-graph traversal; decides if a publisher can reach a queue.   |
+| `packages/contract/src/builder/routability.spec.ts` (create) | Unit tests for the resolver, including bridges and cycles.           |
+| `packages/contract/src/builder/validate.ts` (modify)         | Add `_internal_assertPublisherRoutable`.                             |
+| `packages/contract/src/builder/contract.ts` (modify)         | Call the assertion for every publisher after bindings are collected. |
+| `packages/contract/src/builder/publisher.ts` (modify)        | Accept and carry `externalConsumers`.                                |
+| `packages/contract/src/types.ts` (modify)                    | Add `externalConsumers?: boolean` to `PublisherDefinition`.          |
+| `packages/contract/src/builder/routing-types.ts` (modify)    | Add the rung-1 type-level routability check.                         |
+| `packages/contract/src/routability.test-d.ts` (create)       | Type-level tests + the shared corpus asserted at type level.         |
+| `packages/contract/src/builder/match-corpus.ts` (create)     | Shared key/pattern corpus used by both runtime and type-level tests. |
+| `tests/src/unroutable-publish.spec.ts` (create)              | Real-broker prove-the-loss / prove-the-guard tests.                  |
+
+---
+
+### Task 1: Runtime topic matcher
+
+**Files:**
+
+- Create: `packages/contract/src/builder/topic-match.ts`
+- Create: `packages/contract/src/builder/match-corpus.ts`
+- Test: `packages/contract/src/builder/topic-match.spec.ts`
+- Modify: `pnpm-workspace.yaml` (add `fast-check` to catalog)
+- Modify: `packages/contract/package.json` (add `fast-check` devDependency)
+
+**Interfaces:**
+
+- Produces: `_internal_matchesTopicPattern(routingKey: string, pattern: string): boolean`
+- Produces: `MATCH_CORPUS: readonly { key: string; pattern: string; matches: boolean }[]`
+
+- [ ] **Step 1: Add fast-check to the catalog**
+
+In `pnpm-workspace.yaml`, add to the `catalog:` block (alphabetical position):
+
+```yaml
+fast-check: ^4.3.0
+```
+
+In `packages/contract/package.json` `devDependencies`, add (alphabetical):
+
+```json
+    "fast-check": "catalog:",
+```
+
+Then run:
+
+```bash
+pnpm install
+```
+
+- [ ] **Step 2: Write the shared corpus**
+
+Create `packages/contract/src/builder/match-corpus.ts`:
+
+```ts
+/**
+ * Shared routing-key/pattern corpus.
+ *
+ * Asserted twice — once against the runtime matcher
+ * (`topic-match.spec.ts`) and once against the type-level matcher
+ * (`routability.test-d.ts`). That double assertion is what pins the
+ * spec's invariant that the two implementations agree; if they ever
+ * diverge, one of the two suites fails.
+ *
+ * @internal
+ */
+export const MATCH_CORPUS = [
+  // Exact matches, no wildcards.
+  { key: "order.created", pattern: "order.created", matches: true },
+  { key: "order.created", pattern: "order.updated", matches: false },
+  { key: "order", pattern: "order", matches: true },
+
+  // '*' matches exactly one word.
+  { key: "order.created", pattern: "order.*", matches: true },
+  { key: "order.created.v2", pattern: "order.*", matches: false },
+  { key: "order.created", pattern: "*.created", matches: true },
+  { key: "order.created", pattern: "*.*", matches: true },
+  { key: "order", pattern: "*", matches: true },
+  { key: "order.created", pattern: "*", matches: false },
+
+  // '#' matches zero or more words.
+  { key: "order.created", pattern: "#", matches: true },
+  { key: "order", pattern: "#", matches: true },
+  { key: "order.created", pattern: "order.#", matches: true },
+  { key: "order", pattern: "order.#", matches: true },
+  { key: "order.created.v2", pattern: "order.#", matches: true },
+  { key: "order.created", pattern: "#.created", matches: true },
+  { key: "created", pattern: "#.created", matches: true },
+  { key: "order.created.v2", pattern: "order.#.v2", matches: true },
+  { key: "order.v2", pattern: "order.#.v2", matches: true },
+  { key: "order.a.b.v2", pattern: "order.#.v2", matches: true },
+  { key: "order.created", pattern: "order.#.v2", matches: false },
+
+  // Mixed wildcards.
+  { key: "order.created.v2", pattern: "order.*.#", matches: true },
+  { key: "order.created", pattern: "order.*.#", matches: true },
+  { key: "order", pattern: "order.*.#", matches: false },
+
+  // Non-matches that must not accidentally pass.
+  { key: "user.created", pattern: "order.#", matches: false },
+  { key: "order.created", pattern: "order.created.v2", matches: false },
+] as const satisfies readonly { key: string; pattern: string; matches: boolean }[];
+```
+
+- [ ] **Step 3: Write the failing test**
+
+Create `packages/contract/src/builder/topic-match.spec.ts`:
+
+```ts
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+
+import { MATCH_CORPUS } from "./match-corpus.js";
+import { _internal_matchesTopicPattern } from "./topic-match.js";
+
+describe("_internal_matchesTopicPattern", () => {
+  describe("shared corpus", () => {
+    for (const { key, pattern, matches } of MATCH_CORPUS) {
+      it(`${matches ? "matches" : "does not match"} key "${key}" against pattern "${pattern}"`, () => {
+        expect(_internal_matchesTopicPattern(key, pattern)).toBe(matches);
+      });
+    }
+  });
+
+  describe("properties", () => {
+    // Words are non-empty, wildcard-free AMQP-ish tokens.
+    const word = fc.stringMatching(/^[a-z0-9_-]{1,6}$/);
+    const key = fc.array(word, { minLength: 1, maxLength: 4 }).map((w) => w.join("."));
+
+    it("a wildcard-free pattern matches exactly its own key", () => {
+      fc.assert(
+        fc.property(key, (k) => {
+          expect(_internal_matchesTopicPattern(k, k)).toBe(true);
+        }),
+      );
+    });
+
+    it("'#' alone matches every key", () => {
+      fc.assert(
+        fc.property(key, (k) => {
+          expect(_internal_matchesTopicPattern(k, "#")).toBe(true);
+        }),
+      );
+    });
+
+    it("an all-'*' pattern matches iff the word counts are equal", () => {
+      fc.assert(
+        fc.property(key, fc.integer({ min: 1, max: 6 }), (k, starCount) => {
+          const pattern = Array.from({ length: starCount }, () => "*").join(".");
+          const expected = k.split(".").length === starCount;
+          expect(_internal_matchesTopicPattern(k, pattern)).toBe(expected);
+        }),
+      );
+    });
+
+    it("appending '.#' to a matching pattern keeps it matching", () => {
+      fc.assert(
+        fc.property(key, (k) => {
+          expect(_internal_matchesTopicPattern(k, `${k}.#`)).toBe(true);
+        }),
+      );
+    });
+
+    it("is deterministic", () => {
+      fc.assert(
+        fc.property(key, key, (k, p) => {
+          expect(_internal_matchesTopicPattern(k, p)).toBe(_internal_matchesTopicPattern(k, p));
+        }),
+      );
+    });
+  });
+});
+```
+
+- [ ] **Step 4: Run the test to verify it fails**
+
+```bash
+cd packages/contract && pnpm vitest run src/builder/topic-match.spec.ts
+```
+
+Expected: FAIL — cannot resolve `./topic-match.js`.
+
+- [ ] **Step 5: Implement the matcher**
+
+Create `packages/contract/src/builder/topic-match.ts`:
+
+```ts
+/**
+ * Runtime AMQP topic-pattern matching.
+ *
+ * Mirrors the compile-time `MatchesPattern` in `routing-types.ts`. The two
+ * must agree on every input — `match-corpus.ts` is asserted against both,
+ * and a divergence fails one of the two suites.
+ *
+ * AMQP semantics:
+ * - a routing key is dot-separated words
+ * - `*` matches exactly one word
+ * - `#` matches zero or more words
+ *
+ * @internal
+ */
+
+/**
+ * Backtracking match of `key[ki..]` against `pattern[pi..]`.
+ *
+ * `#` needs backtracking rather than a greedy consume: `order.#.v2` against
+ * `order.a.b.v2` only matches if `#` gives back the trailing `v2`.
+ */
+function matchFrom(
+  key: readonly string[],
+  ki: number,
+  pattern: readonly string[],
+  pi: number,
+): boolean {
+  if (pi === pattern.length) {
+    return ki === key.length;
+  }
+
+  const token = pattern[pi];
+
+  if (token === "#") {
+    // Try every number of words '#' could absorb, shortest first.
+    for (let skip = 0; ki + skip <= key.length; skip += 1) {
+      if (matchFrom(key, ki + skip, pattern, pi + 1)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  if (ki === key.length) {
+    return false;
+  }
+
+  if (token === "*" || token === key[ki]) {
+    return matchFrom(key, ki + 1, pattern, pi + 1);
+  }
+
+  return false;
+}
+
+/**
+ * True when `routingKey` is delivered by a binding declared with `pattern`.
+ *
+ * @param routingKey - Concrete routing key (no wildcards)
+ * @param pattern - Binding pattern (may contain `*` and `#`)
+ * @internal
+ */
+export function _internal_matchesTopicPattern(routingKey: string, pattern: string): boolean {
+  const keyWords = routingKey === "" ? [] : routingKey.split(".");
+  const patternWords = pattern === "" ? [] : pattern.split(".");
+  return matchFrom(keyWords, 0, patternWords, 0);
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+```bash
+cd packages/contract && pnpm vitest run src/builder/topic-match.spec.ts
+```
+
+Expected: PASS, all corpus cases and all 5 properties.
+
+- [ ] **Step 7: Typecheck and lint**
+
+```bash
+cd /Users/btravers/Projects/btravstack/amqp-contract
+pnpm typecheck && pnpm lint
+```
+
+Expected: both clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add pnpm-workspace.yaml pnpm-lock.yaml packages/contract/package.json \
+  packages/contract/src/builder/topic-match.ts \
+  packages/contract/src/builder/match-corpus.ts \
+  packages/contract/src/builder/topic-match.spec.ts
+git commit -m "feat(contract): add a runtime AMQP topic-pattern matcher
+
+Mirrors the compile-time MatchesPattern. The shared corpus is asserted
+against both implementations so they cannot silently diverge."
+```
+
+---
+
+### Task 2: Routability resolver
+
+**Files:**
+
+- Create: `packages/contract/src/builder/routability.ts`
+- Test: `packages/contract/src/builder/routability.spec.ts`
+
+**Interfaces:**
+
+- Consumes: `_internal_matchesTopicPattern` from Task 1
+- Produces: `_internal_isPublisherRoutable(exchange: ExchangeDefinition, routingKey: string | undefined, bindings: readonly BindingDefinition[]): boolean`
+- Produces: `_internal_declaredPatternsFor(exchangeName: string, bindings: readonly BindingDefinition[]): readonly string[]`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/contract/src/builder/routability.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import type { BindingDefinition, ExchangeDefinition } from "../types.js";
+import { defineExchange } from "./exchange.js";
+import { defineQueue } from "./queue.js";
+import { _internal_declaredPatternsFor, _internal_isPublisherRoutable } from "./routability.js";
+
+const ordersTopic = defineExchange("orders", { type: "topic" });
+const ordersDirect = defineExchange("orders-direct", { type: "direct" });
+const broadcast = defineExchange("broadcast", { type: "fanout" });
+const billing = defineExchange("billing", { type: "topic" });
+const q = defineQueue("audit-log");
+
+// Widened to ExchangeDefinition so topic exchanges with different name
+// literals (`orders`, `billing`) share one helper.
+function queueBinding(exchange: ExchangeDefinition, routingKey: string): BindingDefinition {
+  return { type: "queue", queue: q, exchange, routingKey } as BindingDefinition;
+}
+
+describe("_internal_isPublisherRoutable", () => {
+  it("is routable when a topic queue binding matches the key", () => {
+    const bindings = [queueBinding(ordersTopic, "order.#")];
+    expect(_internal_isPublisherRoutable(ordersTopic, "order.created", bindings)).toBe(true);
+  });
+
+  it("is NOT routable when no topic binding matches the key", () => {
+    const bindings = [queueBinding(ordersTopic, "user.#")];
+    expect(_internal_isPublisherRoutable(ordersTopic, "order.created", bindings)).toBe(false);
+  });
+
+  it("is NOT routable when there are no bindings at all", () => {
+    expect(_internal_isPublisherRoutable(ordersTopic, "order.created", [])).toBe(false);
+  });
+
+  it("requires exact equality on a direct exchange", () => {
+    const bindings = [
+      { type: "queue", queue: q, exchange: ordersDirect, routingKey: "order.created" },
+    ] as BindingDefinition[];
+    expect(_internal_isPublisherRoutable(ordersDirect, "order.created", bindings)).toBe(true);
+    expect(_internal_isPublisherRoutable(ordersDirect, "order.*", bindings)).toBe(false);
+  });
+
+  it("treats any binding on a fanout exchange as routable", () => {
+    const bindings = [{ type: "queue", queue: q, exchange: broadcast }] as BindingDefinition[];
+    expect(_internal_isPublisherRoutable(broadcast, undefined, bindings)).toBe(true);
+  });
+
+  it("is NOT routable on a fanout exchange with no bindings", () => {
+    expect(_internal_isPublisherRoutable(broadcast, undefined, [])).toBe(false);
+  });
+
+  it("follows an exchange-to-exchange forward to a queue (bridged publisher)", () => {
+    // orders --order.#--> billing --#--> queue
+    const bindings = [
+      { type: "exchange", source: ordersTopic, destination: billing, routingKey: "order.#" },
+      { type: "queue", queue: q, exchange: billing, routingKey: "#" },
+    ] as BindingDefinition[];
+    expect(_internal_isPublisherRoutable(ordersTopic, "order.created", bindings)).toBe(true);
+  });
+
+  it("is NOT routable when the forward exists but the destination has no matching queue", () => {
+    const bindings = [
+      { type: "exchange", source: ordersTopic, destination: billing, routingKey: "order.#" },
+      { type: "queue", queue: q, exchange: billing, routingKey: "user.#" },
+    ] as BindingDefinition[];
+    expect(_internal_isPublisherRoutable(ordersTopic, "order.created", bindings)).toBe(false);
+  });
+
+  it("terminates on a cyclic exchange graph", () => {
+    // orders -> billing -> orders, with no queue anywhere.
+    const bindings = [
+      { type: "exchange", source: ordersTopic, destination: billing, routingKey: "#" },
+      { type: "exchange", source: billing, destination: ordersTopic, routingKey: "#" },
+    ] as BindingDefinition[];
+    expect(_internal_isPublisherRoutable(ordersTopic, "order.created", bindings)).toBe(false);
+  });
+});
+
+describe("_internal_declaredPatternsFor", () => {
+  it("lists the patterns declared on an exchange, for the error message", () => {
+    const bindings = [
+      queueBinding(ordersTopic, "user.#"),
+      queueBinding(ordersTopic, "audit.*"),
+      queueBinding(billing, "order.#"),
+    ];
+    expect(_internal_declaredPatternsFor("orders", bindings)).toEqual(["user.#", "audit.*"]);
+  });
+
+  it("returns an empty list when nothing is declared on the exchange", () => {
+    expect(_internal_declaredPatternsFor("orders", [])).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd packages/contract && pnpm vitest run src/builder/routability.spec.ts
+```
+
+Expected: FAIL — cannot resolve `./routability.js`.
+
+- [ ] **Step 3: Implement the resolver**
+
+Create `packages/contract/src/builder/routability.ts`:
+
+```ts
+import type { BindingDefinition, ExchangeDefinition } from "../types.js";
+import { _internal_matchesTopicPattern } from "./topic-match.js";
+
+/**
+ * Decides whether a publisher can reach at least one queue.
+ *
+ * Routability is a graph problem, not a single-hop lookup: an exchange can
+ * forward to another exchange (`defineBridgedPublisher`), so the publisher's
+ * message may reach a queue several hops away. A single-hop check would
+ * falsely reject every bridged contract.
+ *
+ * @internal
+ */
+
+/** True when a binding declared on `exchange` accepts `routingKey`. */
+function bindingAccepts(
+  exchange: ExchangeDefinition,
+  routingKey: string | undefined,
+  bindingRoutingKey: string | undefined,
+): boolean {
+  switch (exchange.type) {
+    case "fanout":
+      // The broker ignores the routing key entirely: any binding routes.
+      return true;
+    case "headers":
+      // Matching is on the binding's arguments, which cannot be decided
+      // against a routing key. Treat any binding as potentially routable
+      // rather than raising a false alarm.
+      return true;
+    case "direct":
+      return routingKey !== undefined && routingKey === bindingRoutingKey;
+    case "topic":
+      return (
+        routingKey !== undefined &&
+        bindingRoutingKey !== undefined &&
+        _internal_matchesTopicPattern(routingKey, bindingRoutingKey)
+      );
+  }
+}
+
+/**
+ * True when a message published to `exchange` with `routingKey` reaches at
+ * least one queue, directly or through exchange-to-exchange forwards.
+ *
+ * @internal
+ */
+export function _internal_isPublisherRoutable(
+  exchange: ExchangeDefinition,
+  routingKey: string | undefined,
+  bindings: readonly BindingDefinition[],
+): boolean {
+  // Cycle guard: exchange graphs may contain loops, and the routing key is
+  // preserved across forwards, so the exchange name alone identifies a state.
+  const visited = new Set<string>();
+  const queue: ExchangeDefinition[] = [exchange];
+
+  while (queue.length > 0) {
+    const current = queue.shift() as ExchangeDefinition;
+    if (visited.has(current.name)) {
+      continue;
+    }
+    visited.add(current.name);
+
+    for (const binding of bindings) {
+      if (binding.type === "queue") {
+        if (binding.exchange.name !== current.name) continue;
+        const bindingKey = "routingKey" in binding ? binding.routingKey : undefined;
+        if (bindingAccepts(current, routingKey, bindingKey)) {
+          return true;
+        }
+        continue;
+      }
+
+      if (binding.source.name !== current.name) continue;
+      const bindingKey = "routingKey" in binding ? binding.routingKey : undefined;
+      if (bindingAccepts(current, routingKey, bindingKey)) {
+        queue.push(binding.destination);
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * The routing patterns declared on an exchange, in declaration order — used
+ * to make the define-time error actionable by showing what *is* declared.
+ *
+ * @internal
+ */
+export function _internal_declaredPatternsFor(
+  exchangeName: string,
+  bindings: readonly BindingDefinition[],
+): readonly string[] {
+  const patterns: string[] = [];
+  for (const binding of bindings) {
+    const source = binding.type === "queue" ? binding.exchange : binding.source;
+    if (source.name !== exchangeName) continue;
+    if ("routingKey" in binding && typeof binding.routingKey === "string") {
+      patterns.push(binding.routingKey);
+    }
+  }
+  return patterns;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd packages/contract && pnpm vitest run src/builder/routability.spec.ts
+```
+
+Expected: PASS, 11 tests.
+
+- [ ] **Step 5: Typecheck and lint**
+
+```bash
+cd /Users/btravers/Projects/btravstack/amqp-contract && pnpm typecheck && pnpm lint
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/contract/src/builder/routability.ts \
+  packages/contract/src/builder/routability.spec.ts
+git commit -m "feat(contract): resolve publisher routability across the binding graph
+
+Walks queue bindings and exchange-to-exchange forwards with a cycle guard,
+so bridged publishers resolve correctly instead of being reported unroutable."
+```
+
+---
+
+### Task 3: Rung 2 — `defineContract` throws for unroutable publishers
+
+**Files:**
+
+- Modify: `packages/contract/src/types.ts` (add `externalConsumers` to `PublisherDefinition`)
+- Modify: `packages/contract/src/builder/publisher.ts` (accept and carry it)
+- Modify: `packages/contract/src/builder/validate.ts` (add the assertion)
+- Modify: `packages/contract/src/builder/contract.ts` (call it)
+- Test: `packages/contract/src/builder/routability-define-time.spec.ts` (create)
+
+**Interfaces:**
+
+- Consumes: `_internal_isPublisherRoutable`, `_internal_declaredPatternsFor` from Task 2
+- Produces: `_internal_assertPublisherRoutable(publisherName: string, exchange: ExchangeDefinition, routingKey: string | undefined, externalConsumers: boolean | undefined, bindings: readonly BindingDefinition[]): void`
+- Produces: `PublisherDefinition` gains `externalConsumers?: boolean | undefined`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/contract/src/builder/routability-define-time.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { defineConsumer } from "./consumer.js";
+import { defineContract } from "./contract.js";
+import { defineExchange } from "./exchange.js";
+import { defineMessage } from "./message.js";
+import { definePublisher } from "./publisher.js";
+import { defineQueue } from "./queue.js";
+import { defineQueueBinding } from "./binding.js";
+
+const message = defineMessage(z.object({ orderId: z.string() }));
+const orders = defineExchange("orders", { type: "topic" });
+const auditQueue = defineQueue("audit-log");
+
+describe("defineContract publisher routability", () => {
+  it("throws when a publisher's routing key reaches no queue", () => {
+    const orderCreated = definePublisher(orders, message, { routingKey: "order.created" });
+
+    expect(() =>
+      defineContract({
+        publishers: { orderCreated },
+        bindings: {
+          audit: defineQueueBinding(auditQueue, orders, { routingKey: "user.#" }),
+        },
+      }),
+    ).toThrow(/orderCreated/);
+  });
+
+  it("names the routing key, the exchange, and the declared patterns", () => {
+    const orderCreated = definePublisher(orders, message, { routingKey: "order.created" });
+
+    expect(() =>
+      defineContract({
+        publishers: { orderCreated },
+        bindings: {
+          audit: defineQueueBinding(auditQueue, orders, { routingKey: "user.#" }),
+        },
+      }),
+    ).toThrow(/order\.created[\s\S]*orders[\s\S]*user\.#/);
+  });
+
+  it("accepts a publisher whose key matches a declared binding", () => {
+    const orderCreated = definePublisher(orders, message, { routingKey: "order.created" });
+
+    expect(() =>
+      defineContract({
+        publishers: { orderCreated },
+        bindings: {
+          audit: defineQueueBinding(auditQueue, orders, { routingKey: "order.#" }),
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts a publisher routable via a consumer-contributed binding", () => {
+    // Consumers contribute bindings, so the check must run after they are
+    // collected — not while publishers are being processed.
+    const orderCreated = definePublisher(orders, message, { routingKey: "order.created" });
+
+    expect(() =>
+      defineContract({
+        publishers: { orderCreated },
+        consumers: { audit: defineConsumer(auditQueue, message) },
+        bindings: {
+          audit: defineQueueBinding(auditQueue, orders, { routingKey: "order.*" }),
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts an unroutable publisher explicitly marked externalConsumers", () => {
+    const orderCreated = definePublisher(orders, message, {
+      routingKey: "order.created",
+      externalConsumers: true,
+    });
+
+    expect(() => defineContract({ publishers: { orderCreated } })).not.toThrow();
+  });
+
+  it("still throws for a publish-only contract that is NOT marked", () => {
+    const orderCreated = definePublisher(orders, message, { routingKey: "order.created" });
+
+    expect(() => defineContract({ publishers: { orderCreated } })).toThrow(/externalConsumers/);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd packages/contract && pnpm vitest run src/builder/routability-define-time.spec.ts
+```
+
+Expected: FAIL — the first test does not throw (contracts are currently accepted).
+
+- [ ] **Step 3: Add `externalConsumers` to the publisher type**
+
+In `packages/contract/src/types.ts`, inside the `PublisherDefinition` object half (the part before the `& (` union, alongside `message`), add:
+
+```ts
+  /**
+   * Declares that this publisher's consumers live outside this contract —
+   * a separate service or deployment owns the binding.
+   *
+   * Routability cannot be verified for such a publisher, so the define-time
+   * check is skipped. This is deliberately explicit: a heuristic ("no
+   * bindings at all means external") would silently miss the mistyped-key
+   * case the check exists to catch.
+   */
+  externalConsumers?: boolean | undefined;
+```
+
+- [ ] **Step 4: Carry `externalConsumers` through `definePublisher`**
+
+In `packages/contract/src/builder/publisher.ts`, add `"externalConsumers"` to the allowed-keys array passed to `_internal_assertKnownKeys`, and include it on the returned object:
+
+```ts
+    ...(options?.externalConsumers !== undefined
+      ? { externalConsumers: options.externalConsumers }
+      : {}),
+```
+
+- [ ] **Step 5: Add the assertion helper**
+
+Append to `packages/contract/src/builder/validate.ts`:
+
+```ts
+/**
+ * Throw when a publisher's routing key reaches no queue in this contract.
+ *
+ * RabbitMQ publisher confirms mean "the broker took responsibility", not "a
+ * queue received it": a message routed to zero queues is confirmed and then
+ * discarded. Without this check a mistyped binding pattern silently drops
+ * every message while the publishing code observes success.
+ *
+ * Publishers whose consumers are owned by another service opt out with
+ * `externalConsumers: true`.
+ */
+export function _internal_assertPublisherRoutable(
+  publisherName: string,
+  exchange: ExchangeDefinition,
+  routingKey: string | undefined,
+  externalConsumers: boolean | undefined,
+  bindings: readonly BindingDefinition[],
+): void {
+  if (externalConsumers === true) return;
+  if (_internal_isPublisherRoutable(exchange, routingKey, bindings)) return;
+
+  const declared = _internal_declaredPatternsFor(exchange.name, bindings);
+  const declaredText =
+    declared.length > 0
+      ? `Declared on "${exchange.name}": ${declared.map((p) => `"${p}"`).join(", ")}.`
+      : `No bindings are declared on "${exchange.name}".`;
+
+  // oxlint-disable-next-line unthrown/no-throw -- fail-fast declaration-time config error (see module doc)
+  throw new Error(
+    `Publisher "${publisherName}" is unroutable: routing key ` +
+      `${routingKey === undefined ? "(none)" : `"${routingKey}"`} on exchange ` +
+      `"${exchange.name}" (${exchange.type}) reaches no queue. ${declaredText} ` +
+      `Messages published here would be confirmed by the broker and then discarded. ` +
+      `Add a binding that matches, or set \`externalConsumers: true\` on the publisher ` +
+      `if another service owns the binding.`,
+  );
+}
+```
+
+Add the imports at the top of `validate.ts`:
+
+```ts
+import type { BindingDefinition, ExchangeDefinition } from "../types.js";
+import { _internal_declaredPatternsFor, _internal_isPublisherRoutable } from "./routability.js";
+```
+
+- [ ] **Step 6: Call it from `defineContract`**
+
+In `packages/contract/src/builder/contract.ts`, the tail of `defineContract` currently reads:
+
+```ts
+result.exchanges = exchanges;
+result.queues = queues;
+result.bindings = bindings;
+
+return result as ContractOutput<TContract>;
+```
+
+Insert the check between the assignments and the `return`, so it runs after every
+`addResource` loop has populated the local `bindings` record:
+
+```ts
+result.exchanges = exchanges;
+result.queues = queues;
+result.bindings = bindings;
+
+// Runs last: consumers and bridged publishers contribute bindings, so
+// routability can only be decided once every binding is collected.
+const declaredBindings = Object.values(bindings);
+for (const [publisherName, publisher] of Object.entries(result.publishers ?? {})) {
+  _internal_assertPublisherRoutable(
+    publisherName,
+    publisher.exchange,
+    "routingKey" in publisher ? publisher.routingKey : undefined,
+    publisher.externalConsumers,
+    declaredBindings,
+  );
+}
+
+return result as ContractOutput<TContract>;
+```
+
+Note `result.publishers` (set at line 233 from `processedPublishers`) rather than a local —
+`defineContract` has no `publishers` local, and `result.publishers` is absent when the contract
+declares none, hence the `?? {}`.
+
+Import it:
+
+```ts
+import { _internal_assertPublisherRoutable } from "./validate.js";
+```
+
+- [ ] **Step 7: Run the new tests to verify they pass**
+
+```bash
+cd packages/contract && pnpm vitest run src/builder/routability-define-time.spec.ts
+```
+
+Expected: PASS, 6 tests.
+
+- [ ] **Step 8: Run the whole repo test suite**
+
+Existing fixtures across every package now go through this check, and some will legitimately need `externalConsumers: true` or a binding. Fix each one at the source — do not weaken the check.
+
+```bash
+cd /Users/btravers/Projects/btravstack/amqp-contract
+pnpm build && pnpm typecheck && pnpm test
+```
+
+Expected: green. Where a fixture fails, decide deliberately: add the missing binding if the contract was genuinely wrong, or mark `externalConsumers: true` if the fixture models a publish-only service.
+
+- [ ] **Step 9: Add a changeset**
+
+```bash
+pnpm changeset
+```
+
+Choose a **major** bump. Summary:
+
+```
+`defineContract` now throws when a publisher's routing key reaches no queue.
+RabbitMQ confirms an unroutable message and then discards it, so a mistyped
+binding pattern silently dropped every message while `publish()` returned
+`Ok`. Publishers whose consumers live in another service opt out with
+`externalConsumers: true`.
+```
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add -A
+git commit -m "feat(contract)!: throw at define time for unroutable publishers
+
+A publisher whose routing key reaches no queue is a silent total message
+loss at runtime, because publisher confirms acknowledge messages routed to
+zero queues. Publish-only services opt out with externalConsumers: true."
+```
+
+---
+
+### Task 4: Real-broker proof — the loss and the guard
+
+**Files:**
+
+- Create: `tests/src/unroutable-publish.spec.ts`
+
+**Interfaces:**
+
+- Consumes: the `externalConsumers` escape hatch from Task 3 (needed to construct the _unguarded_ scenario deliberately)
+
+- [ ] **Step 1: Write the test**
+
+Create `tests/src/unroutable-publish.spec.ts`:
+
+```ts
+import {
+  defineContract,
+  defineExchange,
+  defineMessage,
+  definePublisher,
+} from "@amqp-contract/contract";
+import { TypedAmqpClient } from "@amqp-contract/client";
+import { it } from "@amqp-contract/testing";
+import { describe, expect } from "vitest";
+import { z } from "zod";
+
+/**
+ * H1, proven end to end against a real broker.
+ *
+ * Test 1 demonstrates the hazard is genuine: an unroutable publish is
+ * confirmed by RabbitMQ and the message is gone. Test 2 demonstrates the
+ * define-time guard catches the same contract before it can run.
+ *
+ * The first test is the reason the second exists; if anyone ever weakens
+ * the guard, the pair reads as a complete argument for putting it back.
+ */
+describe("unroutable publish", () => {
+  const message = defineMessage(z.object({ orderId: z.string() }));
+
+  it("INVARIANT: an unroutable publish is confirmed by the broker and the message is lost", async ({
+    amqpChannel,
+    amqpConnectionUrl,
+  }) => {
+    const exchangeName = `orders-${Date.now()}`;
+    await amqpChannel.assertExchange(exchangeName, "topic", { durable: false });
+
+    // A queue bound with a pattern that cannot match the publisher's key.
+    const queueName = `audit-${Date.now()}`;
+    await amqpChannel.assertQueue(queueName, { durable: false });
+    await amqpChannel.bindQueue(queueName, exchangeName, "user.#");
+
+    const orders = defineExchange(exchangeName, { type: "topic", durable: false });
+    const orderCreated = definePublisher(orders, message, {
+      routingKey: "order.created",
+      // Deliberately bypass the define-time guard so the raw broker
+      // behavior is observable.
+      externalConsumers: true,
+    });
+    const contract = defineContract({ publishers: { orderCreated } });
+
+    const client = await TypedAmqpClient.create({
+      contract,
+      urls: [amqpConnectionUrl],
+    }).get();
+
+    const result = await client.publish("orderCreated", { orderId: "1" });
+
+    // The broker confirms it — publish reports success...
+    expect(result).toBeOk();
+
+    // ...and the message reached no queue.
+    const stats = await amqpChannel.checkQueue(queueName);
+    expect(stats.messageCount).toBe(0);
+
+    await client.close().get();
+  });
+
+  it("INVARIANT: the same contract is rejected at define time", () => {
+    const orders = defineExchange("orders-guarded", { type: "topic", durable: false });
+    const orderCreated = definePublisher(orders, message, { routingKey: "order.created" });
+
+    expect(() => defineContract({ publishers: { orderCreated } })).toThrow(/unroutable/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run the integration suite**
+
+Requires Docker.
+
+```bash
+cd /Users/btravers/Projects/btravstack/amqp-contract
+pnpm --filter @amqp-contract/tests test:integration
+```
+
+Expected: PASS. If Docker is unavailable, say so explicitly — do not claim integration coverage that did not run.
+
+- [ ] **Step 3: Record the invariant**
+
+In `AGENTS.md`, append to the "Load-bearing invariants" list:
+
+```markdown
+19. **A publisher whose routing key reaches no queue is rejected at define time** (RabbitMQ confirms an unroutable message and discards it, so the runtime signal is indistinguishable from success) — `tests/src/unroutable-publish.spec.ts` (the paired prove-the-loss / prove-the-guard tests) + `packages/contract/src/builder/routability-define-time.spec.ts`.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/src/unroutable-publish.spec.ts AGENTS.md
+git commit -m "test: prove unroutable publishes are lost, and that the guard catches them"
+```
+
+---
+
+### Task 5: Rung 1 — type-level routability
+
+**Files:**
+
+- Modify: `packages/contract/src/builder/routing-types.ts`
+- Create: `packages/contract/src/routability.test-d.ts`
+- Modify: `packages/contract/src/builder/contract.ts` (apply the type to `defineContract`'s input)
+
+**Interfaces:**
+
+- Consumes: `MatchesPattern` (already in `routing-types.ts`), `MATCH_CORPUS` from Task 1
+- Produces: `RoutableRoutingKey<Key, Patterns>` — resolves to `Key` when routable, otherwise a readable error-message string type
+
+**Scope note:** the type-level check covers the **single-hop queue-binding case on topic and direct exchanges only**. Fanout, headers, and any exchange participating in an exchange-to-exchange forward are skipped and left to the Task 3 runtime check. This is deliberate: multi-hop graph traversal in the type system risks recursion-depth failures and, worse, false compile errors on valid bridged contracts. Never reject a valid contract at compile time.
+
+- [ ] **Step 1: Write the failing type test**
+
+Create `packages/contract/src/routability.test-d.ts`:
+
+```ts
+import { describe, expectTypeOf, it } from "vitest";
+
+import type { RoutableRoutingKey } from "./builder/routing-types.js";
+
+describe("RoutableRoutingKey", () => {
+  it("resolves to the key when a pattern matches", () => {
+    expectTypeOf<RoutableRoutingKey<"order.created", "order.#">>().toEqualTypeOf<"order.created">();
+    expectTypeOf<RoutableRoutingKey<"order.created", "order.*">>().toEqualTypeOf<"order.created">();
+    expectTypeOf<
+      RoutableRoutingKey<"order.created", "order.created">
+    >().toEqualTypeOf<"order.created">();
+  });
+
+  it("resolves to the key when ANY pattern in the union matches", () => {
+    expectTypeOf<
+      RoutableRoutingKey<"order.created", "user.#" | "order.#">
+    >().toEqualTypeOf<"order.created">();
+  });
+
+  it("resolves to a readable error when no pattern matches", () => {
+    expectTypeOf<
+      RoutableRoutingKey<"order.created", "user.#">
+    >().toEqualTypeOf<"Error: routing key 'order.created' matches none of the declared binding patterns; the broker would confirm and discard every message">();
+  });
+
+  it("skips the check when the key is not a literal", () => {
+    expectTypeOf<RoutableRoutingKey<string, "user.#">>().toEqualTypeOf<string>();
+  });
+
+  it("skips the check when the patterns are not literal", () => {
+    expectTypeOf<RoutableRoutingKey<"order.created", string>>().toEqualTypeOf<"order.created">();
+  });
+
+  it("skips the check when there are no patterns", () => {
+    expectTypeOf<RoutableRoutingKey<"order.created", never>>().toEqualTypeOf<"order.created">();
+  });
+});
+```
+
+- [ ] **Step 2: Run the type test to verify it fails**
+
+```bash
+cd packages/contract && pnpm vitest run --typecheck src/routability.test-d.ts
+```
+
+Expected: FAIL — `RoutableRoutingKey` is not exported.
+
+- [ ] **Step 3: Implement the type**
+
+Append to `packages/contract/src/builder/routing-types.ts`:
+
+```ts
+/**
+ * True when `Key` matches at least one pattern in the `Patterns` union.
+ *
+ * Distributes over the union rather than recursing across a list, which
+ * keeps instantiation depth bounded by the longest single pattern instead
+ * of by the number of bindings.
+ * @internal
+ */
+type MatchesAnyPattern<Key extends string, Patterns extends string> = [Patterns] extends [never]
+  ? false
+  : true extends (Patterns extends string ? MatchesPattern<Key, Patterns> : never)
+    ? true
+    : false;
+
+/**
+ * A publisher routing key validated against the binding patterns declared on
+ * its exchange.
+ *
+ * A message routed to zero queues is confirmed by RabbitMQ and then
+ * discarded, so an unmatched routing key is silent total message loss. On no
+ * match this resolves to a human-readable error-message string type, so the
+ * compile error explains the problem instead of collapsing to `never` —
+ * matching the {@link MatchingBindingPattern} convention.
+ *
+ * Skipped (resolves to `Key`) when either side is non-literal, or when no
+ * patterns are declared: those cases cannot be decided at compile time and
+ * are left to the define-time check in `defineContract`.
+ *
+ * @template Key - The publisher's concrete routing key
+ * @template Patterns - Union of binding patterns declared on the exchange
+ */
+export type RoutableRoutingKey<Key extends string, Patterns extends string> = string extends Key
+  ? Key
+  : string extends Patterns
+    ? Key
+    : [Patterns] extends [never]
+      ? Key
+      : MatchesAnyPattern<Key, Patterns> extends true
+        ? Key
+        : `Error: routing key '${Key}' matches none of the declared binding patterns; the broker would confirm and discard every message`;
+```
+
+- [ ] **Step 4: Run the type test to verify it passes**
+
+```bash
+cd packages/contract && pnpm vitest run --typecheck src/routability.test-d.ts
+```
+
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Assert the shared corpus at the type level**
+
+Append to `packages/contract/src/routability.test-d.ts`:
+
+```ts
+/**
+ * The corpus in `match-corpus.ts` is asserted against the runtime matcher in
+ * `topic-match.spec.ts`. These assertions pin the same cases at the type
+ * level, so the two implementations cannot diverge without a test failing.
+ *
+ * Kept as explicit lines rather than a loop: types cannot be generated from
+ * a runtime array.
+ */
+describe("type-level matcher agrees with the runtime corpus", () => {
+  it("matches the cases the runtime matcher matches", () => {
+    expectTypeOf<
+      RoutableRoutingKey<"order.created", "order.created">
+    >().toEqualTypeOf<"order.created">();
+    expectTypeOf<RoutableRoutingKey<"order.created", "order.*">>().toEqualTypeOf<"order.created">();
+    expectTypeOf<
+      RoutableRoutingKey<"order.created", "*.created">
+    >().toEqualTypeOf<"order.created">();
+    expectTypeOf<RoutableRoutingKey<"order.created", "*.*">>().toEqualTypeOf<"order.created">();
+    expectTypeOf<RoutableRoutingKey<"order", "*">>().toEqualTypeOf<"order">();
+    expectTypeOf<RoutableRoutingKey<"order.created", "#">>().toEqualTypeOf<"order.created">();
+    expectTypeOf<RoutableRoutingKey<"order", "#">>().toEqualTypeOf<"order">();
+    expectTypeOf<RoutableRoutingKey<"order.created", "order.#">>().toEqualTypeOf<"order.created">();
+    expectTypeOf<RoutableRoutingKey<"order", "order.#">>().toEqualTypeOf<"order">();
+    expectTypeOf<
+      RoutableRoutingKey<"order.created.v2", "order.#">
+    >().toEqualTypeOf<"order.created.v2">();
+    expectTypeOf<
+      RoutableRoutingKey<"order.created", "#.created">
+    >().toEqualTypeOf<"order.created">();
+    expectTypeOf<RoutableRoutingKey<"created", "#.created">>().toEqualTypeOf<"created">();
+    expectTypeOf<
+      RoutableRoutingKey<"order.created.v2", "order.#.v2">
+    >().toEqualTypeOf<"order.created.v2">();
+    expectTypeOf<RoutableRoutingKey<"order.v2", "order.#.v2">>().toEqualTypeOf<"order.v2">();
+    expectTypeOf<
+      RoutableRoutingKey<"order.a.b.v2", "order.#.v2">
+    >().toEqualTypeOf<"order.a.b.v2">();
+    expectTypeOf<
+      RoutableRoutingKey<"order.created.v2", "order.*.#">
+    >().toEqualTypeOf<"order.created.v2">();
+    expectTypeOf<
+      RoutableRoutingKey<"order.created", "order.*.#">
+    >().toEqualTypeOf<"order.created">();
+  });
+
+  it("rejects the cases the runtime matcher rejects", () => {
+    expectTypeOf<
+      RoutableRoutingKey<"order.created", "order.updated">
+    >().not.toEqualTypeOf<"order.created">();
+    expectTypeOf<
+      RoutableRoutingKey<"order.created.v2", "order.*">
+    >().not.toEqualTypeOf<"order.created.v2">();
+    expectTypeOf<RoutableRoutingKey<"order.created", "*">>().not.toEqualTypeOf<"order.created">();
+    expectTypeOf<
+      RoutableRoutingKey<"order.created", "order.#.v2">
+    >().not.toEqualTypeOf<"order.created">();
+    expectTypeOf<RoutableRoutingKey<"order", "order.*.#">>().not.toEqualTypeOf<"order">();
+    expectTypeOf<
+      RoutableRoutingKey<"user.created", "order.#">
+    >().not.toEqualTypeOf<"user.created">();
+    expectTypeOf<
+      RoutableRoutingKey<"order.created", "order.created.v2">
+    >().not.toEqualTypeOf<"order.created">();
+  });
+});
+```
+
+- [ ] **Step 6: Run and verify the corpus assertions pass**
+
+```bash
+cd packages/contract && pnpm vitest run --typecheck src/routability.test-d.ts
+```
+
+Expected: PASS. **If any case fails, the runtime and type-level matchers disagree — fix the mismatch rather than editing the expectation.**
+
+- [ ] **Step 7: Measure `tsc` cost before wiring into `defineContract`**
+
+```bash
+cd /Users/btravers/Projects/btravstack/amqp-contract
+time pnpm typecheck
+```
+
+Record the wall-clock. Acceptance criterion 10 in the spec: a large regression means fall back to rung 2 only. Compare against the same command on `main` before this branch.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/contract/src/builder/routing-types.ts \
+  packages/contract/src/routability.test-d.ts
+git commit -m "feat(contract): add compile-time publisher routability checking
+
+RoutableRoutingKey resolves to a readable error-message type when a routing
+key matches none of the declared binding patterns. The shared corpus is now
+asserted at both the runtime and type level so they cannot diverge."
+```
+
+**Note on wiring into `defineContract`'s signature:** applying `RoutableRoutingKey` to `defineContract`'s input requires inferring the binding-pattern union per exchange from the `bindings` record — a non-trivial mapped type over the input. Attempt it only after Step 7 confirms `tsc` cost is acceptable. If the inference proves unreliable or slow, stop here: the type is exported and usable directly, and rung 2 already provides full coverage. Document the decision in the commit message.
+
+---
+
+### Task 6: Rung 3 spike — `basic.return` correlation
+
+**Files:**
+
+- Create: `docs/superpowers/specs/2026-08-01-h1-rung3-spike-findings.md`
+- Create (throwaway): `tests/src/spike-return-correlation.spec.ts` — deleted before the final commit
+
+**Interfaces:**
+
+- Produces: a findings document that unblocks a rung-3 implementation plan. **No production code.**
+
+This task is research. Do not write library code. The deliverable is a decision.
+
+- [ ] **Step 1: Establish whether `mandatory` returns are observable**
+
+Write a throwaway integration test that publishes with `mandatory: true` to an exchange with no matching binding, and attaches a `return` listener to the underlying channel. Determine:
+
+1. Does `amqp-connection-manager`'s `ChannelWrapper` surface `basic.return`? Check whether it re-emits `'return'`, and whether the raw `amqplib` channel is reachable via the `setup` callback.
+2. Does the returned message carry enough to identify which publish it belongs to (`fields.exchange`, `fields.routingKey`, `properties.headers`, `properties.messageId`)?
+3. What is the ordering relative to the publish promise resolving? Confirm empirically whether the return arrives before the confirm.
+
+- [ ] **Step 2: Test the correlation candidate**
+
+Stamp a unique header (for example `x-amqp-contract-publish-id`) on each publish, publish several unroutable messages concurrently, and verify every return can be matched back to its originating publish by that header.
+
+- [ ] **Step 3: Test reconnect behavior**
+
+Publish an unroutable message, force-close the connection via the management API (`DELETE /api/connections/{name}`, port available as `__TESTCONTAINERS_RABBITMQ_PORT_15672__`) and determine what happens to a pending return correlation across the reconnect. Establish whether a pending publish can be left unresolved.
+
+- [ ] **Step 4: Write the findings document**
+
+Create `docs/superpowers/specs/2026-08-01-h1-rung3-spike-findings.md` covering:
+
+- Whether `basic.return` is reachable through `amqp-connection-manager`, and how
+- The chosen correlation mechanism, with the evidence supporting it
+- Ordering guarantees observed between return and confirm
+- Reconnect behavior and how a pending correlation is resolved or abandoned
+- Per-publish overhead of the correlation (extra header bytes, bookkeeping)
+- **Recommendation: implement rung 3, or stop at rungs 1–2 and document the residual risk**
+
+- [ ] **Step 5: Delete the throwaway test and commit the findings**
+
+```bash
+rm tests/src/spike-return-correlation.spec.ts
+git add docs/superpowers/specs/2026-08-01-h1-rung3-spike-findings.md
+git commit -m "docs: findings from the basic.return correlation spike"
+```
+
+---
+
+## Out of scope for this plan
+
+Covered by the follow-up plan for H2–H4 and mock removal:
+
+- H2 — DLX-less queue throws unless `onPoison: "drop"`
+- H3 — default `prefetch: 10`, `prefetch: "unbounded"` opt-out
+- H4 — default `publishTimeoutMs: 30000`
+- Migrating the 9 broker-mocking specs to management-API fault injection
+- Ratcheting the `core` / `worker` / `client` coverage floors
+- The upgrade-guide entries for every breaking change above
+
+Rung 3 implementation is gated on the Task 6 spike and gets its own plan.

--- a/docs/superpowers/specs/2026-08-01-h1-rung3-spike-findings.md
+++ b/docs/superpowers/specs/2026-08-01-h1-rung3-spike-findings.md
@@ -1,0 +1,497 @@
+# H1 rung 3 — `basic.return` correlation spike
+
+**Date:** 2026-08-01
+**Status:** research complete — decision recorded
+**Question:** can a returned (unroutable) message be reliably matched back to the
+specific `publish()` call that produced it, through `amqp-connection-manager`?
+
+**Answer: yes.** The mechanism is reachable, and correlation by a per-publish
+header is empirically exact under concurrency, forced reconnects, and a
+TCP-level split between the return frame and the confirm frame.
+
+**Recommendation: implement rung 3.** Scope, cost, and the parts it provably
+does _not_ cover are in [Recommendation](#recommendation).
+
+Everything below was measured against a real RabbitMQ 4.2.1 broker
+(`rabbitmq:4.2.1-management-alpine`) with `amqp-connection-manager@5.0.0` and
+`amqplib@2.0.1` — the versions this repo pins. Nothing here is inferred from
+documentation.
+
+---
+
+## 1. Is `basic.return` reachable?
+
+**Yes — on the raw amqplib channel handed to the `setup` callback. Not on the
+`ChannelWrapper`.**
+
+`ChannelWrapper` (v5.0.0) emits exactly three events. Its source contains six
+`emit(` call sites and they are all one of:
+
+| event     | source line (`dist/esm/ChannelWrapper.js`) |
+| --------- | ------------------------------------------ |
+| `error`   | 267, 285, 492, 537                         |
+| `connect` | 282                                        |
+| `close`   | 344                                        |
+
+There is no occurrence of the string `return` as an event name, and none of
+`mandatory`, anywhere in the package. A listener attached with
+`wrapper.on("return", …)` never fires — confirmed empirically alongside a raw
+listener that _did_ fire for the same message.
+
+The raw channel **is** reachable. `_onConnect` calls each registered setup
+function with the live channel (`pb.call(setupFn, this, channel)`, line 262),
+and that object is an `amqplib` `ConfirmChannel`, which is an `EventEmitter`:
+
+```js
+conn.createChannel({
+  confirm: true,
+  setup: async (ch) => {
+    // ch.constructor.name === "ConfirmChannel"
+    ch.on("return", (msg) => {
+      /* fires */
+    });
+  },
+});
+```
+
+Two properties of this attachment point matter and both were verified:
+
+- **It is re-run on every reconnect.** Each reconnect creates a _new_ channel
+  object and re-runs every setup function against it, so the listener is
+  re-attached exactly once per channel incarnation — no stacking, no leak.
+  (Observed: `setup incarnation 1` → forced close → `setup incarnation 2`, with
+  returns arriving on both.)
+- **It is per-channel, so returns do not leak between clients.** This codebase
+  pools _connections_ (`ConnectionManagerSingleton`) but gives every
+  `AmqpClient` its own `ChannelWrapper`. Two wrappers on one pooled connection,
+  each publishing one unroutable message: channel A saw only A's return, channel
+  B only B's.
+
+### This is already reachable from userland today
+
+`AmqpClient.addSetup((channel) => …)` is public and hands out the same raw
+channel, and `AmqpClient.publish` forwards `options` straight through. Verified
+against the built `packages/core/dist`:
+
+```js
+client.addSetup((ch) =>
+  ch.on("return", (m) => {
+    /* … */
+  }),
+);
+await client.publish({ exchange, routingKey }, payload, {
+  mandatory: true,
+  headers: { "x-ac-pid": id },
+});
+// -> { isOk: true, unroutable: { code: 312, text: "NO_ROUTE", ex, rk } }
+```
+
+Rung 3 is therefore not a capability the library is missing — it is plumbing
+and a modeled error the library would own on the user's behalf.
+
+---
+
+## 2. What the returned message carries
+
+A returned message is the original message, echoed back with a delivery header
+describing why. Full dump of a real return:
+
+```json
+{
+  "fields": {
+    "replyCode": 312,
+    "replyText": "NO_ROUTE",
+    "exchange": "spike.direct",
+    "routingKey": "no.such.key"
+  },
+  "properties": {
+    "contentType": "application/json",
+    "headers": { "x-amqp-contract-publish-id": "pid-1" },
+    "correlationId": "corr-id-1",
+    "messageId": "msg-id-1",
+    "appId": "spike"
+  },
+  "content": "{\"hello\":\"world\"}"
+}
+```
+
+Every AMQP basic property survives, **including the full user headers table**
+and the exact body bytes. `fields.exchange` / `fields.routingKey` are the
+original publish target. `replyCode` is `312 NO_ROUTE`.
+
+For `sendToQueue` to a nonexistent queue, the return arrives with
+`fields.exchange === ""` and `fields.routingKey === "<queue name>"`.
+
+---
+
+## 3. Ordering: the return always precedes the confirm
+
+RabbitMQ sends `basic.return` before `basic.ack` for the same message, amqplib
+dispatches frames in socket order, and `amqp-connection-manager` resolves the
+publish promise from the confirm callback — so the `'return'` event is observed
+strictly before the promise settles.
+
+Measured, never violated:
+
+| run                  | publishes | unroutable | return-after-its-own-confirm |
+| -------------------- | --------- | ---------- | ---------------------------- |
+| interleaved N=200    | 200       | 100        | **0**                        |
+| interleaved N=2000   | 2000      | 1000       | **0**                        |
+| burst N=50000 + kill | 50000     | 50000      | **0**                        |
+| paced 7620 + kill    | 7620      | 7620       | **0**                        |
+
+The single most important derived number, from the 50 000-publish burst with a
+forced reconnect in the middle:
+
+```
+"resolvedOk": 47353,
+"SILENT_LOSS_okButNoReturn": 0
+```
+
+**Every publish that resolved `Ok` and was in fact unroutable had already had
+its return observed by the time the promise settled.** Zero exceptions.
+
+The return is _not_ the immediately preceding event, though — under load, up to
+96 unrelated events interleaved between a return and its own confirm. So "the
+last return I saw belongs to this publish" is wrong; explicit correlation is
+required.
+
+---
+
+## 4. Correlation mechanism
+
+### Recommended: a per-publish header
+
+Stamp `x-amqp-contract-publish-id` on every publish, register a pending entry
+under that id, let the `'return'` handler flip a flag on it, and read the flag
+when the publish promise settles.
+
+```
+publish(target, payload, opts):
+  id = nextId()                       // channel-scoped monotonic counter
+  entry = { unroutable: undefined }
+  pending.set(id, entry)
+  try:
+    await wrapper.publish(ex, rk, body, { ...opts, mandatory: true,
+                                          headers: { ...opts.headers, [H]: id } })
+    // the return, if any, has already been observed (§3)
+    return entry.unroutable ? Err(new UnroutableMessageError(...)) : Ok()
+  finally:
+    pending.delete(id)                // no orphan is possible: see §5
+```
+
+Evidence, 2000 concurrent publishes with 1000 unroutable interleaved among 1000
+routable ones:
+
+```json
+{
+  "publishesConfirmed": 2000,
+  "returnsSeen": 1000,
+  "expectedUnroutable": 1000,
+  "missingReturns": 0,
+  "spuriousReturns": 0,
+  "returnCarriedUndefinedPid": false,
+  "orderViolations_returnAfterItsOwnConfirm": 0,
+  "allReturnsUnique": true
+}
+```
+
+### Rejected: header-free FIFO correlation
+
+Returns _do_ arrive in publish order — verified exactly, 1000 publishes across
+7 routing keys, `GLOBAL_FIFO_matches_publish_order: true`. That makes a
+zero-wire-overhead design look possible: keep a FIFO of pending publishes per
+`(exchange, routingKey)` and pop its head on each return.
+
+It is unsound, and unsound _specifically in the scenario rung 3 exists for_.
+FIFO correlation assumes routability for a key is constant across the in-flight
+window; a binding deleted mid-flight breaks that assumption, and there is no
+way to tell which of the pending publishes for that key were the routable ones.
+
+Measured: 6000 paced publishes to one key, binding deleted at #2000.
+
+```json
+{
+  "actuallyUnroutable_byHeader": 4179,
+  "firstUnroutableIndex_truth": 1821,
+  "firstBlamedIndex_fifo": 1600,
+  "MISATTRIBUTED_BY_FIFO": 4155,
+  "fifoIsSound": false
+}
+```
+
+**99.4 % of returns were attributed to the wrong publish.** Both a false
+positive (a delivered message reported unroutable) and a false negative (a lost
+message reported `Ok`) on nearly every one. The header is not optional.
+
+### Rejected: reusing `messageId` / `correlationId`
+
+Both survive the return intact, but both are user-owned AMQP properties with
+established meanings — `correlationId` is already load-bearing for RPC
+(`client.ts:722`). A namespaced header cannot collide.
+
+---
+
+## 5. Reconnect behavior
+
+Forced via the management API, `DELETE /api/connections/{name}` with basic auth
+(`guest:guest`), the port available to integration tests as
+`__TESTCONTAINERS_RABBITMQ_PORT_15672__`. Note the management DB takes ~1 s to
+register a new connection — a test that kills too early lists zero connections
+and silently no-ops.
+
+### Can a publish be left permanently unresolved? No.
+
+Across every run — 7620 paced publishes spanning a forced reconnect, and 50 000
+burst publishes with ~40 000 still queued when the connection died — the count
+of publishes that never settled was **0**. Max observed settle latency was
+2063 ms (the reconnect gap plus the requeued backlog).
+
+The 50 000-burst reconnect split as:
+
+```json
+{
+  "settled": 50000,
+  "PERMANENTLY_UNSETTLED": 0,
+  "resolvedOk": 47353,
+  "rejected": 2647,
+  "rejectReasons": ["channel closed"],
+  "returnsPerChannelIncarnation": { "1": 7400, "2": 39953 },
+  "PIDS_WITH_MULTIPLE_RETURNS": 0,
+  "SILENT_LOSS_okButNoReturn": 0
+}
+```
+
+- Messages **already sent but unconfirmed** when the connection dropped
+  (2647 of them) had their confirm callbacks invoked with an error and
+  `_messageRejected` rejected them outright with `"channel closed"` — because
+  `this._channel` was still set at that instant, the requeue branch
+  (`ChannelWrapper.js:368`) was not taken. The caller sees a `Defect`.
+- Messages **still queued and never sent** (39 953) were published for the first
+  time on the new channel and returned there.
+- **No message produced two returns.** The republish-with-the-same-headers
+  hazard did not materialise in any run.
+
+### The worst window: return delivered, confirm never
+
+Tested directly with a TCP proxy that parses the broker→client frame stream,
+forwards bytes up to and including the returned message's body frame, and then
+destroys the socket — so the client observes the return and can never receive
+the ack.
+
+```
+[11ms] >>> forwarded the basic.return, now destroying the TCP connection
+[11ms] RETURN pid=SPLIT-1 incarnation=1
+[12ms] DISCONNECT: Unexpected close
+[12ms] publish -> REJECTED: channel closed after 2ms
+```
+
+```json
+{ "publishOutcome": "REJECTED: channel closed", "DUPLICATE_RETURN_AFTER_RECONNECT": false }
+```
+
+The publish rejects in 2 ms. It does not hang, and the message is not
+republished. The pending entry is removed on the rejection path, so **an orphan
+correlation entry is not reachable** — every registered entry is deleted when
+its promise settles, and every promise settles.
+
+An implementation may optionally report `UnroutableMessageError` rather than the
+generic channel-closed `Defect` here, since the return _was_ observed. That is
+strictly more information; it is not required for correctness.
+
+### The one residual correlation hazard
+
+If a message is requeued rather than rejected (the `!this._channel` branch), it
+is republished with the _same_ headers and therefore the same publish id. The
+design above tolerates that — the second return simply re-sets the same boolean
+on a still-registered entry. The only misreport it can produce is: attempt 1
+unroutable, connection drops, binding restored during the gap, attempt 2
+routable → reported unroutable. That requires the topology to be repaired inside
+the reconnect window, and it fails in the safe direction (a spurious error on a
+message that got through, which at-least-once delivery already permits callers
+to handle).
+
+---
+
+## 6. Per-publish cost
+
+**Wire.** An AMQP field-table entry costs `1 + len(name) + 1 + 4 + len(value)`
+bytes.
+
+| scheme                                             | bytes/message |
+| -------------------------------------------------- | ------------- |
+| `x-amqp-contract-publish-id` + UUID                | 68            |
+| `x-ac-pid` + base-36 counter (up to 60 M messages) | **19**        |
+
+Plus a 4-byte field-table length prefix on messages that had no headers at all.
+The id only needs to be unique within a channel's in-flight window, so a
+channel-scoped monotonic counter is sufficient and 19 bytes is the number to
+budget. On a 60-byte JSON body that is ~30 % overhead; on a realistic 500-byte
+event, ~4 %.
+
+**Latency.** Sequential publish-and-await, 3000 iterations after 300 warmup:
+
+| variant          | p50 (ms) | p95    | p99    | mean   |
+| ---------------- | -------- | ------ | ------ | ------ |
+| plain            | 0.1390   | 0.1582 | 0.1801 | 0.1393 |
+| mandatory + corr | 0.1374   | 0.1540 | 0.1797 | 0.1398 |
+
+**+0.4 % mean, inside the noise floor.** For any workload that awaits its
+publishes, the cost is not measurable.
+
+**Throughput,** 20 000 publishes fired without backpressure:
+
+| variant          | msg/s  | vs plain |
+| ---------------- | ------ | -------- |
+| plain            | 97 653 | —        |
+| mandatory only   | 88 560 | −9.3 %   |
+| mandatory + corr | 85 979 | −12.0 %  |
+
+Most of that is `mandatory` itself (the broker doing routing bookkeeping and
+emitting returns for 100 % of these publishes), not the correlation. The
+correlation adds 2.7 points on top.
+
+**Bookkeeping.** One `Map` entry per in-flight publish, deleted on settle;
+`pendingMapLeftover: 0` in every benchmark. Bounded by concurrency, not by
+throughput.
+
+**Visibility.** The header is delivered to consumers — it appears in
+`properties.headers` on the receiving side and is not stripped. It does not break
+headers-exchange routing (verified with `x-match: all`), but it is permanently
+part of every message this library ever publishes, including messages consumed
+by systems that are not using this library.
+
+---
+
+## 7. What rung 3 provably does _not_ cover
+
+These are measured negative results, not caveats-by-analogy.
+
+1. **RPC replies cannot be covered.** RabbitMQ ignores `mandatory` on
+   `amq.rabbitmq.reply-to`. With the requester's connection fully closed, a
+   `mandatory` reply publish to its direct-reply-to pseudo-queue produced
+   **zero returns** — the reply is silently dropped. `worker.ts:964` is
+   therefore out of reach; a dead RPC requester still surfaces only as the
+   caller's `RpcTimeoutError`.
+2. **An alternate exchange suppresses the return, correctly.** An exchange
+   declared with `alternate-exchange` routes its otherwise-unroutable messages
+   to the AE; the message lands in the AE's queue and **no return is issued**.
+   That is right — the message _was_ routed — but it means "no return" means
+   "routed somewhere", not "routed to the queue you intended".
+3. **`Ok` still does not mean "processed".** A return only fires when the
+   exchange matches _zero_ queues. A message dropped by `x-max-length`
+   overflow, expired by a queue TTL, or sitting in a queue nobody consumes is
+   routed, confirmed, and returns nothing.
+4. **The reconnect window is best-effort.** 2647 of 50 000 publishes in the
+   burst test rejected with `"channel closed"` — their routability is unknown,
+   as it is today.
+
+There is also a framing correction worth recording: **"topology never set up in
+this environment" is already impossible.** `setupAmqpTopology` runs inside the
+channel `setup` callback (`amqp-client.ts:235`) and asserts every exchange,
+queue, and binding in the contract on _every_ connect and reconnect. The
+library creates its own topology. What rung 3 actually guards is narrower than
+the framing suggests:
+
+| scenario                                                                                   | covered by                       | rung 3 adds                 |
+| ------------------------------------------------------------------------------------------ | -------------------------------- | --------------------------- |
+| mistyped routing key inside one contract                                                   | rung 1 (types) + rung 2 (define) | nothing                     |
+| topology missing in a fresh environment                                                    | auto-setup on connect            | nothing                     |
+| contract-declared binding deleted by an operator                                           | self-heals at the next reconnect | detection during the window |
+| **`externalConsumers: true` publisher whose binding never existed, or was decommissioned** | **nothing**                      | **the only check there is** |
+
+---
+
+## Recommendation
+
+**Implement rung 3.**
+
+The single strongest piece of evidence: across 50 000 publishes spanning a
+broker-forced reconnect, `SILENT_LOSS_okButNoReturn` was **0** and
+`PIDS_WITH_MULTIPLE_RETURNS` was **0** — header-correlated detection produced
+neither a false negative nor a false positive, including when a TCP-level cut
+delivered the return and destroyed the connection before the confirm could
+arrive (that case rejects in 2 ms rather than hanging or double-reporting).
+
+The decisive _product_ argument is the last row of the table above.
+`externalConsumers: true` is the escape hatch rungs 1 and 2 hand to anyone whose
+consumer lives in another service, and it is exactly the population most likely
+to have drifted: another team's deploy, another repo's contract, a queue
+decommissioned without telling the publisher. For those publishers there is
+currently **no check at any level** — define-time, connect-time, or runtime —
+and the failure mode is total, permanent, silent message loss. Rung 3 is the
+only thing that can catch it, and it catches it on the first message.
+
+### Proposed API shape
+
+Client-level, opt-out-able, because the cost is not free for high-throughput
+fire-and-forget publishers and because it widens a public error union:
+
+```ts
+TypedAmqpClient.create({
+  contract,
+  urls,
+  // "error"  — publish with mandatory; an unroutable message becomes Err
+  // "ignore" — today's behaviour; no mandatory flag, no header, no cost
+  onUnroutable: "error", // default in the next major; "ignore" behind a flag before that
+});
+```
+
+### Signature changes required
+
+| location                              | from                                        | to                                                 |
+| ------------------------------------- | ------------------------------------------- | -------------------------------------------------- |
+| `AmqpClient.publish`                  | `AsyncResult<void, never>`                  | `AsyncResult<void, UnroutableMessageError>`        |
+| `AmqpClient.sendToQueue`              | `AsyncResult<void, never>`                  | `AsyncResult<void, UnroutableMessageError>`        |
+| `PublishError` (`interceptors.ts:12`) | `MessageValidationError`                    | `MessageValidationError \| UnroutableMessageError` |
+| `TypedAmqpClient.publish`             | `AsyncResult<void, MessageValidationError>` | `AsyncResult<void, PublishError>`                  |
+
+This is a **breaking change**: every user `errCases` matcher that handles only
+`P.tag("@amqp-contract/MessageValidationError")` without a `P._` catch-all stops
+compiling. It needs a major bump, a changeset, and an upgrade-guide entry.
+
+Additional implementation notes for whoever picks this up:
+
+- Register the `'return'` listener inside `AmqpClient`'s `defaultSetup`
+  (`amqp-client.ts:235`), before the user-setup wrapper, so it survives every
+  reconnect and cannot be displaced by a user-supplied `channelOptions.setup`.
+- The publish id must be **channel-scoped** and reset per incarnation; reuse the
+  existing `channelEpoch` counter (`amqp-client.ts:206`) as its prefix rather
+  than inventing a second one.
+- Merge the header into `options.headers`; never replace the table.
+- `retry.ts:310` republishes to the _original_ exchange or, for classic-queue
+  immediate requeue, to the default exchange. Turning `mandatory` on there
+  converts a silently-lost retry into a modeled error, which is desirable, but
+  it changes the retry pipeline's error surface — see load-bearing invariants
+  1, 3 and 14 in `CLAUDE.md`. Cover it explicitly.
+- Do **not** enable `mandatory` on the RPC reply path (`worker.ts:964`); per §7
+  it is inert there and only costs bytes.
+- Guarding test to add to the invariant list: an unroutable publish on a
+  contract with `externalConsumers: true` returns `Err(UnroutableMessageError)`
+  while a routable one on the same channel returns `Ok`, both published
+  concurrently.
+
+### If this is deferred instead
+
+The residual risk to document is precise: **for any publisher declared with
+`externalConsumers: true`, a missing or deleted broker-side binding causes
+total, permanent, silent message loss, and `publish()` reports success.** The
+mitigation a user should apply is to assert the binding themselves at startup —
+`channel.checkQueue(name)` plus a management-API binding check — or to attach
+their own return listener via the already-public
+`AmqpClient.addSetup((ch) => ch.on("return", …))`, which §1 shows works today.
+
+---
+
+## Reproduction
+
+All experiments were throwaway scripts run against a standalone
+`rabbitmq:4.2.1-management-alpine` container on ports 45672/45673, and were
+deleted after the run. The ten of them covered: reachability and message dump;
+correlation under concurrency at N=200/2000; a paced reconnect with management-API
+force-close; a 50 000-message in-flight burst kill; alternate-exchange, headers-exchange,
+and `sendToQueue` edge cases; throughput and sequential-latency benchmarks; channel
+isolation across a pooled connection; a frame-parsing TCP proxy that splits the
+return from the confirm; FIFO-correlation soundness under a mid-flight unbind;
+and an end-to-end check through the built `AmqpClient`. Raw output is recorded in
+`.superpowers/sdd/2026-08-01-h1-unroutable-publish/task-6-report.md`.

--- a/docs/superpowers/specs/2026-08-01-h1-rung3-spike-findings.md
+++ b/docs/superpowers/specs/2026-08-01-h1-rung3-spike-findings.md
@@ -6,16 +6,20 @@
 specific `publish()` call that produced it, through `amqp-connection-manager`?
 
 **Answer: yes.** The mechanism is reachable, and correlation by a per-publish
-header is empirically exact under concurrency, forced reconnects, and a
-TCP-level split between the return frame and the confirm frame.
+header held under every configuration tested — including the one that exercises
+both error oracles at once (mixed routable/unroutable traffic across a forced
+reconnect, verdict sampled at promise-settle time).
 
-**Recommendation: implement rung 3.** Scope, cost, and the parts it provably
-does _not_ cover are in [Recommendation](#recommendation).
+**Recommendation: implement rung 3.** The decision rests on the _product_
+argument in [Recommendation](#recommendation) — publishers declared
+`externalConsumers: true` have zero coverage at any rung today and fail totally
+and silently. The measurements below establish that the mechanism is sound
+enough to build on; they are not themselves the reason to build it.
 
-Everything below was measured against a real RabbitMQ 4.2.1 broker
+Everything here was measured against a real RabbitMQ 4.2.1 broker
 (`rabbitmq:4.2.1-management-alpine`) with `amqp-connection-manager@5.0.0` and
-`amqplib@2.0.1` — the versions this repo pins. Nothing here is inferred from
-documentation.
+`amqplib@2.0.1` — the versions this repo pins. Claims a given run did not
+instrument are marked **not measured**, never assumed to be zero.
 
 ---
 
@@ -59,8 +63,6 @@ Two properties of this attachment point matter and both were verified:
 - **It is re-run on every reconnect.** Each reconnect creates a _new_ channel
   object and re-runs every setup function against it, so the listener is
   re-attached exactly once per channel incarnation — no stacking, no leak.
-  (Observed: `setup incarnation 1` → forced close → `setup incarnation 2`, with
-  returns arriving on both.)
 - **It is per-channel, so returns do not leak between clients.** This codebase
   pools _connections_ (`ConnectionManagerSingleton`) but gives every
   `AmqpClient` its own `ChannelWrapper`. Two wrappers on one pooled connection,
@@ -124,37 +126,34 @@ For `sendToQueue` to a nonexistent queue, the return arrives with
 
 ---
 
-## 3. Ordering: the return always precedes the confirm
+## 3. Ordering: the return precedes the confirm
 
 RabbitMQ sends `basic.return` before `basic.ack` for the same message, amqplib
 dispatches frames in socket order, and `amqp-connection-manager` resolves the
 publish promise from the confirm callback — so the `'return'` event is observed
-strictly before the promise settles.
+before the promise settles.
 
-Measured, never violated:
+What each run actually instrumented:
 
-| run                  | publishes | unroutable | return-after-its-own-confirm |
-| -------------------- | --------- | ---------- | ---------------------------- |
-| interleaved N=200    | 200       | 100        | **0**                        |
-| interleaved N=2000   | 2000      | 1000       | **0**                        |
-| burst N=50000 + kill | 50000     | 50000      | **0**                        |
-| paced 7620 + kill    | 7620      | 7620       | **0**                        |
+| run                           | publishes  | mixed workload?         | reconnect? | return-after-its-own-confirm | return arriving _after_ its own settle |
+| ----------------------------- | ---------- | ----------------------- | ---------- | ---------------------------- | -------------------------------------- |
+| §4 interleaved N=200          | 200        | yes (50 % routable)     | no         | **0**                        | not measured                           |
+| §4 interleaved N=2000         | 2000       | yes (50 % routable)     | no         | **0**                        | not measured                           |
+| §5 paced 7620 + kill          | 7620       | no (100 % unroutable)   | yes        | not measured                 | not measured                           |
+| §5 burst 50 000 + kill        | 50 000     | no (100 % unroutable)   | yes        | not measured                 | not measured                           |
+| **§6 mixed 12 000 + kill ×4** | **48 000** | **yes (50 % routable)** | **yes**    | **0**                        | **0**                                  |
 
-The single most important derived number, from the 50 000-publish burst with a
-forced reconnect in the middle:
+The two middle rows only ever produced an _end-of-run tally_ of "did a return
+ever arrive for this publish id". That tally cannot distinguish "the return
+arrived before the confirm" from "the return arrived 5 ms after it" — and the
+proposed design reads the flag at settle time, so a late return is a silent
+false negative in production while still scoring as "seen" at end of run. §6 is
+the run that closes that gap.
 
-```
-"resolvedOk": 47353,
-"SILENT_LOSS_okButNoReturn": 0
-```
-
-**Every publish that resolved `Ok` and was in fact unroutable had already had
-its return observed by the time the promise settled.** Zero exceptions.
-
-The return is _not_ the immediately preceding event, though — under load, up to
-96 unrelated events interleaved between a return and its own confirm. So "the
-last return I saw belongs to this publish" is wrong; explicit correlation is
-required.
+Under load the return is _not_ the immediately preceding event: up to 96
+unrelated events interleaved between a return and its own confirm at N=2000. So
+"the last return I saw belongs to this publish" is wrong; explicit correlation
+is required.
 
 ---
 
@@ -169,19 +168,19 @@ when the publish promise settles.
 ```
 publish(target, payload, opts):
   id = nextId()                       // channel-scoped monotonic counter
-  entry = { unroutable: undefined }
+  entry = { unroutable: false }
   pending.set(id, entry)
   try:
     await wrapper.publish(ex, rk, body, { ...opts, mandatory: true,
                                           headers: { ...opts.headers, [H]: id } })
-    // the return, if any, has already been observed (§3)
+    // read the flag HERE, at settle time — §6 measures that no return arrives later
     return entry.unroutable ? Err(new UnroutableMessageError(...)) : Ok()
   finally:
     pending.delete(id)                // no orphan is possible: see §5
 ```
 
 Evidence, 2000 concurrent publishes with 1000 unroutable interleaved among 1000
-routable ones:
+routable ones (no reconnect — that combination is §6):
 
 ```json
 {
@@ -220,9 +219,8 @@ Measured: 6000 paced publishes to one key, binding deleted at #2000.
 }
 ```
 
-**99.4 % of returns were attributed to the wrong publish.** Both a false
-positive (a delivered message reported unroutable) and a false negative (a lost
-message reported `Ok`) on nearly every one. The header is not optional.
+**99.4 % of returns were attributed to the wrong publish** — both false
+positives and false negatives. The header is not optional.
 
 ### Rejected: reusing `messageId` / `correlationId`
 
@@ -236,16 +234,22 @@ established meanings — `correlationId` is already load-bearing for RPC
 
 Forced via the management API, `DELETE /api/connections/{name}` with basic auth
 (`guest:guest`), the port available to integration tests as
-`__TESTCONTAINERS_RABBITMQ_PORT_15672__`. Note the management DB takes ~1 s to
-register a new connection — a test that kills too early lists zero connections
-and silently no-ops.
+`__TESTCONTAINERS_RABBITMQ_PORT_15672__`. **The management DB takes 0.5–5 s to
+register a new connection**; a `DELETE` issued before that silently no-ops
+against an empty listing. Poll `/api/connections` until non-empty first.
 
 ### Can a publish be left permanently unresolved? No.
 
-Across every run — 7620 paced publishes spanning a forced reconnect, and 50 000
-burst publishes with ~40 000 still queued when the connection died — the count
-of publishes that never settled was **0**. Max observed settle latency was
-2063 ms (the reconnect gap plus the requeued backlog).
+Across every run — 7620 paced publishes spanning a forced reconnect, 50 000
+burst publishes with ~40 000 still queued when the connection died, and the four
+§6 runs — the count of publishes that never settled was **0**.
+
+Max settle latency, attributed precisely:
+
+| run                    | max settle latency |
+| ---------------------- | ------------------ |
+| §5 paced 7620 + kill   | 1021 ms            |
+| §5 burst 50 000 + kill | 2063 ms            |
 
 The 50 000-burst reconnect split as:
 
@@ -258,9 +262,15 @@ The 50 000-burst reconnect split as:
   "rejectReasons": ["channel closed"],
   "returnsPerChannelIncarnation": { "1": 7400, "2": 39953 },
   "PIDS_WITH_MULTIPLE_RETURNS": 0,
-  "SILENT_LOSS_okButNoReturn": 0
+  "SILENT_LOSS_okButNoReturn": 0,
+  "maxLatencyMs": 2063
 }
 ```
+
+Note the scope limit on that run: **every publish in it was unroutable**, so
+`PIDS_WITH_MULTIPLE_RETURNS: 0` and `SILENT_LOSS: 0` there are informative about
+false _negatives_ only. There was no routable publish available to be falsely
+blamed, so the run carries no evidence about false positives. §6 supplies that.
 
 - Messages **already sent but unconfirmed** when the connection dropped
   (2647 of them) had their confirm callbacks invoked with an error and
@@ -269,25 +279,18 @@ The 50 000-burst reconnect split as:
   (`ChannelWrapper.js:368`) was not taken. The caller sees a `Defect`.
 - Messages **still queued and never sent** (39 953) were published for the first
   time on the new channel and returned there.
-- **No message produced two returns.** The republish-with-the-same-headers
-  hazard did not materialise in any run.
 
 ### The worst window: return delivered, confirm never
 
-Tested directly with a TCP proxy that parses the broker→client frame stream,
-forwards bytes up to and including the returned message's body frame, and then
-destroys the socket — so the client observes the return and can never receive
-the ack.
+Tested with a TCP proxy that parses the broker→client frame stream, forwards
+bytes up to and including the returned message's body frame, then destroys the
+socket — so the client observes the return and can never receive the ack.
 
 ```
 [11ms] >>> forwarded the basic.return, now destroying the TCP connection
 [11ms] RETURN pid=SPLIT-1 incarnation=1
-[12ms] DISCONNECT: Unexpected close
 [12ms] publish -> REJECTED: channel closed after 2ms
-```
-
-```json
-{ "publishOutcome": "REJECTED: channel closed", "DUPLICATE_RETURN_AFTER_RECONNECT": false }
+DUPLICATE_RETURN_AFTER_RECONNECT: false
 ```
 
 The publish rejects in 2 ms. It does not hang, and the message is not
@@ -299,21 +302,104 @@ An implementation may optionally report `UnroutableMessageError` rather than the
 generic channel-closed `Defect` here, since the return _was_ observed. That is
 strictly more information; it is not required for correctness.
 
-### The one residual correlation hazard
+### The duplicate-return hazard is UNTESTED, not disproven
 
-If a message is requeued rather than rejected (the `!this._channel` branch), it
-is republished with the _same_ headers and therefore the same publish id. The
-design above tolerates that — the second return simply re-sets the same boolean
-on a still-registered entry. The only misreport it can produce is: attempt 1
+If a message takes the requeue branch of `_messageRejected` rather than the
+reject branch, it is republished with the _same_ headers and therefore the same
+publish id, and can produce a second return. Every run reported
+`PIDS_WITH_MULTIPLE_RETURNS: 0` — but that proves the hazard never _fired_, not
+that the design survives it.
+
+`_messageRejected` was instrumented directly to count which branch each
+rejection takes. Two disturbance mechanisms were tried:
+
+| disturbance                                    | reject branch | requeue branch |
+| ---------------------------------------------- | ------------- | -------------- |
+| connection-level force close (management API)  | 0             | 0              |
+| channel-level 404 (exchange deleted mid-burst) | 300           | 0              |
+| 50 000-message in-flight burst + force close   | 2647          | 0              |
+
+**The requeue branch was never reached in any attempt.** On amqplib 2.0.1,
+pending confirm callbacks are invoked with an error before
+`amqp-connection-manager`'s channel-close handler clears `this._channel`, so the
+`!this._channel` guard is false and the reject branch always wins. That may be
+timing-dependent rather than structural.
+
+An implementation must therefore be idempotent **by construction, not by
+evidence**. The design above is: a second return simply re-sets the same boolean
+on a still-registered entry. Its one misreport remains analytic — attempt 1
 unroutable, connection drops, binding restored during the gap, attempt 2
-routable → reported unroutable. That requires the topology to be repaired inside
-the reconnect window, and it fails in the safe direction (a spurious error on a
-message that got through, which at-least-once delivery already permits callers
-to handle).
+routable → reported unroutable. That fails in the safe direction (a spurious
+error on a message that got through, which at-least-once already permits), but
+it has not been observed and should be covered by a unit test that fakes the
+republish rather than by an integration test that cannot trigger it.
 
 ---
 
-## 6. Per-publish cost
+## 6. Mixed workload across a forced reconnect, verdict read at settle time
+
+This is the configuration the other runs were missing: both error oracles active
+at once, and the flag sampled at the exact instant the design would read it.
+
+- **Ground truth** = routing key. The binding is re-asserted by `setup` on every
+  reconnect, so routability is constant by construction for the whole run.
+- **Verdict** = `entry.unroutable` read synchronously inside the promise's
+  settle handler.
+- **False negative** = truly unroutable, verdict said routable (silent loss).
+- **False positive** = truly routable, verdict said unroutable.
+- **Late return** = the flag flipped _after_ the settle-time snapshot — the
+  silent-false-negative mode an end-of-run tally cannot see.
+- Publishes rejected with `"channel closed"` have unknown routability and are
+  excluded from both oracles.
+
+Four runs, 12 000 publishes each (50 % routable), connection force-closed at a
+different point in each:
+
+| kill at batch | resolved Ok | truly unroutable | truly routable | rejected | FN    | FP    | late returns | order violations | dup returns |
+| ------------- | ----------- | ---------------- | -------------- | -------- | ----- | ----- | ------------ | ---------------- | ----------- |
+| 2             | 11 093      | 5586             | 5507           | 907      | 0     | 0     | 0            | 0                | 0           |
+| 3             | 11 073      | 5537             | 5536           | 927      | 0     | 0     | 0            | 0                | 0           |
+| 6             | 11 349      | 5750             | 5599           | 651      | 0     | 0     | 0            | 0                | 0           |
+| 10            | 11 816      | 6000             | 5816           | 184      | 0     | 0     | 0            | 0                | 0           |
+| **total**     | **45 331**  | **22 873**       | **22 458**     | **2669** | **0** | **0** | **0**        | **0**            | **0**       |
+
+Representative raw output:
+
+```json
+{
+  "publishes": 12000,
+  "disconnects": 1,
+  "channelIncarnations": 2,
+  "settleOutcome": "ALL-SETTLED",
+  "permanentlyUnsettled": 0,
+  "resolvedOk": 11073,
+  "rejected_routabilityUnknown": 927,
+  "oracle": {
+    "okAndTrulyUnroutable": 5537,
+    "okAndTrulyRoutable": 5536,
+    "FALSE_NEGATIVES_lostButReportedOk": 0,
+    "FALSE_POSITIVES_deliveredButReportedUnroutable": 0
+  },
+  "LATE_RETURNS_arrivedAfterItsOwnSettle": 0,
+  "returnAfterItsOwnConfirm_seqViolations": 0,
+  "pidsWithMultipleReturns": 0
+}
+```
+
+Each run allowed a 5-second grace period after the last settle before tallying,
+so a late return had every opportunity to appear. None did.
+
+**What this does and does not establish.** It establishes that across 45 331
+successfully-confirmed publishes spanning four forced reconnects, with roughly
+equal routable and unroutable traffic, the settle-time verdict was correct every
+time. It does not establish a probabilistic bound — 0/45 331 on loopback with a
+sub-millisecond RTT is consistent with a rare ordering violation on a
+high-latency link — and it says nothing about brokers other than RabbitMQ 4.2.1
+or clients other than amqplib 2.0.1.
+
+---
+
+## 7. Per-publish cost
 
 **Wire.** An AMQP field-table entry costs `1 + len(name) + 1 + 4 + len(value)`
 bytes.
@@ -329,7 +415,9 @@ channel-scoped monotonic counter is sufficient and 19 bytes is the number to
 budget. On a 60-byte JSON body that is ~30 % overhead; on a realistic 500-byte
 event, ~4 %.
 
-**Latency.** Sequential publish-and-await, 3000 iterations after 300 warmup:
+**Latency**, sequential publish-and-await (each publish awaited before the next
+is issued), 3000 iterations after 300 warmup, small two-field JSON body, single
+channel, loopback broker, all publishes routable:
 
 | variant          | p50 (ms) | p95    | p99    | mean   |
 | ---------------- | -------- | ------ | ------ | ------ |
@@ -339,7 +427,9 @@ event, ~4 %.
 **+0.4 % mean, inside the noise floor.** For any workload that awaits its
 publishes, the cost is not measurable.
 
-**Throughput,** 20 000 publishes fired without backpressure:
+**Throughput**, 20 000 publishes enqueued in one synchronous loop with no
+backpressure (all in flight simultaneously), 60-byte JSON body, single channel,
+loopback broker, all publishes routable so returns are not a factor:
 
 | variant          | msg/s  | vs plain |
 | ---------------- | ------ | -------- |
@@ -347,9 +437,9 @@ publishes, the cost is not measurable.
 | mandatory only   | 88 560 | −9.3 %   |
 | mandatory + corr | 85 979 | −12.0 %  |
 
-Most of that is `mandatory` itself (the broker doing routing bookkeeping and
-emitting returns for 100 % of these publishes), not the correlation. The
-correlation adds 2.7 points on top.
+Most of the cost is `mandatory` itself, not the correlation; the correlation
+adds 2.7 points on top. This is a worst-case shape — maximum pipelining, tiny
+bodies, zero network latency — chosen so the overhead is visible at all.
 
 **Bookkeeping.** One `Map` entry per in-flight publish, deleted on settle;
 `pendingMapLeftover: 0` in every benchmark. Bounded by concurrency, not by
@@ -358,40 +448,42 @@ throughput.
 **Visibility.** The header is delivered to consumers — it appears in
 `properties.headers` on the receiving side and is not stripped. It does not break
 headers-exchange routing (verified with `x-match: all`), but it is permanently
-part of every message this library ever publishes, including messages consumed
-by systems that are not using this library.
+part of every message this library publishes, including messages consumed by
+systems that are not using this library.
 
 ---
 
-## 7. What rung 3 provably does _not_ cover
+## 8. What rung 3 provably does _not_ cover
 
-These are measured negative results, not caveats-by-analogy.
+Measured negative results, not caveats-by-analogy.
 
-1. **RPC replies cannot be covered.** RabbitMQ ignores `mandatory` on
-   `amq.rabbitmq.reply-to`. With the requester's connection fully closed, a
-   `mandatory` reply publish to its direct-reply-to pseudo-queue produced
-   **zero returns** — the reply is silently dropped. `worker.ts:964` is
-   therefore out of reach; a dead RPC requester still surfaces only as the
-   caller's `RpcTimeoutError`.
+1. **`amq.rabbitmq.reply-to` cannot be covered.** RabbitMQ ignores `mandatory`
+   on the direct reply-to pseudo-queue. With the requester's connection fully
+   closed, a `mandatory` reply publish produced **zero returns** — the reply is
+   silently dropped. Since `client.ts` sets `replyTo: DIRECT_REPLY_TO` for every
+   RPC it issues, `worker.ts:964` is out of reach _for this library's own RPC
+   clients_. The narrower claim is the accurate one: this is a property of
+   direct reply-to, not of reply publishing in general — a third-party requester
+   that set `replyTo` to a real declared queue would get a normal return if that
+   queue were deleted, so `mandatory` is not universally inert on that code path.
 2. **An alternate exchange suppresses the return, correctly.** An exchange
    declared with `alternate-exchange` routes its otherwise-unroutable messages
    to the AE; the message lands in the AE's queue and **no return is issued**.
-   That is right — the message _was_ routed — but it means "no return" means
+   That is right — the message _was_ routed — but "no return" then means
    "routed somewhere", not "routed to the queue you intended".
 3. **`Ok` still does not mean "processed".** A return only fires when the
-   exchange matches _zero_ queues. A message dropped by `x-max-length`
-   overflow, expired by a queue TTL, or sitting in a queue nobody consumes is
-   routed, confirmed, and returns nothing.
-4. **The reconnect window is best-effort.** 2647 of 50 000 publishes in the
-   burst test rejected with `"channel closed"` — their routability is unknown,
-   as it is today.
+   exchange matches _zero_ queues. A message dropped by `x-max-length` overflow,
+   expired by a queue TTL, or sitting in a queue nobody consumes is routed,
+   confirmed, and returns nothing.
+4. **The reconnect window is best-effort.** 2669 of 48 000 publishes in the §6
+   runs (and 2647 of 50 000 in §5) rejected with `"channel closed"` — their
+   routability is unknown, as it is today.
 
 There is also a framing correction worth recording: **"topology never set up in
 this environment" is already impossible.** `setupAmqpTopology` runs inside the
 channel `setup` callback (`amqp-client.ts:235`) and asserts every exchange,
-queue, and binding in the contract on _every_ connect and reconnect. The
-library creates its own topology. What rung 3 actually guards is narrower than
-the framing suggests:
+queue, and binding in the contract on _every_ connect and reconnect. What rung 3
+actually guards is narrower than the original framing suggests:
 
 | scenario                                                                                   | covered by                       | rung 3 adds                 |
 | ------------------------------------------------------------------------------------------ | -------------------------------- | --------------------------- |
@@ -406,21 +498,26 @@ the framing suggests:
 
 **Implement rung 3.**
 
-The single strongest piece of evidence: across 50 000 publishes spanning a
-broker-forced reconnect, `SILENT_LOSS_okButNoReturn` was **0** and
-`PIDS_WITH_MULTIPLE_RETURNS` was **0** — header-correlated detection produced
-neither a false negative nor a false positive, including when a TCP-level cut
-delivered the return and destroyed the connection before the confirm could
-arrive (that case rejects in 2 ms rather than hanging or double-reporting).
+The reason is the last row of the table above, not a zero-defect measurement
+count. `externalConsumers: true` (`contract/src/types.ts:878`) is the escape
+hatch rungs 1 and 2 hand to anyone whose consumer lives in another service, and
+it is exactly the population most likely to have drifted: another team's deploy,
+another repo's contract, a queue decommissioned without telling the publisher.
+For those publishers there is **no check at any level today** — define-time,
+connect-time, or runtime — and the failure mode is total, permanent, silent
+message loss with `publish()` reporting success. Rung 3 is the only thing that
+can catch it, and it catches it on the first message.
 
-The decisive _product_ argument is the last row of the table above.
-`externalConsumers: true` is the escape hatch rungs 1 and 2 hand to anyone whose
-consumer lives in another service, and it is exactly the population most likely
-to have drifted: another team's deploy, another repo's contract, a queue
-decommissioned without telling the publisher. For those publishers there is
-currently **no check at any level** — define-time, connect-time, or runtime —
-and the failure mode is total, permanent, silent message loss. Rung 3 is the
-only thing that can catch it, and it catches it on the first message.
+The measurements support that decision without carrying it. What they establish
+is that the mechanism is sound enough to build on: 45 331 confirmed publishes of
+mixed routable/unroutable traffic across four forced reconnects produced no
+false negative, no false positive, and no return arriving after its own settle
+(§6); a TCP-level cut delivering the return and destroying the connection before
+the confirm rejects in 2 ms rather than hanging or double-reporting (§5); and
+header-free correlation is definitively ruled out (§4). What they do **not**
+establish: a probabilistic bound on a high-latency link, and anything at all
+about the requeue-branch duplicate-return hazard, which no attempt could
+trigger (§5).
 
 ### Proposed API shape
 
@@ -437,7 +534,16 @@ TypedAmqpClient.create({
 });
 ```
 
-### Signature changes required
+### Signature changes and internal blast radius
+
+**The type widens unconditionally.** `onUnroutable: "ignore"` changes runtime
+behaviour but not the static type, so _every_ consumer of
+`AmqpClient.publish`'s result must be updated regardless of the default — unless
+the option is encoded in the type system (a generic, or a separate method),
+which is more complex and is the alternative worth weighing during
+implementation.
+
+Public surface:
 
 | location                              | from                                        | to                                                 |
 | ------------------------------------- | ------------------------------------------- | -------------------------------------------------- |
@@ -446,30 +552,37 @@ TypedAmqpClient.create({
 | `PublishError` (`interceptors.ts:12`) | `MessageValidationError`                    | `MessageValidationError \| UnroutableMessageError` |
 | `TypedAmqpClient.publish`             | `AsyncResult<void, MessageValidationError>` | `AsyncResult<void, PublishError>`                  |
 
-This is a **breaking change**: every user `errCases` matcher that handles only
+Breaking: every user `errCases` matcher handling only
 `P.tag("@amqp-contract/MessageValidationError")` without a `P._` catch-all stops
-compiling. It needs a major bump, a changeset, and an upgrade-guide entry.
+compiling. Major bump, changeset, upgrade-guide entry.
 
-Additional implementation notes for whoever picks this up:
+Internal call sites that break — all four must be fixed in the same change:
+
+| site                             | current shape                                                                                              | why it breaks / what it needs                                                                                                                                                                                                                                                                                                                                                                 |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `worker.ts:964` `publishReply`   | `.publish(...).recoverDefect(cause => Err<HandlerError>(...))`, declared `AsyncResult<void, HandlerError>` | `recoverDefect` only collapses the defect channel, so the widened `E` survives and the result is `UnroutableMessageError \| HandlerError` — not assignable to `HandlerError`. Needs an explicit `mapErrCases` folding `UnroutableMessageError` into `NonRetryableError`, matching the documented "reply failure → DLQ" policy.                                                                |
+| `retry.ts:310` `publishForRetry` | `.publish(...).map(ack).tapDefect(log)`, declared `AsyncResult<void, never>`                               | Declared `E = never` no longer holds. Semantically the `.map` short-circuit already skips the ack on `Err`, so **invariant 1 (retry publishes before ack) survives** — but `tapDefect` will not fire for an `Err`, so the failure would go unlogged. Needs a `tapErrCases` alongside it. Invariant 14's default-exchange republish is routable by construction, so no new failure mode there. |
+| `client.ts:487`                  | contract publish, wrapped by interceptors                                                                  | The intended surface. `PublishError` widening flows through `chainInterceptors` and the `PublishInterceptor` type.                                                                                                                                                                                                                                                                            |
+| `client.ts:728` `publishRequest` | declared `AsyncResult<void, never>`, feeds `call()`                                                        | Declared `E = never` no longer holds, and `call()`'s error union gains `UnroutableMessageError`. Behaviourally an improvement — a missing RPC queue fails fast instead of waiting out `RpcTimeoutError` — but it is a second breaking union widening, on a separate public method.                                                                                                            |
+
+Additional implementation notes:
 
 - Register the `'return'` listener inside `AmqpClient`'s `defaultSetup`
-  (`amqp-client.ts:235`), before the user-setup wrapper, so it survives every
-  reconnect and cannot be displaced by a user-supplied `channelOptions.setup`.
+  (`amqp-client.ts:235`), before the user-setup wrapper at line 257, so it
+  survives every reconnect and cannot be displaced by a user-supplied
+  `channelOptions.setup`.
 - The publish id must be **channel-scoped** and reset per incarnation; reuse the
   existing `channelEpoch` counter (`amqp-client.ts:206`) as its prefix rather
   than inventing a second one.
 - Merge the header into `options.headers`; never replace the table.
-- `retry.ts:310` republishes to the _original_ exchange or, for classic-queue
-  immediate requeue, to the default exchange. Turning `mandatory` on there
-  converts a silently-lost retry into a modeled error, which is desirable, but
-  it changes the retry pipeline's error surface — see load-bearing invariants
-  1, 3 and 14 in `CLAUDE.md`. Cover it explicitly.
-- Do **not** enable `mandatory` on the RPC reply path (`worker.ts:964`); per §7
-  it is inert there and only costs bytes.
-- Guarding test to add to the invariant list: an unroutable publish on a
-  contract with `externalConsumers: true` returns `Err(UnroutableMessageError)`
-  while a routable one on the same channel returns `Ok`, both published
-  concurrently.
+- Do **not** enable `mandatory` on the RPC reply path (`worker.ts:964`) — per §8
+  it is inert for this library's own clients and only costs bytes. Fix the
+  _type_ there; leave the behaviour alone.
+- Guarding tests to add: (a) an unroutable publish on an
+  `externalConsumers: true` contract returns `Err(UnroutableMessageError)` while
+  a routable one on the same channel returns `Ok`, both published concurrently;
+  (b) a **unit** test that fakes a republish of the same publish id, since §5
+  shows the requeue branch cannot be reached from an integration test.
 
 ### If this is deferred instead
 
@@ -485,13 +598,26 @@ their own return listener via the already-public
 
 ## Reproduction
 
-All experiments were throwaway scripts run against a standalone
-`rabbitmq:4.2.1-management-alpine` container on ports 45672/45673, and were
-deleted after the run. The ten of them covered: reachability and message dump;
-correlation under concurrency at N=200/2000; a paced reconnect with management-API
-force-close; a 50 000-message in-flight burst kill; alternate-exchange, headers-exchange,
-and `sendToQueue` edge cases; throughput and sequential-latency benchmarks; channel
-isolation across a pooled connection; a frame-parsing TCP proxy that splits the
-return from the confirm; FIFO-correlation soundness under a mid-flight unbind;
-and an end-to-end check through the built `AmqpClient`. Raw output is recorded in
+All experiments were throwaway `.mjs` scripts run against a standalone
+`rabbitmq:4.2.1-management-alpine` container on ports 45672/45673, deleted after
+the run. Fourteen experiments across fifteen files:
+
+| script                          | covers                                                               |
+| ------------------------------- | -------------------------------------------------------------------- |
+| `01-reachability`               | §1 reachability, §2 message dump, §3 first ordering datapoint        |
+| `02-concurrency`                | §4 header correlation at N=200 / N=2000                              |
+| `03-reconnect`                  | §5 paced 7620 + management-API force close                           |
+| `04-inflight-kill`              | §5 50 000-message in-flight burst kill                               |
+| `05-alternatives`               | §4 FIFO ordering, §8 alternate exchange, `sendToQueue`, §7 wire cost |
+| `06-overhead`                   | §7 throughput                                                        |
+| `07-seq-latency`                | §7 sequential latency                                                |
+| `08-channel-isolation`          | §1 per-channel isolation across a pooled connection                  |
+| `09-direct-reply-to`            | §8 `amq.rabbitmq.reply-to`                                           |
+| `10-proxy-split` (+`10b-debug`) | §5 frame-parsing TCP proxy splitting the return from the confirm     |
+| `11-real-client`                | §1 end-to-end through the built `AmqpClient`                         |
+| `12-fifo-unsound`               | §4 FIFO misattribution under a mid-flight unbind                     |
+| `13-mixed-reconnect`            | §6 mixed workload + reconnect, settle-time verdict                   |
+| `14-requeue-branch`             | §5 `_messageRejected` branch instrumentation                         |
+
+Raw output for every run is recorded in
 `.superpowers/sdd/2026-08-01-h1-unroutable-publish/task-6-report.md`.

--- a/docs/superpowers/specs/2026-08-01-robustness-hardening-design.md
+++ b/docs/superpowers/specs/2026-08-01-robustness-hardening-design.md
@@ -251,9 +251,77 @@ cannot.
 
 ---
 
+## Carried forward from the H1 implementation
+
+H1 shipped on branch `audit/h1-unroutable-publish`. These items were triaged during that work
+and deliberately deferred — the final whole-branch review confirmed none of them blocks merge.
+Recorded here because the working ledger is scratch and does not survive.
+
+**Feed into the H2–H4 / mock-removal plan:**
+
+- **`@amqp-contract/tests` has no `@unthrown/vitest` dependency and no `setupFiles`**, so unthrown
+  matchers are unavailable across the whole integration suite; every spec hand-rolls `isOk()`.
+  Small shared-test-config change.
+- **`docs/**/*.md` and the JSDoc `@example` blocks in ~5 source files are unswept.** Smaller than
+  first feared — the main guides (`docs/index.md`, `getting-started.md`,
+  `how-to/define-a-contract.md`) route correctly via `defineEventConsumer`/`defineCommandConsumer`.
+  Neither markdown nor JSDoc is typechecked, so nothing breaks CI.
+- **`packages/client/src/client-cleanup.spec.ts` → "releases the pooled connection when
+  waitForConnect times out" is flaky** under full-monorepo parallel load. Passes 3/3 in isolation;
+  the full suite passes on retry. Pre-existing — the H1 branch changed no runtime source in
+  `client` or `core`. Worth de-flaking: a flaky test erodes trust in the CI signal.
+- **Coverage floors** for `core` / `worker` / `client` (see the table above) still sit far below
+  actual and cannot catch a regression.
+
+**Independent bug, pre-existing and live:**
+
+- **`MatchingBindingPattern` (`packages/contract/src/builder/routing-types.ts:165`) has a
+  template-literal hole.** Its non-literal escape valve tests `string extends Pattern`, which does
+  not catch template-literal types — so a pattern typed `` `order.${string}` `` resolves to the
+  error-message type and produces a **false compile error on a valid binding**. Unlike the same
+  hole in `RoutableRoutingKey` (inert, since nothing wires it), `MatchingBindingPattern` **is**
+  wired into `defineEventConsumer`, so this one is live today. Not introduced by H1; worth its own
+  fix outside this design.
+
+**Minor, low value, fix opportunistically:**
+
+- `_internal_isPublisherRoutable` has no production callers — kept as a stable boolean view with
+  its own tests.
+- `routability.ts` marks its BFS `visited` set on dequeue rather than enqueue, so a node can be
+  queued twice; bounded and correctness-neutral, but the inline comment overstates the guard.
+- The runtime and type-level match corpora have no length guard, so they can drift (one missing
+  case was already found this way). `expect(MATCH_CORPUS).toHaveLength(N)` would pin it.
+- Type-level rejection assertions use the weak `.not.toEqualTypeOf` form; the dangerous direction
+  is still caught, only error-message wording is unguarded.
+- `definePublisher` options do not go through `_internal_assertKnownKeys`, unlike its sibling
+  builders, so a typo'd option name yields the unroutable error rather than "unknown option".
+  Fail-safe direction only.
+
+**Operational notes for the rung-3 implementation plan:**
+
+- A 40,000-message `mandatory`-unroutable burst killed the broker container outright. Keep
+  integration bursts at or below ~12k.
+- The management API takes 0.5–5s to register a connection; `DELETE /api/connections/{name}`
+  before that silently no-ops. Poll `/api/connections` until non-empty first.
+- The `_messageRejected` requeue branch proved **unreachable** from integration (0 of 2,947
+  rejections, via both connection-kill and channel-level 404). The duplicate-return hazard is
+  therefore untested rather than disproven, and needs a unit test faking the republish.
+
+---
+
 ## Open questions
 
-### H1 rung 3 correlation mechanism — requires a spike
+### H1 rung 3 correlation mechanism — resolved by the spike
+
+The spike ran and its findings are committed at
+`docs/superpowers/specs/2026-08-01-h1-rung3-spike-findings.md`. Outcome: `basic.return` is
+reachable via the raw `ConfirmChannel` handed to the `setup` callback (not via `ChannelWrapper`,
+which never emits it), and header-based correlation held across 45,331 confirmed publishes with a
+forced reconnect — 0 false negatives, 0 false positives. **Recommendation: implement rung 3**,
+justified primarily by the coverage gap (`externalConsumers: true` publishers have no check at any
+rung and fail totally and silently), not by the loopback measurements alone.
+
+### Original framing, retained for context
 
 A returned (unroutable) message arrives before its confirm, so publishes must be correlated
 with returns. Normally this uses the confirm sequence number, but `amqp-connection-manager`

--- a/docs/superpowers/specs/2026-08-01-robustness-hardening-design.md
+++ b/docs/superpowers/specs/2026-08-01-robustness-hardening-design.md
@@ -1,0 +1,302 @@
+# Robustness hardening for 3.0 stable
+
+**Date:** 2026-08-01
+**Status:** Approved design, ready for implementation planning
+
+## Context
+
+`@amqp-contract/*` carries production financial workloads for external clients. This spec
+defines a hardening pass targeting four properties: strong typing, a strong API, patterns
+that make end-user best practices automatic, and high-quality tests that do not mock the
+broker.
+
+The trigger is proactive, not incident-driven. Breadth over depth: close the systemic gaps
+in priority order.
+
+### The sequencing constraint
+
+3.0 stable has **not** shipped. npm shows `latest: 2.4.0`, `beta: 3.0.0-beta.4`, with ~20
+changesets pending.
+
+The four properties have different clocks:
+
+- **Typing, API shape, enforced patterns** — breaking. Free inside the beta window; after
+  3.0.0 the same improvement costs a 4.0 and a migration for every client running real money.
+- **Test coverage and mock removal** — additive. Costs the same today or in six months.
+
+**Decision: hold 3.0 stable until the API hardening below lands.** Test hardening follows
+continuously and does not gate the release.
+
+## Non-goals
+
+- Refactoring for its own sake. Every change traces to a hazard in the catalog.
+- Throughput or latency optimization. Where safety and throughput conflict, safety wins and
+  the trade is documented.
+- Idempotency/deduplication machinery (H5) beyond documentation — deferred.
+- Toxiproxy or network-level fault injection — deferred (see Testing).
+
+## The safety ladder
+
+The organizing principle. For any unsafe configuration, the question is _when it is caught_:
+
+1. **Impossible** — the type system rejects it
+2. **Fails fast** — throws at `defineContract` / `create`, before a message moves
+3. **Safe by default** — the right thing happens unless explicitly opted out
+4. **Warned** — logged at runtime, after the damage
+
+Every hazard below currently sits on rung 3 or 4, or is entirely unguarded. Each one moves as
+far up as it economically goes.
+
+**Enforcement policy: fail fast with no implicit escape hatch.** An unsafe contract throws.
+Opting out requires the author to write it explicitly (`onPoison: "drop"`,
+`prefetch: "unbounded"`). A client upgrading must consciously acknowledge each hazard; the
+migration guide carries that burden.
+
+---
+
+## Hazard catalog
+
+### H1 — Unroutable publish reports success
+
+**Severity: critical. Currently unguarded at every rung.**
+
+`defineContract` accepts a publisher whose routing key matches no binding in the contract.
+Verified empirically: a contract with `publishers: { orderCreated }` on a topic exchange with
+routing key `order.created` and zero bindings is accepted without complaint.
+
+At runtime `client.publish(...)` resolves to `Ok(void)`, because RabbitMQ publisher confirms
+mean _the broker took responsibility_, not _a queue received it_. A message routed to zero
+queues is confirmed and discarded.
+
+Client-visible consequence: a typo in a binding pattern, or a consumer deployed without its
+topology set up, and every message silently vanishes while the publishing code observes
+success. No error, no log, no metric.
+
+This library is uniquely able to fix this at the top of the ladder because the contract knows
+the entire topology at define time — a generic AMQP client cannot. The type-level machinery
+already exists: `MatchesPattern` / `MatchingBindingPattern` in
+`packages/contract/src/builder/routing-types.ts`.
+
+#### Rung 1 — type-level routability
+
+`defineContract` checks each publisher's routing key against the union of binding patterns on
+the same exchange, reusing `MatchesPattern`.
+
+On no match, resolve to a template-literal error-message type naming the publisher, its
+routing key, and the exchange — following the established `MatchingBindingPattern` convention
+(`routing-types.ts:162`) so the compile error is readable rather than a bare `never`.
+
+Escape valve, matching existing behavior: if either side is non-literal `string`, skip the
+check. It cannot be decided at compile time.
+
+Exchange type changes the rule and must be handled explicitly:
+
+| Exchange type | Routability rule                                          |
+| ------------- | --------------------------------------------------------- |
+| `direct`      | exact string equality between routing key and binding key |
+| `topic`       | AMQP pattern match (`*`, `#`) via `MatchesPattern`        |
+| `fanout`      | routing key ignored by broker — routable iff ≥1 binding   |
+| `headers`     | matches on arguments, not keys — key check does not apply |
+
+**Risk:** this is a cross-product over two records. TypeScript recursion depth and compile
+time are real concerns. Mitigation: check each publisher against a _union_ of that exchange's
+patterns so union distribution does the work rather than nested recursion. `tsc` wall-clock on
+the example contracts is an acceptance criterion (see below).
+
+#### Rung 2 — define-time throw
+
+The type check cannot see JS callers, dynamically-built contracts, or non-literal routing
+keys. `defineContract` therefore also computes routability at runtime and throws, naming the
+publisher, its routing key, the exchange, and the patterns that _are_ declared on it.
+
+This requires a runtime topic matcher — new, small, pure, total.
+
+**Derived invariant:** the runtime matcher and the type-level matcher must agree on every
+input. Pinned by a property-based test (see Testing).
+
+#### Rung 3 — runtime unroutable detection
+
+`mandatory: true` on publishes plus a `basic.return` listener on the channel. An unroutable
+message is returned by the broker before its confirm; each publish must be correlated with any
+return issued against it.
+
+`publish()` gains `UnroutableMessageError` in its error channel — a **modeled error**, not a
+defect, because it is expected and actionable by the caller. This is a breaking signature
+change and is a primary reason the release is held.
+
+**This mechanism requires a spike before implementation** — see Open Questions.
+
+### H2 — DLX-less queue drops messages
+
+**Current rung: 4 (warning).** `packages/worker/src/retry.ts:360` logs
+`"Queue does not have DLX configured - message will be lost on nack"` — emitted at the instant
+the message is already being lost, and only when a logger is wired.
+
+**Target rung: 2.** `defineQueue` throws unless the queue has a dead-letter exchange or the
+author explicitly writes `onPoison: "drop"`.
+
+### H3 — Unbounded prefetch
+
+**Current: no rung.** `packages/core/src/amqp-client.ts:455` only calls `basic.qos` when
+`prefetch` is explicitly set. Unset means AMQP's default: unlimited. The broker pushes the
+entire ready backlog into a single worker — unbounded memory, and a crash redelivers all of it
+at once.
+
+**Target rung: 3.** Default `prefetch: 10`. Conservative and predictable: bounds in-flight
+memory to 10 messages per consumer and keeps the redelivery burst small. Throughput-bound
+users raise it explicitly. `prefetch: "unbounded"` is the explicit opt-out.
+
+### H4 — No `publishTimeoutMs` default
+
+**Current: no rung.** The option exists (`packages/client/src/client.ts:133`) but defaults to
+undefined, so publishes issued during a broker outage buffer without bound and their promises
+never settle.
+
+**Target rung: 3.** Default `publishTimeoutMs: 30000` — long enough that a brief reconnect
+does not fail healthy publishes, short enough that an outage surfaces as an error rather than
+an unbounded buffer.
+
+### H5 — No idempotency support
+
+At-least-once delivery is inherent and correct, but the library offers clients no help
+deduplicating. **Deferred to documentation only** for this pass. Not an enforcement change.
+
+---
+
+## Testing strategy
+
+### What "no mocks" means here
+
+Two distinct things get conflated:
+
+- **Mocking the broker** — `vi.mock("amqp-connection-manager")`, present in 9 spec files.
+  Harmful: it proves the code matches _our beliefs about RabbitMQ_, which is exactly the
+  assumption that breaks in production. These are the target.
+- **A test double for a user-supplied callback** — a handler that throws, a telemetry provider
+  that throws. Not mocking a dependency; it is the test's input. Legitimate, retained.
+
+The 9 broker-mocking specs are:
+
+```
+packages/core/src/channel-epoch.spec.ts
+packages/core/src/publish-buffer-full.spec.ts
+packages/core/src/connection-manager.spec.ts
+packages/core/src/amqp-client-error-events.spec.ts
+packages/worker/src/publish-timeout.spec.ts
+packages/worker/src/rpc-reply-failure.spec.ts
+packages/client/src/unknown-names.spec.ts
+packages/client/src/publish-timeout.spec.ts
+packages/client/src/rpc-timeout.spec.ts
+```
+
+These cover the highest-risk paths in the library — reconnect/epoch, buffer-full,
+connection-pool leasing, RPC timeout, retry-publish failure.
+
+### Prove the loss, then prove the guard
+
+Each hazard gets a pair of real-broker tests:
+
+1. A test demonstrating the hazard is **genuine** — publish to a deliberately unbound routing
+   key and assert the message is actually gone from the broker.
+2. A test demonstrating the guard **catches** it.
+
+The first test documents why the guard exists and fails loudly if anyone weakens it. It also
+makes the hazard catalog credible to a client as evidence rather than as a claim.
+
+### Fault injection: management API
+
+`packages/testing/src/global-setup.ts` already exposes port 15672 and provides it to tests
+(`__TESTCONTAINERS_RABBITMQ_PORT_15672__`), and each test already gets an isolated vhost.
+The RabbitMQ management HTTP API is therefore reachable today with **no new infrastructure**.
+
+Capabilities used:
+
+- `DELETE /api/connections/{name}` — force-close a connection server-side, producing a genuine
+  reconnect rather than a synthesized `'error'` emit. This is what de-mocks the channel-epoch
+  and error-event specs.
+- Deleting queues/bindings mid-flight — consumer-cancel and topology-drift paths.
+
+**Accepted limit:** write-buffer-full is internal `ChannelWrapper` state. Producing it
+naturally requires publishing faster than the socket drains, which is inherently
+timing-dependent. `publish-buffer-full.spec.ts` may remain broker-mocked. Network-level
+throttling (Toxiproxy) would close this and is explicitly deferred; revisit only if the
+remaining mocked tests are found to hide real bugs.
+
+### Property-based tests
+
+The runtime topic matcher and the type-level matcher must agree on every input. `fast-check`
+over generated routing-key/pattern pairs pins this. Scope is deliberately narrow — the matcher
+is pure and total, which is where property testing pays without straining CI.
+
+### Coverage floors
+
+Ratchet after the work lands, not before. Current state for reference:
+
+| Package  | Stmts | Branch | Funcs | Lines | Floors (s/b/f/l) |
+| -------- | ----- | ------ | ----- | ----- | ---------------- |
+| core     | 54.17 | 39.52  | 47.50 | 55.52 | 20/10/12/20      |
+| client   | 61.11 | 54.32  | 60.93 | 62.72 | 14/15/18/14      |
+| worker   | 76.06 | 67.35  | 79.16 | 75.96 | 30/33/31/30      |
+| contract | 94.88 | 91.56  | 93.18 | 95.16 | 90/88/90/90      |
+| asyncapi | 98.22 | 80.51  | 100   | 98.17 | 95/78/95/95      |
+
+`core` is both the weakest and the most safety-critical, and its floors are the loosest in the
+repo: a **10%** branch floor against 39.52% actual means roughly three quarters of its covered
+branches could regress without CI noticing. `worker` and `client` floors likewise sit at less
+than half their actual coverage.
+
+Ratchet all three to just under actual once this work lands, following the convention already
+applied to `contract` — the floors exist to catch regressions, and at their current values they
+cannot.
+
+---
+
+## Open questions
+
+### H1 rung 3 correlation mechanism — requires a spike
+
+A returned (unroutable) message arrives before its confirm, so publishes must be correlated
+with returns. Normally this uses the confirm sequence number, but `amqp-connection-manager`
+abstracts that away.
+
+Likely approach: stamp a unique header on each publish and match returns by it. This must be
+**proven against a real broker before being specced**, including behavior when a return arrives
+during a reconnect. Resolve this before writing the H1 rung 3 implementation plan; H1 rungs 1
+and 2 are unblocked and can proceed in parallel.
+
+---
+
+## Acceptance criteria
+
+1. A contract with a publisher whose routing key matches no binding fails to compile, with an
+   error naming the publisher, its routing key, and the exchange.
+2. The same contract built dynamically (defeating the type check) throws from
+   `defineContract`, naming the same three things plus the declared patterns.
+3. Publishing to a routing key that is unroutable _at the broker_ resolves to
+   `Err(UnroutableMessageError)`, not `Ok`.
+4. `defineQueue` without a DLX and without `onPoison: "drop"` throws.
+5. A consumer with no explicit prefetch is observably limited to 10 unacked messages against a
+   real broker.
+6. A publish issued while the broker is unreachable settles within ~30s rather than hanging.
+7. Every hazard has both a prove-the-loss and a prove-the-guard test against a real broker.
+8. The runtime and type-level matchers agree across the property-test corpus.
+9. `channel-epoch.spec.ts` and `amqp-client-error-events.spec.ts` no longer mock
+   `amqp-connection-manager`; they force real reconnects via the management API.
+10. `tsc` wall-clock on the example contracts does not regress materially from the rung-1 type
+    machinery. Measure before and after; treat a large regression as a design failure requiring
+    a fallback to rung 2 only.
+
+## Migration impact
+
+Every item below breaks existing client contracts by design — that is the point, and it is why
+this lands inside the beta window rather than after.
+
+- Publishers with no matching binding: compile error, then define-time throw.
+- Queues with no DLX: define-time throw until `onPoison: "drop"` is added.
+- Consumers relying on unlimited prefetch: silently limited to 10 unless
+  `prefetch: "unbounded"` is set. **This is a behavior change, not a compile error** — it must
+  be prominent in the upgrade guide, since it is the one item a client can miss.
+- `publish()` error channel gains `UnroutableMessageError`: exhaustive `errCases` matchers
+  fail to compile until the case is handled.
+
+The upgrade guide must present each as: what breaks, why it was unsafe, and the exact edit.

--- a/packages/asyncapi/src/index.spec.ts
+++ b/packages/asyncapi/src/index.spec.ts
@@ -3,6 +3,7 @@ import {
   defineConsumer,
   defineContract,
   defineExchange,
+  defineExchangeBinding,
   defineMessage,
   definePublisher,
   defineQueue,
@@ -47,6 +48,11 @@ describe("AsyncAPIGenerator", () => {
         consumers: {
           processOrder: defineConsumer(orderQueue, orderMessage),
         },
+        bindings: {
+          orderProcessing: defineQueueBinding(orderQueue, orderExchange, {
+            routingKey: "order.created",
+          }),
+        },
       });
 
       const generator = new AsyncAPIGenerator({
@@ -88,7 +94,7 @@ describe("AsyncAPIGenerator", () => {
                   },
                 },
               },
-              "description": "AMQP Queue: order-processing",
+              "description": "AMQP Queue: order-processing (bound to exchange 'orders' with routing key 'order.created')",
               "messages": {
                 "processOrderMessage": {
                   "contentType": "application/json",
@@ -320,7 +326,9 @@ describe("AsyncAPIGenerator", () => {
 
       const contract = defineContract({
         publishers: {
-          sendEvent: definePublisher(exchange, message),
+          // Publish-only fixture: this document describes what the service
+          // emits; the consumers are owned elsewhere.
+          sendEvent: definePublisher(exchange, message, { externalConsumers: true }),
         },
       });
 
@@ -486,6 +494,11 @@ describe("AsyncAPIGenerator", () => {
         consumers: {
           processNotification: defineConsumer(notificationQueue, notificationMessage),
         },
+        bindings: {
+          notifications: defineQueueBinding(notificationQueue, notificationExchange, {
+            routingKey: "notification.send",
+          }),
+        },
       });
 
       const generator = new AsyncAPIGenerator({
@@ -519,7 +532,7 @@ describe("AsyncAPIGenerator", () => {
                   },
                 },
               },
-              "description": "AMQP Queue: notification-queue",
+              "description": "AMQP Queue: notification-queue (bound to exchange 'notifications' with routing key 'notification.send')",
               "messages": {
                 "processNotificationMessage": {
                   "contentType": "application/json",
@@ -763,6 +776,11 @@ describe("AsyncAPIGenerator", () => {
         consumers: {
           processPayment: defineConsumer(paymentQueue, paymentMessage),
         },
+        bindings: {
+          payments: defineQueueBinding(paymentQueue, paymentExchange, {
+            routingKey: "payment.created",
+          }),
+        },
       });
 
       const generator = new AsyncAPIGenerator({
@@ -796,7 +814,7 @@ describe("AsyncAPIGenerator", () => {
                   },
                 },
               },
-              "description": "AMQP Queue: payment-processing",
+              "description": "AMQP Queue: payment-processing (bound to exchange 'payments' with routing key 'payment.created')",
               "messages": {
                 "processPaymentMessage": {
                   "contentType": "application/json",
@@ -1064,11 +1082,14 @@ describe("AsyncAPIGenerator", () => {
 
       const contract = defineContract({
         publishers: {
+          // Publish-only fixture: consumers are owned elsewhere.
           publishZod: definePublisher(exchange, zodMessage, {
             routingKey: "zod.event",
+            externalConsumers: true,
           }),
           publishValibot: definePublisher(exchange, valibotMessage, {
             routingKey: "valibot.event",
+            externalConsumers: true,
           }),
         },
       });
@@ -1257,7 +1278,9 @@ describe("AsyncAPIGenerator", () => {
       const exchange = defineExchange("generic", { type: "fanout" });
       const message = defineMessage(z.object({ id: z.string() }));
       const contract = defineContract({
-        publishers: { publish: definePublisher(exchange, message) },
+        publishers: {
+          publish: definePublisher(exchange, message, { externalConsumers: true }),
+        },
       });
 
       const generator = new AsyncAPIGenerator();
@@ -1283,7 +1306,7 @@ describe("AsyncAPIGenerator", () => {
 
       const contract = defineContract({
         publishers: {
-          publish: definePublisher(exchange, message),
+          publish: definePublisher(exchange, message, { externalConsumers: true }),
         },
       });
 
@@ -1496,6 +1519,7 @@ describe("AsyncAPIGenerator", () => {
         publishers: {
           orderCreated: definePublisher(exchange, message, {
             routingKey: "order.created",
+            externalConsumers: true,
           }),
         },
       });
@@ -1646,7 +1670,7 @@ describe("AsyncAPIGenerator", () => {
 
       const contract = defineContract({
         publishers: {
-          broadcast: definePublisher(exchange, message),
+          broadcast: definePublisher(exchange, message, { externalConsumers: true }),
         },
       });
 
@@ -1763,6 +1787,9 @@ describe("AsyncAPIGenerator", () => {
         defineContract({
           publishers: { sent: definePublisher(exchange, message, { routingKey: "order.created" }) },
           consumers: { processOrder: consumer },
+          bindings: {
+            ordersQ: defineQueueBinding(queue, exchange, { routingKey: "order.created" }),
+          },
         }) as unknown as ContractDefinition,
         { info: { title: "DLX Test", version: "1.0.0" } },
       );
@@ -1797,26 +1824,21 @@ describe("AsyncAPIGenerator", () => {
       const billingQueue = defineQueue("billing-orders");
       const message = defineMessage(z.object({ id: z.string() }));
 
-      // Build a contract by hand to avoid pulling in defineEventConsumer's
-      // bridge wiring — we just want a binding of type "exchange" between
-      // the two exchanges.
+      // Declared by hand to avoid pulling in defineEventConsumer's bridge
+      // wiring — we just want a binding of type "exchange" between the two
+      // exchanges, plus the queue binding that makes `sent` routable
+      // (orders → billing → billing-orders).
       const contract = defineContract({
         publishers: { sent: definePublisher(orders, message, { routingKey: "order.created" }) },
         consumers: {
           process: defineConsumer(billingQueue, message),
         },
+        exchanges: { billing },
+        bindings: {
+          ordersToBilling: defineExchangeBinding(billing, orders, { routingKey: "order.#" }),
+          billingOrders: defineQueueBinding(billingQueue, billing, { routingKey: "order.#" }),
+        },
       }) as unknown as ContractDefinition;
-      // Inject the e2e binding manually.
-      contract.bindings = {
-        ...contract.bindings,
-        ordersToBilling: {
-          type: "exchange",
-          source: orders,
-          destination: billing,
-          routingKey: "order.#",
-        } as never,
-      };
-      contract.exchanges = { ...contract.exchanges, billing };
 
       const generator = new AsyncAPIGenerator({
         schemaConverters: [new ZodToJsonSchemaConverter()],
@@ -1911,7 +1933,12 @@ describe("AsyncAPIGenerator", () => {
       await expect(
         generator.generate(
           defineContract({
-            publishers: { sent: definePublisher(exchange, message, { routingKey: "x" }) },
+            publishers: {
+              sent: definePublisher(exchange, message, {
+                routingKey: "x",
+                externalConsumers: true,
+              }),
+            },
           }),
           { info: { title: "Strict", version: "1.0.0" } },
         ),

--- a/packages/client/src/__tests__/client.spec.ts
+++ b/packages/client/src/__tests__/client.spec.ts
@@ -74,6 +74,9 @@ describe("AmqpClient Integration", () => {
         publishers: {
           testPublisher: definePublisher(exchange, defineMessage(TestMessage), {
             routingKey: "test.key",
+            // The binding is declared at the broker via the initConsumer test
+            // fixture below, outside the contract, so the contract cannot see it.
+            externalConsumers: true,
           }),
         },
       });
@@ -116,6 +119,10 @@ describe("AmqpClient Integration", () => {
         publishers: {
           testPublisher: definePublisher(exchange, defineMessage(TestMessage), {
             routingKey: "validation.test",
+            // Nothing is ever published successfully here — validation always
+            // rejects the payload before a message hits the broker — so there
+            // is no consumer to bind to.
+            externalConsumers: true,
           }),
         },
       });
@@ -147,6 +154,9 @@ describe("AmqpClient Integration", () => {
         publishers: {
           testPublisher: definePublisher(exchange, defineMessage(TestMessage), {
             routingKey: "test.key",
+            // The binding is declared at the broker via the initConsumer test
+            // fixture below, outside the contract, so the contract cannot see it.
+            externalConsumers: true,
           }),
         },
       });
@@ -191,6 +201,9 @@ describe("AmqpClient Integration", () => {
         publishers: {
           testPublisher: definePublisher(exchange, defineMessage(TestMessage), {
             routingKey: "test.key",
+            // The binding is declared at the broker via the initConsumer test
+            // fixture below, outside the contract, so the contract cannot see it.
+            externalConsumers: true,
           }),
         },
       });
@@ -233,6 +246,9 @@ describe("AmqpClient Integration", () => {
         publishers: {
           testPublisher: definePublisher(exchange, defineMessage(TestMessage), {
             routingKey: "test.default",
+            // The binding is declared at the broker via the initConsumer test
+            // fixture below, outside the contract, so the contract cannot see it.
+            externalConsumers: true,
           }),
         },
       });
@@ -281,6 +297,9 @@ describe("AmqpClient Integration", () => {
         publishers: {
           testPublisher: definePublisher(exchange, defineMessage(TestMessage), {
             routingKey: "test.override",
+            // The binding is declared at the broker via the initConsumer test
+            // fixture below, outside the contract, so the contract cannot see it.
+            externalConsumers: true,
           }),
         },
       });
@@ -405,6 +424,11 @@ describe("AmqpClient Integration", () => {
             defineMessage(z.object({ msg: z.string() })),
             {
               routingKey: "test.important",
+              // Routed via a manual exchange-to-exchange binding set up below
+              // (not supported by defineContract) plus a broker-level queue
+              // bound by the initConsumer test fixture — both outside the
+              // contract's own topology.
+              externalConsumers: true,
             },
           ),
         },
@@ -480,6 +504,9 @@ describe("AmqpClient Integration", () => {
         publishers: {
           testPublisher: definePublisher(exchange, defineMessage(z.object({ id: z.string() })), {
             routingKey: "test.key",
+            // Nothing is ever published in this test — it only exercises
+            // close() — so there is no consumer to bind to.
+            externalConsumers: true,
           }),
         },
       });
@@ -523,6 +550,9 @@ describe("AmqpClient Integration", () => {
         publishers: {
           testPublisher: definePublisher(exchange, defineMessage(z.object({ value: z.number() })), {
             routingKey: "test.value",
+            // The binding is declared at the broker via the initConsumer test
+            // fixture below, outside the contract, so the contract cannot see it.
+            externalConsumers: true,
           }),
         },
       });
@@ -560,6 +590,10 @@ describe("AmqpClient Integration", () => {
         publishers: {
           testPublisher: definePublisher(exchange, defineMessage(TestMessage), {
             routingKey: "validation.test",
+            // Nothing is ever published successfully here — validation always
+            // rejects the payload before a message hits the broker — so there
+            // is no consumer to bind to.
+            externalConsumers: true,
           }),
         },
       });

--- a/packages/client/src/unknown-names.spec.ts
+++ b/packages/client/src/unknown-names.spec.ts
@@ -2,9 +2,11 @@ import type { EventEmitter } from "node:events";
 
 import {
   defineContract,
+  defineEventConsumer,
   defineEventPublisher,
   defineExchange,
   defineMessage,
+  defineQueue,
 } from "@amqp-contract/contract";
 import { TechnicalError } from "@amqp-contract/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -49,6 +51,9 @@ const orderCreated = defineEventPublisher(exchange, defineMessage(z.object({ id:
 });
 const contract = defineContract({
   publishers: { orderCreated },
+  // The publisher has to reach a queue for the contract to be definable; the
+  // consumer side is irrelevant to this test but must exist.
+  consumers: { processOrder: defineEventConsumer(orderCreated, defineQueue("orders-q")) },
 });
 
 async function createClient() {

--- a/packages/client/src/unknown-names.spec.ts
+++ b/packages/client/src/unknown-names.spec.ts
@@ -2,11 +2,9 @@ import type { EventEmitter } from "node:events";
 
 import {
   defineContract,
-  defineEventConsumer,
   defineEventPublisher,
   defineExchange,
   defineMessage,
-  defineQueue,
 } from "@amqp-contract/contract";
 import { TechnicalError } from "@amqp-contract/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -48,12 +46,12 @@ vi.mock("amqp-connection-manager", async () => {
 const exchange = defineExchange("orders-x", { durable: false });
 const orderCreated = defineEventPublisher(exchange, defineMessage(z.object({ id: z.string() })), {
   routingKey: "order.created",
+  // Publish-only fixture: this test only exercises the client's publish/call
+  // surface, so no consumer is declared and none is needed.
+  externalConsumers: true,
 });
 const contract = defineContract({
   publishers: { orderCreated },
-  // The publisher has to reach a queue for the contract to be definable; the
-  // consumer side is irrelevant to this test but must exist.
-  consumers: { processOrder: defineEventConsumer(orderCreated, defineQueue("orders-q")) },
 });
 
 async function createClient() {

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -66,6 +66,7 @@
     "@btravstack/typedoc": "catalog:",
     "@types/node": "catalog:",
     "@vitest/coverage-v8": "catalog:",
+    "fast-check": "catalog:",
     "publint": "catalog:",
     "tsdown": "catalog:",
     "typedoc": "catalog:",

--- a/packages/contract/src/builder.spec.ts
+++ b/packages/contract/src/builder.spec.ts
@@ -1842,12 +1842,10 @@ describe("builder", () => {
         publishers: {
           runCommand: defineCommandPublisher(command, {
             bridgeExchange: localExchange,
+            // The local domain only owns the bridge; the remote domain owns
+            // `remote-queue` and its binding, so they are not in this contract.
+            externalConsumers: true,
           }),
-        },
-        // The bridge only forwards local → remote; the remote queue's binding
-        // has to be in the contract too, or nothing consumes the command.
-        consumers: {
-          handleCommand: command,
         },
       });
 

--- a/packages/contract/src/builder.spec.ts
+++ b/packages/contract/src/builder.spec.ts
@@ -959,7 +959,12 @@ describe("builder", () => {
           "final-queue": { name: "final-queue" },
         },
         bindings: {
-          finalQueue: { type: "queue", queue: finalQueue, exchange: sourceExchange },
+          finalQueue: {
+            type: "queue",
+            queue: finalQueue,
+            exchange: sourceExchange,
+            routingKey: "order.created",
+          },
         },
       });
     });

--- a/packages/contract/src/builder.spec.ts
+++ b/packages/contract/src/builder.spec.ts
@@ -866,6 +866,13 @@ describe("builder", () => {
         consumers: {
           processOrder: defineConsumer(orderProcessingQueue, message),
         },
+        // A plain consumer contributes no binding, so the queue has to be
+        // bound explicitly — without it the publisher reaches no queue.
+        bindings: {
+          orderProcessing: defineQueueBinding(orderProcessingQueue, ordersExchange, {
+            routingKey: "order.created",
+          }),
+        },
       });
 
       // THEN - exchanges and queues are auto-extracted using resource names as keys
@@ -876,7 +883,14 @@ describe("builder", () => {
         queues: {
           "order-processing": { name: "order-processing", durable: true },
         },
-        bindings: {},
+        bindings: {
+          orderProcessing: {
+            type: "queue",
+            queue: orderProcessingQueue,
+            exchange: ordersExchange,
+            routingKey: "order.created",
+          },
+        },
         publishers: {
           orderCreated: {
             exchange: ordersExchange,
@@ -929,6 +943,11 @@ describe("builder", () => {
         consumers: {
           processOrder: defineConsumer(finalQueue, message),
         },
+        bindings: {
+          finalQueue: defineQueueBinding(finalQueue, sourceExchange, {
+            routingKey: "order.created",
+          }),
+        },
       });
 
       // THEN - exchanges and queues use resource names as keys
@@ -939,7 +958,9 @@ describe("builder", () => {
         queues: {
           "final-queue": { name: "final-queue" },
         },
-        bindings: {},
+        bindings: {
+          finalQueue: { type: "queue", queue: finalQueue, exchange: sourceExchange },
+        },
       });
     });
   });
@@ -1822,6 +1843,11 @@ describe("builder", () => {
           runCommand: defineCommandPublisher(command, {
             bridgeExchange: localExchange,
           }),
+        },
+        // The bridge only forwards local → remote; the remote queue's binding
+        // has to be in the contract too, or nothing consumes the command.
+        consumers: {
+          handleCommand: command,
         },
       });
 

--- a/packages/contract/src/builder.test-d.ts
+++ b/packages/contract/src/builder.test-d.ts
@@ -307,8 +307,11 @@ describe("ContractOutput type inference", () => {
   const logMessage = defineMessage(z.object({ level: z.string() }));
 
   test("should extract exchanges from EventPublisherConfig in publishers", () => {
+    // Publishers only, deliberately: the point is that the exchange arrives
+    // from the publisher and not from some consumer's binding.
     const orderCreated = defineEventPublisher(ordersExchange, orderMessage, {
       routingKey: "order.created",
+      externalConsumers: true,
     });
     const contract = defineContract({
       publishers: { orderCreated },
@@ -365,8 +368,10 @@ describe("ContractOutput type inference", () => {
   });
 
   test("should normalize EventPublisherConfig to PublisherDefinition", () => {
+    // Publishers only, deliberately: see above.
     const orderCreated = defineEventPublisher(ordersExchange, orderMessage, {
       routingKey: "order.created",
+      externalConsumers: true,
     });
     const contract = defineContract({
       publishers: { orderCreated },
@@ -406,6 +411,14 @@ describe("ContractOutput type inference", () => {
       },
       consumers: {
         processCommand,
+      },
+      // `processCommand` only binds `order.process`; without these two the
+      // other publishers would reach no queue.
+      bindings: {
+        orderCreatedBinding: defineQueueBinding(orderQueue, ordersExchange, {
+          routingKey: "order.created",
+        }),
+        notificationsBinding: defineQueueBinding(notificationQueue, fanoutExchange),
       },
     });
 

--- a/packages/contract/src/builder.ts
+++ b/packages/contract/src/builder.ts
@@ -50,6 +50,7 @@ export type {
   BindingPattern,
   MatchingBindingPattern,
   MatchingRoutingKey,
+  RoutableRoutingKey,
   // Event pattern types
   EventPublisherConfig,
   EventConsumerResult,

--- a/packages/contract/src/builder/command.ts
+++ b/packages/contract/src/builder/command.ts
@@ -275,6 +275,9 @@ export function defineCommandConsumer<TMessage extends MessageDefinition>(
  * @param commandConsumer - The command consumer configuration
  * @param options - Configuration with required bridgeExchange
  * @param options.bridgeExchange - The local domain exchange to bridge through (must be fanout to match target)
+ * @param options.externalConsumers - Declare that the command's owner lives in
+ *   another service, opting this publisher out of `defineContract`'s
+ *   define-time routability check
  * @returns A bridged publisher configuration
  */
 export function defineCommandPublisher<
@@ -285,6 +288,7 @@ export function defineCommandPublisher<
   commandConsumer: CommandConsumerConfig<TMessage, TExchange, undefined>,
   options: {
     bridgeExchange: TBridgeExchange;
+    externalConsumers?: boolean;
   },
 ): BridgedPublisherConfig<TMessage, TBridgeExchange, TExchange>;
 
@@ -304,6 +308,7 @@ export function defineCommandPublisher<
   commandConsumer: CommandConsumerConfig<TMessage, TExchange, undefined>,
   options: {
     bridgeExchange: TBridgeExchange;
+    externalConsumers?: boolean;
   },
 ): BridgedPublisherConfig<TMessage, TBridgeExchange, TExchange>;
 
@@ -313,6 +318,9 @@ export function defineCommandPublisher<
  * @param commandConsumer - The command consumer configuration
  * @param options - Configuration with required bridgeExchange
  * @param options.bridgeExchange - The bridge exchange (must be direct or topic to preserve routing keys)
+ * @param options.externalConsumers - Declare that the command's owner lives in
+ *   another service, opting this publisher out of `defineContract`'s
+ *   define-time routability check
  * @returns A bridged publisher configuration
  */
 export function defineCommandPublisher<
@@ -324,6 +332,7 @@ export function defineCommandPublisher<
   commandConsumer: CommandConsumerConfig<TMessage, TExchange, TRoutingKey>,
   options: {
     bridgeExchange: TBridgeExchange;
+    externalConsumers?: boolean;
   },
 ): BridgedPublisherConfig<TMessage, TBridgeExchange, TExchange>;
 
@@ -334,6 +343,9 @@ export function defineCommandPublisher<
  * @param options - Configuration with required bridgeExchange and optional routingKey override
  * @param options.bridgeExchange - The bridge exchange (must be direct or topic to preserve routing keys)
  * @param options.routingKey - Override routing key (must match consumer's pattern)
+ * @param options.externalConsumers - Declare that the command's owner lives in
+ *   another service, opting this publisher out of `defineContract`'s
+ *   define-time routability check
  * @returns A bridged publisher configuration
  */
 export function defineCommandPublisher<
@@ -347,6 +359,7 @@ export function defineCommandPublisher<
   options: {
     bridgeExchange: TBridgeExchange;
     routingKey?: RoutingKey<TPublisherRoutingKey>;
+    externalConsumers?: boolean;
   },
 ): BridgedPublisherConfig<TMessage, TBridgeExchange, TExchange>;
 
@@ -364,7 +377,10 @@ export function defineCommandPublisher<
  */
 export function defineCommandPublisher<TMessage extends MessageDefinition>(
   commandConsumer: CommandConsumerConfig<TMessage, FanoutExchangeDefinition, undefined>,
-): { message: TMessage; exchange: FanoutExchangeDefinition };
+  options?: {
+    externalConsumers?: boolean;
+  },
+): { message: TMessage; exchange: FanoutExchangeDefinition; externalConsumers?: boolean };
 
 /**
  * Create a publisher that sends commands to a headers exchange consumer.
@@ -380,7 +396,10 @@ export function defineCommandPublisher<TMessage extends MessageDefinition>(
  */
 export function defineCommandPublisher<TMessage extends MessageDefinition>(
   commandConsumer: CommandConsumerConfig<TMessage, HeadersExchangeDefinition, undefined>,
-): { message: TMessage; exchange: HeadersExchangeDefinition };
+  options?: {
+    externalConsumers?: boolean;
+  },
+): { message: TMessage; exchange: HeadersExchangeDefinition; externalConsumers?: boolean };
 
 /**
  * Create a publisher that sends commands to a direct exchange consumer.
@@ -393,7 +412,15 @@ export function defineCommandPublisher<
   TRoutingKey extends string,
 >(
   commandConsumer: CommandConsumerConfig<TMessage, DirectExchangeDefinition, TRoutingKey>,
-): { message: TMessage; exchange: DirectExchangeDefinition; routingKey: TRoutingKey };
+  options?: {
+    externalConsumers?: boolean;
+  },
+): {
+  message: TMessage;
+  exchange: DirectExchangeDefinition;
+  routingKey: TRoutingKey;
+  externalConsumers?: boolean;
+};
 
 /**
  * Create a publisher that sends commands to a topic exchange consumer.
@@ -404,6 +431,9 @@ export function defineCommandPublisher<
  * @param commandConsumer - The command consumer configuration
  * @param options - Optional binding configuration
  * @param options.routingKey - Override routing key (must match consumer's pattern)
+ * @param options.externalConsumers - Declare that the command's owner lives in
+ *   another service, opting this publisher out of `defineContract`'s
+ *   define-time routability check
  * @returns A publisher definition
  *
  * @example
@@ -427,8 +457,14 @@ export function defineCommandPublisher<
   commandConsumer: CommandConsumerConfig<TMessage, TopicExchangeDefinition, TRoutingKey>,
   options?: {
     routingKey?: RoutingKey<TPublisherRoutingKey>;
+    externalConsumers?: boolean;
   },
-): { message: TMessage; exchange: TopicExchangeDefinition; routingKey: TPublisherRoutingKey };
+): {
+  message: TMessage;
+  exchange: TopicExchangeDefinition;
+  routingKey: TPublisherRoutingKey;
+  externalConsumers?: boolean;
+};
 
 /*
  * Implementation signature of defineCommandPublisher. (Deliberately a plain
@@ -440,6 +476,7 @@ export function defineCommandPublisher<TMessage extends MessageDefinition>(
   options?: {
     routingKey?: string;
     bridgeExchange?: ExchangeDefinition;
+    externalConsumers?: boolean | undefined;
   },
 ):
   | PublisherDefinition<TMessage>
@@ -451,9 +488,19 @@ export function defineCommandPublisher<TMessage extends MessageDefinition>(
 
   const bridgeExchange = options?.bridgeExchange;
 
+  // Carried onto the publisher definition in both the bridged and direct
+  // forms: whether the command's owner declares its queue in *this* contract
+  // is the caller's knowledge, not something either form can infer.
+  const externalConsumers: { externalConsumers?: boolean } =
+    options?.externalConsumers !== undefined
+      ? { externalConsumers: options.externalConsumers }
+      : {};
+
   if (bridgeExchange) {
     // Bridged: publisher publishes to bridge exchange, e2e binding from bridge → target
-    const publisherOptions: { routingKey?: string } = {};
+    const publisherOptions: { routingKey?: string; externalConsumers?: boolean } = {
+      ...externalConsumers,
+    };
     if (publisherRoutingKey !== undefined) {
       publisherOptions.routingKey = publisherRoutingKey;
     }
@@ -483,7 +530,9 @@ export function defineCommandPublisher<TMessage extends MessageDefinition>(
     };
   }
 
-  const publisherOptions: { routingKey?: string } = {};
+  const publisherOptions: { routingKey?: string; externalConsumers?: boolean } = {
+    ...externalConsumers,
+  };
   if (publisherRoutingKey !== undefined) {
     publisherOptions.routingKey = publisherRoutingKey;
   }

--- a/packages/contract/src/builder/contract.ts
+++ b/packages/contract/src/builder/contract.ts
@@ -12,6 +12,7 @@ import type {
 import { isBridgedPublisherConfig, isCommandConsumerConfig } from "./command.js";
 import { isEventConsumerResult, isEventPublisherConfig } from "./event.js";
 import { definePublisherInternal } from "./publisher.js";
+import { _internal_assertPublisherRoutable } from "./validate.js";
 
 /**
  * Structural equality for resource definitions. We compare on a JSON projection
@@ -289,6 +290,19 @@ export function defineContract<TContract extends ContractDefinitionInput>(
   result.exchanges = exchanges;
   result.queues = queues;
   result.bindings = bindings;
+
+  // Runs last: consumers and bridged publishers contribute bindings, so
+  // routability can only be decided once every binding is collected.
+  const declaredBindings = Object.values(bindings);
+  for (const [publisherName, publisher] of Object.entries(result.publishers ?? {})) {
+    _internal_assertPublisherRoutable(
+      publisherName,
+      publisher.exchange,
+      "routingKey" in publisher ? publisher.routingKey : undefined,
+      publisher.externalConsumers,
+      declaredBindings,
+    );
+  }
 
   return result as ContractOutput<TContract>;
 }

--- a/packages/contract/src/builder/contract.ts
+++ b/packages/contract/src/builder/contract.ts
@@ -214,9 +214,14 @@ export function defineContract<TContract extends ContractDefinitionInput>(
       } else if (isEventPublisherConfig(entry)) {
         // EventPublisherConfig: extract exchange and convert to publisher definition
         addResource(exchanges, entry.exchange.name, entry.exchange, "exchange");
-        const publisherOptions: { routingKey?: string } = {};
+        const publisherOptions: { routingKey?: string; externalConsumers?: boolean } = {};
         if (entry.routingKey !== undefined) {
           publisherOptions.routingKey = entry.routingKey;
+        }
+        // Must be carried through: an option that is accepted by the builder
+        // and then dropped here would silently fail to opt the event out.
+        if (entry.externalConsumers !== undefined) {
+          publisherOptions.externalConsumers = entry.externalConsumers;
         }
         processedPublishers[name] = definePublisherInternal(
           entry.exchange,

--- a/packages/contract/src/builder/event.ts
+++ b/packages/contract/src/builder/event.ts
@@ -48,6 +48,16 @@ export type EventPublisherConfig<
    * `arguments` option.
    */
   bindingArguments?: Record<string, unknown>;
+  /**
+   * Declares that this event's consumers live outside this contract — a
+   * separate service or deployment owns the binding.
+   *
+   * Carried onto the publisher definition that `defineContract` extracts, so
+   * it opts the event out of the define-time routability check.
+   *
+   * @see PublisherDefinition.externalConsumers
+   */
+  externalConsumers?: boolean | undefined;
 };
 
 /**
@@ -96,6 +106,9 @@ export type EventConsumerResult<
  * @param options.bindingArguments - Default AMQP binding arguments applied to
  *   this event's consumers' queue bindings (a consumer's own `arguments`
  *   option takes precedence)
+ * @param options.externalConsumers - Declare that this event's consumers are
+ *   owned by another service, opting the event out of `defineContract`'s
+ *   define-time routability check
  * @returns An event publisher configuration
  *
  * @example
@@ -124,6 +137,7 @@ export function defineEventPublisher<
   message: TMessage,
   options?: {
     bindingArguments?: Record<string, unknown>;
+    externalConsumers?: boolean;
   },
 ): EventPublisherConfig<TMessage, TExchange, undefined>;
 
@@ -139,6 +153,9 @@ export function defineEventPublisher<
  * @param options.bindingArguments - Default AMQP binding arguments applied to
  *   this event's consumers' queue bindings (a consumer's own `arguments`
  *   option takes precedence)
+ * @param options.externalConsumers - Declare that this event's consumers are
+ *   owned by another service, opting the event out of `defineContract`'s
+ *   define-time routability check
  * @returns An event publisher configuration
  *
  * @example
@@ -167,6 +184,7 @@ export function defineEventPublisher<
   message: TMessage,
   options?: {
     bindingArguments?: Record<string, unknown>;
+    externalConsumers?: boolean;
   },
 ): EventPublisherConfig<TMessage, TExchange, undefined>;
 
@@ -183,6 +201,9 @@ export function defineEventPublisher<
  * @param options.bindingArguments - Default AMQP binding arguments applied to
  *   this event's consumers' queue bindings (a consumer's own `arguments`
  *   option takes precedence)
+ * @param options.externalConsumers - Declare that this event's consumers are
+ *   owned by another service, opting the event out of `defineContract`'s
+ *   define-time routability check
  * @returns An event publisher configuration
  *
  * @example
@@ -205,6 +226,7 @@ export function defineEventPublisher<
   options: {
     routingKey: RoutingKey<TRoutingKey>;
     bindingArguments?: Record<string, unknown>;
+    externalConsumers?: boolean;
   },
 ): EventPublisherConfig<TMessage, TExchange, TRoutingKey>;
 
@@ -221,6 +243,9 @@ export function defineEventPublisher<
  * @param options.bindingArguments - Default AMQP binding arguments applied to
  *   this event's consumers' queue bindings (a consumer's own `arguments`
  *   option takes precedence)
+ * @param options.externalConsumers - Declare that this event's consumers are
+ *   owned by another service, opting the event out of `defineContract`'s
+ *   define-time routability check
  * @returns An event publisher configuration
  *
  * @example
@@ -254,6 +279,7 @@ export function defineEventPublisher<
   options: {
     routingKey: RoutingKey<TRoutingKey>;
     bindingArguments?: Record<string, unknown>;
+    externalConsumers?: boolean;
   },
 ): EventPublisherConfig<TMessage, TExchange, TRoutingKey>;
 
@@ -268,6 +294,7 @@ export function defineEventPublisher<TMessage extends MessageDefinition>(
   options?: {
     routingKey?: string;
     bindingArguments?: Record<string, unknown>;
+    externalConsumers?: boolean | undefined;
   },
 ): EventPublisherConfig<TMessage, ExchangeDefinition, string | undefined> {
   if (exchange.type === "direct" || exchange.type === "topic") {
@@ -288,6 +315,9 @@ export function defineEventPublisher<TMessage extends MessageDefinition>(
 
   if (options?.bindingArguments !== undefined) {
     config.bindingArguments = options.bindingArguments;
+  }
+  if (options?.externalConsumers !== undefined) {
+    config.externalConsumers = options.externalConsumers;
   }
 
   return config;

--- a/packages/contract/src/builder/index.ts
+++ b/packages/contract/src/builder/index.ts
@@ -30,6 +30,7 @@ export type {
   BindingPattern,
   MatchingBindingPattern,
   MatchingRoutingKey,
+  RoutableRoutingKey,
   RoutingKey,
 } from "./routing-types.js";
 

--- a/packages/contract/src/builder/match-corpus.ts
+++ b/packages/contract/src/builder/match-corpus.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared routing-key/pattern corpus.
+ *
+ * Asserted twice — once against the runtime matcher
+ * (`topic-match.spec.ts`) and once against the type-level matcher
+ * (`routability.test-d.ts`). That double assertion is what pins the
+ * spec's invariant that the two implementations agree; if they ever
+ * diverge, one of the two suites fails.
+ *
+ * @internal
+ */
+export const MATCH_CORPUS = [
+  // Exact matches, no wildcards.
+  { key: "order.created", pattern: "order.created", matches: true },
+  { key: "order.created", pattern: "order.updated", matches: false },
+  { key: "order", pattern: "order", matches: true },
+
+  // '*' matches exactly one word.
+  { key: "order.created", pattern: "order.*", matches: true },
+  { key: "order.created.v2", pattern: "order.*", matches: false },
+  { key: "order.created", pattern: "*.created", matches: true },
+  { key: "order.created", pattern: "*.*", matches: true },
+  { key: "order", pattern: "*", matches: true },
+  { key: "order.created", pattern: "*", matches: false },
+
+  // '#' matches zero or more words.
+  { key: "order.created", pattern: "#", matches: true },
+  { key: "order", pattern: "#", matches: true },
+  { key: "order.created", pattern: "order.#", matches: true },
+  { key: "order", pattern: "order.#", matches: true },
+  { key: "order.created.v2", pattern: "order.#", matches: true },
+  { key: "order.created", pattern: "#.created", matches: true },
+  { key: "created", pattern: "#.created", matches: true },
+  { key: "order.created.v2", pattern: "order.#.v2", matches: true },
+  { key: "order.v2", pattern: "order.#.v2", matches: true },
+  { key: "order.a.b.v2", pattern: "order.#.v2", matches: true },
+  { key: "order.created", pattern: "order.#.v2", matches: false },
+
+  // Mixed wildcards.
+  { key: "order.created.v2", pattern: "order.*.#", matches: true },
+  { key: "order.created", pattern: "order.*.#", matches: true },
+  { key: "order", pattern: "order.*.#", matches: false },
+
+  // Non-matches that must not accidentally pass.
+  { key: "user.created", pattern: "order.#", matches: false },
+  { key: "order.created", pattern: "order.created.v2", matches: false },
+] as const satisfies readonly { key: string; pattern: string; matches: boolean }[];

--- a/packages/contract/src/builder/publisher.ts
+++ b/packages/contract/src/builder/publisher.ts
@@ -145,12 +145,20 @@ export function definePublisher<TMessage extends MessageDefinition>(
 export function definePublisher<TMessage extends MessageDefinition>(
   exchange: ExchangeDefinition,
   message: TMessage,
-  options?: { routingKey?: string },
+  options?: { routingKey?: string | undefined; externalConsumers?: boolean | undefined },
 ): PublisherDefinition<TMessage> {
+  // Spread rather than assigned, so an unset option leaves the key off the
+  // definition entirely instead of adding `externalConsumers: undefined`.
+  const externalConsumers =
+    options?.externalConsumers !== undefined
+      ? { externalConsumers: options.externalConsumers }
+      : {};
+
   if (exchange.type === "fanout" || exchange.type === "headers") {
     return {
       exchange,
       message,
+      ...externalConsumers,
     } as PublisherDefinition<TMessage>;
   }
 
@@ -161,6 +169,7 @@ export function definePublisher<TMessage extends MessageDefinition>(
     exchange,
     message,
     routingKey,
+    ...externalConsumers,
   } as PublisherDefinition<TMessage>;
 }
 
@@ -173,8 +182,9 @@ export function definePublisherInternal<TMessage extends MessageDefinition>(
   exchange: ExchangeDefinition,
   message: TMessage,
   options?: {
-    routingKey?: string;
+    routingKey?: string | undefined;
     arguments?: Record<string, unknown>;
+    externalConsumers?: boolean | undefined;
   },
 ): PublisherDefinition<TMessage> {
   // Type assertion is safe because overloaded signatures enforce routingKey requirement

--- a/packages/contract/src/builder/routability-define-time.spec.ts
+++ b/packages/contract/src/builder/routability-define-time.spec.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { defineQueueBinding } from "./binding.js";
+import { defineCommandConsumer, defineCommandPublisher } from "./command.js";
 import { defineConsumer } from "./consumer.js";
 import { defineContract } from "./contract.js";
+import { defineEventPublisher } from "./event.js";
 import { defineExchange } from "./exchange.js";
 import { defineMessage } from "./message.js";
 import { definePublisher } from "./publisher.js";
@@ -82,5 +84,76 @@ describe("defineContract publisher routability", () => {
     const orderCreated = definePublisher(orders, message, { routingKey: "order.created" });
 
     expect(() => defineContract({ publishers: { orderCreated } })).toThrow(/externalConsumers/);
+  });
+});
+
+/*
+ * The opt-out has to be expressible wherever a publisher can be declared.
+ * `defineEventPublisher` and `defineCommandPublisher` reach `defineContract`
+ * through their own config shapes, so a field carried only by
+ * `definePublisher` would leave a publish-only service written in those
+ * styles unable to define a contract at all — the check rejecting valid code.
+ */
+describe("externalConsumers across the publisher builders", () => {
+  describe("defineEventPublisher", () => {
+    it("throws for a publish-only event contract that is NOT marked", () => {
+      const orderCreated = defineEventPublisher(orders, message, { routingKey: "order.created" });
+
+      expect(() => defineContract({ publishers: { orderCreated } })).toThrow(/externalConsumers/);
+    });
+
+    it("accepts a publish-only event contract marked externalConsumers", () => {
+      const orderCreated = defineEventPublisher(orders, message, {
+        routingKey: "order.created",
+        externalConsumers: true,
+      });
+
+      expect(() => defineContract({ publishers: { orderCreated } })).not.toThrow();
+    });
+  });
+
+  describe("defineCommandPublisher", () => {
+    const fulfillOrder = defineCommandConsumer(defineQueue("fulfillment"), orders, message, {
+      routingKey: "order.fulfill",
+    });
+
+    it("throws for a publish-only command contract that is NOT marked", () => {
+      // Only the sender is declared here: the queue binding lives with the
+      // command's owner, in whichever contract declares it as a consumer.
+      const requestFulfillment = defineCommandPublisher(fulfillOrder);
+
+      expect(() => defineContract({ publishers: { requestFulfillment } })).toThrow(
+        /externalConsumers/,
+      );
+    });
+
+    it("accepts a publish-only command contract marked externalConsumers", () => {
+      const requestFulfillment = defineCommandPublisher(fulfillOrder, {
+        externalConsumers: true,
+      });
+
+      expect(() => defineContract({ publishers: { requestFulfillment } })).not.toThrow();
+    });
+
+    it("throws for a publish-only bridged command contract that is NOT marked", () => {
+      // The bridge only gets the message as far as the target exchange; the
+      // target's queue binding is owned by the remote domain.
+      const local = defineExchange("local", { type: "topic" });
+      const requestFulfillment = defineCommandPublisher(fulfillOrder, { bridgeExchange: local });
+
+      expect(() => defineContract({ publishers: { requestFulfillment } })).toThrow(
+        /externalConsumers/,
+      );
+    });
+
+    it("accepts a publish-only bridged command contract marked externalConsumers", () => {
+      const local = defineExchange("local", { type: "topic" });
+      const requestFulfillment = defineCommandPublisher(fulfillOrder, {
+        bridgeExchange: local,
+        externalConsumers: true,
+      });
+
+      expect(() => defineContract({ publishers: { requestFulfillment } })).not.toThrow();
+    });
   });
 });

--- a/packages/contract/src/builder/routability-define-time.spec.ts
+++ b/packages/contract/src/builder/routability-define-time.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
-import { defineQueueBinding } from "./binding.js";
+import { defineExchangeBinding, defineQueueBinding } from "./binding.js";
 import { defineCommandConsumer, defineCommandPublisher } from "./command.js";
 import { defineConsumer } from "./consumer.js";
 import { defineContract } from "./contract.js";
@@ -84,6 +84,64 @@ describe("defineContract publisher routability", () => {
     const orderCreated = definePublisher(orders, message, { routingKey: "order.created" });
 
     expect(() => defineContract({ publishers: { orderCreated } })).toThrow(/externalConsumers/);
+  });
+});
+
+/*
+ * A multi-hop failure is the case where a naive message lies: the source
+ * exchange's own patterns match, so listing them alone sends the reader to a
+ * binding that is working fine while the real gap is a queue binding one hop
+ * further on.
+ */
+describe("unroutable error message for multi-hop failures", () => {
+  const billing = defineExchange("billing", { type: "topic" });
+  const ordersToBilling = defineExchangeBinding(billing, orders, { routingKey: "order.#" });
+
+  const buildBridged = (billingBindings: Record<string, ReturnType<typeof defineQueueBinding>>) => {
+    const orderCreated = definePublisher(orders, message, { routingKey: "order.created" });
+    return () =>
+      defineContract({
+        publishers: { orderCreated },
+        exchanges: { billing },
+        bindings: { ordersToBilling, ...billingBindings },
+      });
+  };
+
+  it("says the key matched on the source and points downstream", () => {
+    const build = buildBridged({
+      billingAudit: defineQueueBinding(auditQueue, billing, { routingKey: "user.#" }),
+    });
+
+    expect(build).toThrow(/The key matches on "orders" and is forwarded on to "billing"/);
+    expect(build).toThrow(/no queue binding downstream accepts it/);
+    expect(build).toThrow(/the break is not on "orders"/);
+  });
+
+  it("lists the declared patterns of every exchange the key reached", () => {
+    const build = buildBridged({
+      billingAudit: defineQueueBinding(auditQueue, billing, { routingKey: "user.#" }),
+    });
+
+    expect(build).toThrow(/Declared on "orders": "order\.#"\./);
+    expect(build).toThrow(/Declared on "billing": "user\.#"\./);
+  });
+
+  it("reports a downstream exchange that declares nothing at all", () => {
+    const build = buildBridged({});
+
+    expect(build).toThrow(/No bindings are declared on "billing"\./);
+  });
+
+  it("keeps the single-hop message local — no downstream wording", () => {
+    const orderCreated = definePublisher(orders, message, { routingKey: "order.created" });
+    const build = () =>
+      defineContract({
+        publishers: { orderCreated },
+        bindings: { audit: defineQueueBinding(auditQueue, orders, { routingKey: "user.#" }) },
+      });
+
+    expect(build).toThrow(/Declared on "orders": "user\.#"\./);
+    expect(build).not.toThrow(/forwarded on to/);
   });
 });
 

--- a/packages/contract/src/builder/routability-define-time.spec.ts
+++ b/packages/contract/src/builder/routability-define-time.spec.ts
@@ -88,6 +88,41 @@ describe("defineContract publisher routability", () => {
 });
 
 /*
+ * `alternate-exchange` is a documented exchange argument whose whole purpose
+ * is to catch messages that match no binding. A publisher on such an exchange
+ * is routable by construction, and throwing on it broke a valid contract.
+ */
+describe("defineContract with an alternate exchange", () => {
+  it("accepts a publisher on an exchange declaring alternate-exchange", () => {
+    const withAe = defineExchange("orders-ae", {
+      type: "topic",
+      arguments: { "alternate-exchange": "catch-all" },
+    });
+    const orderCreated = definePublisher(withAe, message, { routingKey: "order.created" });
+
+    expect(() => defineContract({ publishers: { orderCreated } })).not.toThrow();
+  });
+
+  it("accepts a bridged publisher whose downstream hop declares alternate-exchange", () => {
+    const billingAe = defineExchange("billing-ae", {
+      type: "topic",
+      arguments: { "alternate-exchange": "catch-all" },
+    });
+    const orderCreated = definePublisher(orders, message, { routingKey: "order.created" });
+
+    expect(() =>
+      defineContract({
+        publishers: { orderCreated },
+        exchanges: { billingAe },
+        bindings: {
+          ordersToBillingAe: defineExchangeBinding(billingAe, orders, { routingKey: "order.#" }),
+        },
+      }),
+    ).not.toThrow();
+  });
+});
+
+/*
  * A multi-hop failure is the case where a naive message lies: the source
  * exchange's own patterns match, so listing them alone sends the reader to a
  * binding that is working fine while the real gap is a queue binding one hop

--- a/packages/contract/src/builder/routability-define-time.spec.ts
+++ b/packages/contract/src/builder/routability-define-time.spec.ts
@@ -187,6 +187,39 @@ describe("unroutable error message for multi-hop failures", () => {
  * `definePublisher` would leave a publish-only service written in those
  * styles unable to define a contract at all — the check rejecting valid code.
  */
+describe("unroutable error message on keyless exchanges", () => {
+  /**
+   * Fanout and headers exchanges ignore the routing key, so on those the key is
+   * *not applicable* rather than *missing*. Reporting "(none)" reads as a
+   * misconfiguration and sends the reader chasing a routing key that was never
+   * relevant — the only fix on a keyless exchange is a binding.
+   */
+  it("says the routing key is ignored rather than missing, on a fanout exchange", () => {
+    const broadcast = defineExchange("broadcast", { type: "fanout" });
+    const announce = definePublisher(broadcast, message);
+
+    expect(() => defineContract({ publishers: { announce } })).toThrow(
+      /no routing key \(fanout exchanges ignore it\)/,
+    );
+    expect(() => defineContract({ publishers: { announce } })).not.toThrow(/\(none\)/);
+    // The remedy drops "that matches" — nothing matches on a fanout exchange.
+    expect(() => defineContract({ publishers: { announce } })).toThrow(
+      /Add a binding to this exchange/,
+    );
+  });
+
+  it("keeps the routing-key wording on a topic exchange", () => {
+    const orderCreated = definePublisher(orders, message, { routingKey: "order.created" });
+
+    expect(() => defineContract({ publishers: { orderCreated } })).toThrow(
+      /routing key "order\.created"/,
+    );
+    expect(() => defineContract({ publishers: { orderCreated } })).toThrow(
+      /Add a binding that matches/,
+    );
+  });
+});
+
 describe("externalConsumers across the publisher builders", () => {
   describe("defineEventPublisher", () => {
     it("throws for a publish-only event contract that is NOT marked", () => {

--- a/packages/contract/src/builder/routability-define-time.spec.ts
+++ b/packages/contract/src/builder/routability-define-time.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { defineQueueBinding } from "./binding.js";
+import { defineConsumer } from "./consumer.js";
+import { defineContract } from "./contract.js";
+import { defineExchange } from "./exchange.js";
+import { defineMessage } from "./message.js";
+import { definePublisher } from "./publisher.js";
+import { defineQueue } from "./queue.js";
+
+const message = defineMessage(z.object({ orderId: z.string() }));
+const orders = defineExchange("orders", { type: "topic" });
+const auditQueue = defineQueue("audit-log");
+
+describe("defineContract publisher routability", () => {
+  it("throws when a publisher's routing key reaches no queue", () => {
+    const orderCreated = definePublisher(orders, message, { routingKey: "order.created" });
+
+    expect(() =>
+      defineContract({
+        publishers: { orderCreated },
+        bindings: {
+          audit: defineQueueBinding(auditQueue, orders, { routingKey: "user.#" }),
+        },
+      }),
+    ).toThrow(/orderCreated/);
+  });
+
+  it("names the routing key, the exchange, and the declared patterns", () => {
+    const orderCreated = definePublisher(orders, message, { routingKey: "order.created" });
+
+    expect(() =>
+      defineContract({
+        publishers: { orderCreated },
+        bindings: {
+          audit: defineQueueBinding(auditQueue, orders, { routingKey: "user.#" }),
+        },
+      }),
+    ).toThrow(/order\.created[\s\S]*orders[\s\S]*user\.#/);
+  });
+
+  it("accepts a publisher whose key matches a declared binding", () => {
+    const orderCreated = definePublisher(orders, message, { routingKey: "order.created" });
+
+    expect(() =>
+      defineContract({
+        publishers: { orderCreated },
+        bindings: {
+          audit: defineQueueBinding(auditQueue, orders, { routingKey: "order.#" }),
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts a publisher routable via a consumer-contributed binding", () => {
+    // Consumers contribute bindings, so the check must run after they are
+    // collected — not while publishers are being processed.
+    const orderCreated = definePublisher(orders, message, { routingKey: "order.created" });
+
+    expect(() =>
+      defineContract({
+        publishers: { orderCreated },
+        consumers: { audit: defineConsumer(auditQueue, message) },
+        bindings: {
+          audit: defineQueueBinding(auditQueue, orders, { routingKey: "order.*" }),
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts an unroutable publisher explicitly marked externalConsumers", () => {
+    const orderCreated = definePublisher(orders, message, {
+      routingKey: "order.created",
+      externalConsumers: true,
+    });
+
+    expect(() => defineContract({ publishers: { orderCreated } })).not.toThrow();
+  });
+
+  it("still throws for a publish-only contract that is NOT marked", () => {
+    const orderCreated = definePublisher(orders, message, { routingKey: "order.created" });
+
+    expect(() => defineContract({ publishers: { orderCreated } })).toThrow(/externalConsumers/);
+  });
+});

--- a/packages/contract/src/builder/routability.spec.ts
+++ b/packages/contract/src/builder/routability.spec.ts
@@ -3,7 +3,11 @@ import { describe, expect, it } from "vitest";
 import type { BindingDefinition, ExchangeDefinition } from "../types.js";
 import { defineExchange } from "./exchange.js";
 import { defineQueue } from "./queue.js";
-import { _internal_declaredPatternsFor, _internal_isPublisherRoutable } from "./routability.js";
+import {
+  _internal_declaredPatternsFor,
+  _internal_isPublisherRoutable,
+  _internal_resolvePublisherRoutability,
+} from "./routability.js";
 
 const ordersTopic = defineExchange("orders", { type: "topic" });
 const ordersDirect = defineExchange("orders-direct", { type: "direct" });
@@ -73,6 +77,57 @@ describe("_internal_isPublisherRoutable", () => {
       { type: "exchange", source: billing, destination: ordersTopic, routingKey: "#" },
     ] as BindingDefinition[];
     expect(_internal_isPublisherRoutable(ordersTopic, "order.created", bindings)).toBe(false);
+  });
+});
+
+describe("_internal_resolvePublisherRoutability", () => {
+  it("reports only the source exchange when the key never leaves it", () => {
+    const bindings = [queueBinding(ordersTopic, "user.#")];
+    expect(_internal_resolvePublisherRoutability(ordersTopic, "order.created", bindings)).toEqual({
+      routable: false,
+      reachedExchanges: ["orders"],
+    });
+  });
+
+  it("reports every exchange the key reached when it is forwarded but still lost", () => {
+    // The distinction the error message depends on: "orders" accepted the key
+    // and forwarded it; the missing binding is on "billing".
+    const bindings = [
+      { type: "exchange", source: ordersTopic, destination: billing, routingKey: "order.#" },
+      { type: "queue", queue: q, exchange: billing, routingKey: "user.#" },
+    ] as BindingDefinition[];
+    expect(_internal_resolvePublisherRoutability(ordersTopic, "order.created", bindings)).toEqual({
+      routable: false,
+      reachedExchanges: ["orders", "billing"],
+    });
+  });
+
+  it("does not follow a forward whose pattern rejects the key", () => {
+    const bindings = [
+      { type: "exchange", source: ordersTopic, destination: billing, routingKey: "user.#" },
+    ] as BindingDefinition[];
+    expect(_internal_resolvePublisherRoutability(ordersTopic, "order.created", bindings)).toEqual({
+      routable: false,
+      reachedExchanges: ["orders"],
+    });
+  });
+
+  it("terminates on a cyclic graph and reports the cycle's exchanges once each", () => {
+    const bindings = [
+      { type: "exchange", source: ordersTopic, destination: billing, routingKey: "#" },
+      { type: "exchange", source: billing, destination: ordersTopic, routingKey: "#" },
+    ] as BindingDefinition[];
+    expect(_internal_resolvePublisherRoutability(ordersTopic, "order.created", bindings)).toEqual({
+      routable: false,
+      reachedExchanges: ["orders", "billing"],
+    });
+  });
+
+  it("reports routable as soon as a queue is found", () => {
+    const bindings = [queueBinding(ordersTopic, "order.#")];
+    expect(
+      _internal_resolvePublisherRoutability(ordersTopic, "order.created", bindings).routable,
+    ).toBe(true);
   });
 });
 

--- a/packages/contract/src/builder/routability.spec.ts
+++ b/packages/contract/src/builder/routability.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import type { BindingDefinition, ExchangeDefinition } from "../types.js";
+import { defineExchange } from "./exchange.js";
+import { defineQueue } from "./queue.js";
+import { _internal_declaredPatternsFor, _internal_isPublisherRoutable } from "./routability.js";
+
+const ordersTopic = defineExchange("orders", { type: "topic" });
+const ordersDirect = defineExchange("orders-direct", { type: "direct" });
+const broadcast = defineExchange("broadcast", { type: "fanout" });
+const billing = defineExchange("billing", { type: "topic" });
+const q = defineQueue("audit-log");
+
+// Widened to ExchangeDefinition so topic exchanges with different name
+// literals (`orders`, `billing`) share one helper.
+function queueBinding(exchange: ExchangeDefinition, routingKey: string): BindingDefinition {
+  return { type: "queue", queue: q, exchange, routingKey } as BindingDefinition;
+}
+
+describe("_internal_isPublisherRoutable", () => {
+  it("is routable when a topic queue binding matches the key", () => {
+    const bindings = [queueBinding(ordersTopic, "order.#")];
+    expect(_internal_isPublisherRoutable(ordersTopic, "order.created", bindings)).toBe(true);
+  });
+
+  it("is NOT routable when no topic binding matches the key", () => {
+    const bindings = [queueBinding(ordersTopic, "user.#")];
+    expect(_internal_isPublisherRoutable(ordersTopic, "order.created", bindings)).toBe(false);
+  });
+
+  it("is NOT routable when there are no bindings at all", () => {
+    expect(_internal_isPublisherRoutable(ordersTopic, "order.created", [])).toBe(false);
+  });
+
+  it("requires exact equality on a direct exchange", () => {
+    const bindings = [
+      { type: "queue", queue: q, exchange: ordersDirect, routingKey: "order.created" },
+    ] as BindingDefinition[];
+    expect(_internal_isPublisherRoutable(ordersDirect, "order.created", bindings)).toBe(true);
+    expect(_internal_isPublisherRoutable(ordersDirect, "order.*", bindings)).toBe(false);
+  });
+
+  it("treats any binding on a fanout exchange as routable", () => {
+    const bindings = [{ type: "queue", queue: q, exchange: broadcast }] as BindingDefinition[];
+    expect(_internal_isPublisherRoutable(broadcast, undefined, bindings)).toBe(true);
+  });
+
+  it("is NOT routable on a fanout exchange with no bindings", () => {
+    expect(_internal_isPublisherRoutable(broadcast, undefined, [])).toBe(false);
+  });
+
+  it("follows an exchange-to-exchange forward to a queue (bridged publisher)", () => {
+    // orders --order.#--> billing --#--> queue
+    const bindings = [
+      { type: "exchange", source: ordersTopic, destination: billing, routingKey: "order.#" },
+      { type: "queue", queue: q, exchange: billing, routingKey: "#" },
+    ] as BindingDefinition[];
+    expect(_internal_isPublisherRoutable(ordersTopic, "order.created", bindings)).toBe(true);
+  });
+
+  it("is NOT routable when the forward exists but the destination has no matching queue", () => {
+    const bindings = [
+      { type: "exchange", source: ordersTopic, destination: billing, routingKey: "order.#" },
+      { type: "queue", queue: q, exchange: billing, routingKey: "user.#" },
+    ] as BindingDefinition[];
+    expect(_internal_isPublisherRoutable(ordersTopic, "order.created", bindings)).toBe(false);
+  });
+
+  it("terminates on a cyclic exchange graph", () => {
+    // orders -> billing -> orders, with no queue anywhere.
+    const bindings = [
+      { type: "exchange", source: ordersTopic, destination: billing, routingKey: "#" },
+      { type: "exchange", source: billing, destination: ordersTopic, routingKey: "#" },
+    ] as BindingDefinition[];
+    expect(_internal_isPublisherRoutable(ordersTopic, "order.created", bindings)).toBe(false);
+  });
+});
+
+describe("_internal_declaredPatternsFor", () => {
+  it("lists the patterns declared on an exchange, for the error message", () => {
+    const bindings = [
+      queueBinding(ordersTopic, "user.#"),
+      queueBinding(ordersTopic, "audit.*"),
+      queueBinding(billing, "order.#"),
+    ];
+    expect(_internal_declaredPatternsFor("orders", bindings)).toEqual(["user.#", "audit.*"]);
+  });
+
+  it("returns an empty list when nothing is declared on the exchange", () => {
+    expect(_internal_declaredPatternsFor("orders", [])).toEqual([]);
+  });
+});

--- a/packages/contract/src/builder/routability.spec.ts
+++ b/packages/contract/src/builder/routability.spec.ts
@@ -80,6 +80,62 @@ describe("_internal_isPublisherRoutable", () => {
   });
 });
 
+/*
+ * An alternate exchange is the broker's own answer to unroutable messages, so
+ * a publisher on an exchange that declares one cannot lose a message the way
+ * this check exists to prevent. Rejecting it was a false positive on a
+ * documented feature.
+ */
+describe("alternate-exchange", () => {
+  const withAe = defineExchange("orders-ae", {
+    type: "topic",
+    arguments: { "alternate-exchange": "catch-all" },
+  });
+
+  it("is routable with no bindings at all when the exchange declares one", () => {
+    expect(_internal_isPublisherRoutable(withAe, "order.created", [])).toBe(true);
+  });
+
+  it("is routable when the declared bindings all reject the key", () => {
+    const bindings = [queueBinding(withAe, "user.#")];
+    expect(_internal_isPublisherRoutable(withAe, "order.created", bindings)).toBe(true);
+  });
+
+  it("does not require the alternate exchange to be declared in this contract", () => {
+    // The argument names an exchange, and the name commonly resolves to
+    // another service's topology. Following it would reject every such
+    // contract — the false positive this check must not produce.
+    expect(_internal_resolvePublisherRoutability(withAe, "order.created", [])).toEqual({
+      routable: true,
+      reachedExchanges: ["orders-ae"],
+    });
+  });
+
+  it("honours an alternate exchange declared on a downstream hop", () => {
+    // orders --order.#--> billing-ae, which declares its own alternate.
+    const billingAe = defineExchange("billing-ae", {
+      type: "topic",
+      arguments: { "alternate-exchange": "catch-all" },
+    });
+    const bindings = [
+      { type: "exchange", source: ordersTopic, destination: billingAe, routingKey: "order.#" },
+    ] as BindingDefinition[];
+
+    expect(_internal_resolvePublisherRoutability(ordersTopic, "order.created", bindings)).toEqual({
+      routable: true,
+      reachedExchanges: ["orders", "billing-ae"],
+    });
+  });
+
+  it("still rejects an exchange whose arguments carry no alternate-exchange", () => {
+    const other = defineExchange("orders-other-args", {
+      type: "topic",
+      arguments: { "x-custom": "value" },
+    });
+    expect(_internal_isPublisherRoutable(other, "order.created", [])).toBe(false);
+  });
+});
+
 describe("_internal_resolvePublisherRoutability", () => {
   it("reports only the source exchange when the key never leaves it", () => {
     const bindings = [queueBinding(ordersTopic, "user.#")];

--- a/packages/contract/src/builder/routability.ts
+++ b/packages/contract/src/builder/routability.ts
@@ -9,6 +9,10 @@ import { _internal_matchesTopicPattern } from "./topic-match.js";
  * message may reach a queue several hops away. A single-hop check would
  * falsely reject every bridged contract.
  *
+ * The governing rule is never to reject a valid contract: a missed unroutable
+ * publisher is caught later at runtime, whereas a false alarm breaks a build
+ * that was correct. Undecidable cases therefore resolve to "routable".
+ *
  * @internal
  */
 
@@ -36,6 +40,26 @@ function bindingAccepts(
         _internal_matchesTopicPattern(routingKey, bindingRoutingKey)
       );
   }
+}
+
+/**
+ * True when the exchange declares an `alternate-exchange` argument.
+ *
+ * An alternate exchange is RabbitMQ's own catch-all for exactly the failure
+ * this check exists to prevent: a message that matches no binding is handed to
+ * the named exchange instead of being discarded. Such an exchange therefore
+ * has no unroutable keys, and a publisher on it is always routable.
+ *
+ * The argument holds a *name*, not an {@link ExchangeDefinition}, and the
+ * alternate is usually declared elsewhere — another service's contract, or a
+ * shared operational exchange — so its own bindings are typically not visible
+ * here. Following the name would mean rejecting every contract whose alternate
+ * lives outside it, which is precisely the false positive this module must not
+ * produce. We stop at the declaration instead: an alternate exchange whose own
+ * target is unbound is a far rarer and cheaper mistake than a broken build.
+ */
+function hasAlternateExchange(exchange: ExchangeDefinition): boolean {
+  return exchange.arguments?.["alternate-exchange"] !== undefined;
 }
 
 /**
@@ -83,6 +107,13 @@ export function _internal_resolvePublisherRoutability(
       continue;
     }
     visited.add(current.name);
+
+    // Checked on every hop, not just the source: a forward can land on an
+    // exchange that catches its own unmatched keys, and that hop is just as
+    // routable as the source would be.
+    if (hasAlternateExchange(current)) {
+      return { routable: true, reachedExchanges: [...visited] };
+    }
 
     for (const binding of bindings) {
       if (binding.type === "queue") {

--- a/packages/contract/src/builder/routability.ts
+++ b/packages/contract/src/builder/routability.ts
@@ -39,16 +39,39 @@ function bindingAccepts(
 }
 
 /**
- * True when a message published to `exchange` with `routingKey` reaches at
- * least one queue, directly or through exchange-to-exchange forwards.
+ * The outcome of resolving a publisher against the binding graph.
+ *
+ * `reachedExchanges` is what makes a multi-hop failure diagnosable: it names
+ * every exchange the routing key actually got to, in BFS order with the
+ * publisher's own exchange first. When it holds more than one name the key
+ * *did* match on the source and the loss happened further downstream — a
+ * distinction a bare boolean cannot express, and one the error message needs
+ * so it does not point the reader at a binding that visibly matches.
  *
  * @internal
  */
-export function _internal_isPublisherRoutable(
+export type PublisherRoutability = {
+  /** True when at least one queue is reachable. */
+  readonly routable: boolean;
+  /**
+   * Exchanges the key reached, source first. Complete only when
+   * `routable` is false — resolution stops at the first queue it finds.
+   */
+  readonly reachedExchanges: readonly string[];
+};
+
+/**
+ * Resolve whether a message published to `exchange` with `routingKey` reaches
+ * at least one queue, directly or through exchange-to-exchange forwards, and
+ * report which exchanges it got to along the way.
+ *
+ * @internal
+ */
+export function _internal_resolvePublisherRoutability(
   exchange: ExchangeDefinition,
   routingKey: string | undefined,
   bindings: readonly BindingDefinition[],
-): boolean {
+): PublisherRoutability {
   // Cycle guard: exchange graphs may contain loops, and the routing key is
   // preserved across forwards, so the exchange name alone identifies a state.
   const visited = new Set<string>();
@@ -66,7 +89,7 @@ export function _internal_isPublisherRoutable(
         if (binding.exchange.name !== current.name) continue;
         const bindingKey = "routingKey" in binding ? binding.routingKey : undefined;
         if (bindingAccepts(current, routingKey, bindingKey)) {
-          return true;
+          return { routable: true, reachedExchanges: [...visited] };
         }
         continue;
       }
@@ -79,7 +102,24 @@ export function _internal_isPublisherRoutable(
     }
   }
 
-  return false;
+  return { routable: false, reachedExchanges: [...visited] };
+}
+
+/**
+ * True when a message published to `exchange` with `routingKey` reaches at
+ * least one queue, directly or through exchange-to-exchange forwards.
+ *
+ * The boolean-only view of {@link _internal_resolvePublisherRoutability}, kept
+ * for callers that only need the verdict.
+ *
+ * @internal
+ */
+export function _internal_isPublisherRoutable(
+  exchange: ExchangeDefinition,
+  routingKey: string | undefined,
+  bindings: readonly BindingDefinition[],
+): boolean {
+  return _internal_resolvePublisherRoutability(exchange, routingKey, bindings).routable;
 }
 
 /**

--- a/packages/contract/src/builder/routability.ts
+++ b/packages/contract/src/builder/routability.ts
@@ -1,0 +1,104 @@
+import type { BindingDefinition, ExchangeDefinition } from "../types.js";
+import { _internal_matchesTopicPattern } from "./topic-match.js";
+
+/**
+ * Decides whether a publisher can reach at least one queue.
+ *
+ * Routability is a graph problem, not a single-hop lookup: an exchange can
+ * forward to another exchange (`defineBridgedPublisher`), so the publisher's
+ * message may reach a queue several hops away. A single-hop check would
+ * falsely reject every bridged contract.
+ *
+ * @internal
+ */
+
+/** True when a binding declared on `exchange` accepts `routingKey`. */
+function bindingAccepts(
+  exchange: ExchangeDefinition,
+  routingKey: string | undefined,
+  bindingRoutingKey: string | undefined,
+): boolean {
+  switch (exchange.type) {
+    case "fanout":
+      // The broker ignores the routing key entirely: any binding routes.
+      return true;
+    case "headers":
+      // Matching is on the binding's arguments, which cannot be decided
+      // against a routing key. Treat any binding as potentially routable
+      // rather than raising a false alarm.
+      return true;
+    case "direct":
+      return routingKey !== undefined && routingKey === bindingRoutingKey;
+    case "topic":
+      return (
+        routingKey !== undefined &&
+        bindingRoutingKey !== undefined &&
+        _internal_matchesTopicPattern(routingKey, bindingRoutingKey)
+      );
+  }
+}
+
+/**
+ * True when a message published to `exchange` with `routingKey` reaches at
+ * least one queue, directly or through exchange-to-exchange forwards.
+ *
+ * @internal
+ */
+export function _internal_isPublisherRoutable(
+  exchange: ExchangeDefinition,
+  routingKey: string | undefined,
+  bindings: readonly BindingDefinition[],
+): boolean {
+  // Cycle guard: exchange graphs may contain loops, and the routing key is
+  // preserved across forwards, so the exchange name alone identifies a state.
+  const visited = new Set<string>();
+  const queue: ExchangeDefinition[] = [exchange];
+
+  while (queue.length > 0) {
+    const current = queue.shift() as ExchangeDefinition;
+    if (visited.has(current.name)) {
+      continue;
+    }
+    visited.add(current.name);
+
+    for (const binding of bindings) {
+      if (binding.type === "queue") {
+        if (binding.exchange.name !== current.name) continue;
+        const bindingKey = "routingKey" in binding ? binding.routingKey : undefined;
+        if (bindingAccepts(current, routingKey, bindingKey)) {
+          return true;
+        }
+        continue;
+      }
+
+      if (binding.source.name !== current.name) continue;
+      const bindingKey = "routingKey" in binding ? binding.routingKey : undefined;
+      if (bindingAccepts(current, routingKey, bindingKey)) {
+        queue.push(binding.destination);
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * The routing patterns declared on an exchange, in declaration order — used
+ * to make the define-time error actionable by showing what *is* declared.
+ *
+ * @internal
+ */
+export function _internal_declaredPatternsFor(
+  exchangeName: string,
+  bindings: readonly BindingDefinition[],
+): readonly string[] {
+  const patterns: string[] = [];
+  for (const binding of bindings) {
+    const source = binding.type === "queue" ? binding.exchange : binding.source;
+    if (source.name !== exchangeName) continue;
+    if ("routingKey" in binding && typeof binding.routingKey === "string") {
+      patterns.push(binding.routingKey);
+    }
+  }
+  return patterns;
+}

--- a/packages/contract/src/builder/routing-types.ts
+++ b/packages/contract/src/builder/routing-types.ts
@@ -171,3 +171,57 @@ export type MatchingBindingPattern<
       : MatchesPattern<PublisherKey, Pattern> extends true
         ? Pattern
         : `Error: binding pattern '${Pattern}' can never match the publisher routing key '${PublisherKey}'`;
+
+/**
+ * True when `Key` matches at least one pattern in the `Patterns` union.
+ *
+ * Distributes over the union rather than recursing across a list, which
+ * keeps instantiation depth bounded by the longest single pattern instead
+ * of by the number of bindings.
+ * @internal
+ */
+type MatchesAnyPattern<Key extends string, Patterns extends string> = [Patterns] extends [never]
+  ? false
+  : true extends (Patterns extends string ? MatchesPattern<Key, Patterns> : never)
+    ? true
+    : false;
+
+/**
+ * A publisher routing key validated against the binding patterns declared on
+ * its exchange.
+ *
+ * A message routed to zero queues is confirmed by RabbitMQ and then
+ * discarded, so an unmatched routing key is silent total message loss. On no
+ * match this resolves to a human-readable error-message string type, so the
+ * compile error explains the problem instead of collapsing to `never` —
+ * matching the {@link MatchingBindingPattern} convention.
+ *
+ * Skipped (resolves to `Key`) when either side is non-literal, or when no
+ * patterns are declared: those cases cannot be decided at compile time and
+ * are left to the define-time check in `defineContract`.
+ *
+ * Scope: single-hop queue bindings on topic and direct exchanges. Fanout,
+ * headers, and exchange-to-exchange forwards are deliberately not modelled
+ * here — deciding them needs graph traversal in the type system, which risks
+ * recursion-depth failures and false compile errors on valid contracts. Those
+ * cases fall through to the define-time check, which sees the whole graph.
+ *
+ * @template Key - The publisher's concrete routing key
+ * @template Patterns - Union of binding patterns declared on the exchange
+ * @example
+ * ```typescript
+ * type Ok = RoutableRoutingKey<"order.created", "order.#" | "user.#">; // "order.created"
+ * type Bad = RoutableRoutingKey<"order.created", "user.#">;
+ * // "Error: routing key 'order.created' matches none of the declared binding
+ * //  patterns; the broker would confirm and discard every message"
+ * ```
+ */
+export type RoutableRoutingKey<Key extends string, Patterns extends string> = string extends Key
+  ? Key
+  : string extends Patterns
+    ? Key
+    : [Patterns] extends [never]
+      ? Key
+      : MatchesAnyPattern<Key, Patterns> extends true
+        ? Key
+        : `Error: routing key '${Key}' matches none of the declared binding patterns; the broker would confirm and discard every message`;

--- a/packages/contract/src/builder/topic-match.spec.ts
+++ b/packages/contract/src/builder/topic-match.spec.ts
@@ -1,0 +1,63 @@
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+
+import { MATCH_CORPUS } from "./match-corpus.js";
+import { _internal_matchesTopicPattern } from "./topic-match.js";
+
+describe("_internal_matchesTopicPattern", () => {
+  describe("shared corpus", () => {
+    for (const { key, pattern, matches } of MATCH_CORPUS) {
+      it(`${matches ? "matches" : "does not match"} key "${key}" against pattern "${pattern}"`, () => {
+        expect(_internal_matchesTopicPattern(key, pattern)).toBe(matches);
+      });
+    }
+  });
+
+  describe("properties", () => {
+    // Words are non-empty, wildcard-free AMQP-ish tokens.
+    const word = fc.stringMatching(/^[a-z0-9_-]{1,6}$/);
+    const key = fc.array(word, { minLength: 1, maxLength: 4 }).map((w) => w.join("."));
+
+    it("a wildcard-free pattern matches exactly its own key", () => {
+      fc.assert(
+        fc.property(key, (k) => {
+          expect(_internal_matchesTopicPattern(k, k)).toBe(true);
+        }),
+      );
+    });
+
+    it("'#' alone matches every key", () => {
+      fc.assert(
+        fc.property(key, (k) => {
+          expect(_internal_matchesTopicPattern(k, "#")).toBe(true);
+        }),
+      );
+    });
+
+    it("an all-'*' pattern matches iff the word counts are equal", () => {
+      fc.assert(
+        fc.property(key, fc.integer({ min: 1, max: 6 }), (k, starCount) => {
+          const pattern = Array.from({ length: starCount }, () => "*").join(".");
+          const expected = k.split(".").length === starCount;
+          expect(_internal_matchesTopicPattern(k, pattern)).toBe(expected);
+        }),
+      );
+    });
+
+    it("appending '.#' to a matching pattern keeps it matching", () => {
+      fc.assert(
+        fc.property(key, (k) => {
+          expect(_internal_matchesTopicPattern(k, `${k}.#`)).toBe(true);
+        }),
+      );
+    });
+
+    it("is deterministic", () => {
+      fc.assert(
+        fc.property(key, key, (k, p) => {
+          expect(_internal_matchesTopicPattern(k, p)).toBe(_internal_matchesTopicPattern(k, p));
+        }),
+      );
+    });
+  });
+});

--- a/packages/contract/src/builder/topic-match.ts
+++ b/packages/contract/src/builder/topic-match.ts
@@ -1,0 +1,66 @@
+/**
+ * Runtime AMQP topic-pattern matching.
+ *
+ * Mirrors the compile-time `MatchesPattern` in `routing-types.ts`. The two
+ * must agree on every input — `match-corpus.ts` is asserted against both,
+ * and a divergence fails one of the two suites.
+ *
+ * AMQP semantics:
+ * - a routing key is dot-separated words
+ * - `*` matches exactly one word
+ * - `#` matches zero or more words
+ *
+ * @internal
+ */
+
+/**
+ * Backtracking match of `key[ki..]` against `pattern[pi..]`.
+ *
+ * `#` needs backtracking rather than a greedy consume: `order.#.v2` against
+ * `order.a.b.v2` only matches if `#` gives back the trailing `v2`.
+ */
+function matchFrom(
+  key: readonly string[],
+  ki: number,
+  pattern: readonly string[],
+  pi: number,
+): boolean {
+  if (pi === pattern.length) {
+    return ki === key.length;
+  }
+
+  const token = pattern[pi];
+
+  if (token === "#") {
+    // Try every number of words '#' could absorb, shortest first.
+    for (let skip = 0; ki + skip <= key.length; skip += 1) {
+      if (matchFrom(key, ki + skip, pattern, pi + 1)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  if (ki === key.length) {
+    return false;
+  }
+
+  if (token === "*" || token === key[ki]) {
+    return matchFrom(key, ki + 1, pattern, pi + 1);
+  }
+
+  return false;
+}
+
+/**
+ * True when `routingKey` is delivered by a binding declared with `pattern`.
+ *
+ * @param routingKey - Concrete routing key (no wildcards)
+ * @param pattern - Binding pattern (may contain `*` and `#`)
+ * @internal
+ */
+export function _internal_matchesTopicPattern(routingKey: string, pattern: string): boolean {
+  const keyWords = routingKey === "" ? [] : routingKey.split(".");
+  const patternWords = pattern === "" ? [] : pattern.split(".");
+  return matchFrom(keyWords, 0, patternWords, 0);
+}

--- a/packages/contract/src/builder/validate.ts
+++ b/packages/contract/src/builder/validate.ts
@@ -127,14 +127,26 @@ export function _internal_assertPublisherRoutable(
   );
   if (routable) return;
 
+  // Fanout and headers exchanges ignore the routing key entirely, so on those
+  // the key is *not applicable* rather than *missing* — reporting "(none)"
+  // there reads as a misconfiguration and sends the reader after the wrong
+  // thing. The only fix on a keyless exchange is a binding, so the remedy
+  // wording drops "that matches" too.
+  const ignoresRoutingKey = exchange.type === "fanout" || exchange.type === "headers";
+  const keyClause = ignoresRoutingKey
+    ? `no routing key (${exchange.type} exchanges ignore it)`
+    : `routing key ${routingKey === undefined ? "(none)" : `"${routingKey}"`}`;
+  const remedy = ignoresRoutingKey
+    ? "Add a binding to this exchange"
+    : "Add a binding that matches";
+
   // oxlint-disable-next-line unthrown/no-throw -- fail-fast declaration-time config error (see module doc)
   throw new Error(
-    `Publisher "${publisherName}" is unroutable: routing key ` +
-      `${routingKey === undefined ? "(none)" : `"${routingKey}"`} on exchange ` +
+    `Publisher "${publisherName}" is unroutable: ${keyClause} on exchange ` +
       `"${exchange.name}" (${exchange.type}) reaches no queue. ` +
       `${describeReach(exchange.name, reachedExchanges, bindings)} ` +
       `Messages published here would be confirmed by the broker and then discarded. ` +
-      `Add a binding that matches, or set \`externalConsumers: true\` on the publisher ` +
+      `${remedy}, or set \`externalConsumers: true\` on the publisher ` +
       `if another service owns the binding.`,
   );
 }

--- a/packages/contract/src/builder/validate.ts
+++ b/packages/contract/src/builder/validate.ts
@@ -12,6 +12,9 @@
  * builder modules, no semver guarantee.
  */
 
+import type { BindingDefinition, ExchangeDefinition } from "../types.js";
+import { _internal_declaredPatternsFor, _internal_isPublisherRoutable } from "./routability.js";
+
 /** Throw unless `name` is a non-empty string (AMQP names must not be blank). */
 export function _internal_assertNonEmptyName(kind: string, name: unknown): void {
   if (typeof name !== "string" || name.length === 0) {
@@ -92,4 +95,42 @@ export function _internal_assertStandardSchema(kind: string, schema: unknown): v
         "got a value without one. Zod, Valibot, and ArkType schemas all qualify.",
     );
   }
+}
+
+/**
+ * Throw when a publisher's routing key reaches no queue in this contract.
+ *
+ * RabbitMQ publisher confirms mean "the broker took responsibility", not "a
+ * queue received it": a message routed to zero queues is confirmed and then
+ * discarded. Without this check a mistyped binding pattern silently drops
+ * every message while the publishing code observes success.
+ *
+ * Publishers whose consumers are owned by another service opt out with
+ * `externalConsumers: true`.
+ */
+export function _internal_assertPublisherRoutable(
+  publisherName: string,
+  exchange: ExchangeDefinition,
+  routingKey: string | undefined,
+  externalConsumers: boolean | undefined,
+  bindings: readonly BindingDefinition[],
+): void {
+  if (externalConsumers === true) return;
+  if (_internal_isPublisherRoutable(exchange, routingKey, bindings)) return;
+
+  const declared = _internal_declaredPatternsFor(exchange.name, bindings);
+  const declaredText =
+    declared.length > 0
+      ? `Declared on "${exchange.name}": ${declared.map((p) => `"${p}"`).join(", ")}.`
+      : `No bindings are declared on "${exchange.name}".`;
+
+  // oxlint-disable-next-line unthrown/no-throw -- fail-fast declaration-time config error (see module doc)
+  throw new Error(
+    `Publisher "${publisherName}" is unroutable: routing key ` +
+      `${routingKey === undefined ? "(none)" : `"${routingKey}"`} on exchange ` +
+      `"${exchange.name}" (${exchange.type}) reaches no queue. ${declaredText} ` +
+      `Messages published here would be confirmed by the broker and then discarded. ` +
+      `Add a binding that matches, or set \`externalConsumers: true\` on the publisher ` +
+      `if another service owns the binding.`,
+  );
 }

--- a/packages/contract/src/builder/validate.ts
+++ b/packages/contract/src/builder/validate.ts
@@ -13,7 +13,10 @@
  */
 
 import type { BindingDefinition, ExchangeDefinition } from "../types.js";
-import { _internal_declaredPatternsFor, _internal_isPublisherRoutable } from "./routability.js";
+import {
+  _internal_declaredPatternsFor,
+  _internal_resolvePublisherRoutability,
+} from "./routability.js";
 
 /** Throw unless `name` is a non-empty string (AMQP names must not be blank). */
 export function _internal_assertNonEmptyName(kind: string, name: unknown): void {
@@ -116,21 +119,57 @@ export function _internal_assertPublisherRoutable(
   bindings: readonly BindingDefinition[],
 ): void {
   if (externalConsumers === true) return;
-  if (_internal_isPublisherRoutable(exchange, routingKey, bindings)) return;
 
-  const declared = _internal_declaredPatternsFor(exchange.name, bindings);
-  const declaredText =
-    declared.length > 0
-      ? `Declared on "${exchange.name}": ${declared.map((p) => `"${p}"`).join(", ")}.`
-      : `No bindings are declared on "${exchange.name}".`;
+  const { routable, reachedExchanges } = _internal_resolvePublisherRoutability(
+    exchange,
+    routingKey,
+    bindings,
+  );
+  if (routable) return;
 
   // oxlint-disable-next-line unthrown/no-throw -- fail-fast declaration-time config error (see module doc)
   throw new Error(
     `Publisher "${publisherName}" is unroutable: routing key ` +
       `${routingKey === undefined ? "(none)" : `"${routingKey}"`} on exchange ` +
-      `"${exchange.name}" (${exchange.type}) reaches no queue. ${declaredText} ` +
+      `"${exchange.name}" (${exchange.type}) reaches no queue. ` +
+      `${describeReach(exchange.name, reachedExchanges, bindings)} ` +
       `Messages published here would be confirmed by the broker and then discarded. ` +
       `Add a binding that matches, or set \`externalConsumers: true\` on the publisher ` +
       `if another service owns the binding.`,
+  );
+}
+
+/**
+ * Describe where the key actually got to, so the reader is not sent to the
+ * wrong exchange.
+ *
+ * With a single reached exchange the break is local and listing that
+ * exchange's patterns is the whole story. With more than one, the key *did*
+ * match on the source and was forwarded — naming only the source's patterns
+ * would show a pattern that visibly matches and hide the fact that the real
+ * gap is a missing queue binding downstream.
+ */
+function describeReach(
+  sourceName: string,
+  reachedExchanges: readonly string[],
+  bindings: readonly BindingDefinition[],
+): string {
+  const declaredOn = (name: string): string => {
+    const declared = _internal_declaredPatternsFor(name, bindings);
+    return declared.length > 0
+      ? `Declared on "${name}": ${declared.map((p) => `"${p}"`).join(", ")}.`
+      : `No bindings are declared on "${name}".`;
+  };
+
+  const downstream = reachedExchanges.filter((name) => name !== sourceName);
+  if (downstream.length === 0) {
+    return declaredOn(sourceName);
+  }
+
+  return (
+    `The key matches on "${sourceName}" and is forwarded on to ` +
+    `${downstream.map((name) => `"${name}"`).join(", ")}, but no queue binding ` +
+    `downstream accepts it — the break is not on "${sourceName}". ` +
+    [sourceName, ...downstream].map(declaredOn).join(" ")
   );
 }

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -29,6 +29,7 @@ export type {
   EventPublisherConfig,
   MatchingBindingPattern,
   MatchingRoutingKey,
+  RoutableRoutingKey,
   RoutingKey,
 } from "./builder.js";
 export { formatIssue, summarizeIssues } from "./issues.js";

--- a/packages/contract/src/routability.test-d.ts
+++ b/packages/contract/src/routability.test-d.ts
@@ -1,0 +1,104 @@
+import { describe, expectTypeOf, it } from "vitest";
+
+import type { RoutableRoutingKey } from "./builder/routing-types.js";
+
+describe("RoutableRoutingKey", () => {
+  it("resolves to the key when a pattern matches", () => {
+    expectTypeOf<RoutableRoutingKey<"order.created", "order.#">>().toEqualTypeOf<"order.created">();
+    expectTypeOf<RoutableRoutingKey<"order.created", "order.*">>().toEqualTypeOf<"order.created">();
+    expectTypeOf<
+      RoutableRoutingKey<"order.created", "order.created">
+    >().toEqualTypeOf<"order.created">();
+  });
+
+  it("resolves to the key when ANY pattern in the union matches", () => {
+    expectTypeOf<
+      RoutableRoutingKey<"order.created", "user.#" | "order.#">
+    >().toEqualTypeOf<"order.created">();
+  });
+
+  it("resolves to a readable error when no pattern matches", () => {
+    expectTypeOf<
+      RoutableRoutingKey<"order.created", "user.#">
+    >().toEqualTypeOf<"Error: routing key 'order.created' matches none of the declared binding patterns; the broker would confirm and discard every message">();
+  });
+
+  it("skips the check when the key is not a literal", () => {
+    expectTypeOf<RoutableRoutingKey<string, "user.#">>().toEqualTypeOf<string>();
+  });
+
+  it("skips the check when the patterns are not literal", () => {
+    expectTypeOf<RoutableRoutingKey<"order.created", string>>().toEqualTypeOf<"order.created">();
+  });
+
+  it("skips the check when there are no patterns", () => {
+    expectTypeOf<RoutableRoutingKey<"order.created", never>>().toEqualTypeOf<"order.created">();
+  });
+});
+
+/**
+ * The corpus in `match-corpus.ts` is asserted against the runtime matcher in
+ * `topic-match.spec.ts`. These assertions pin the same cases at the type
+ * level, so the two implementations cannot diverge without a test failing.
+ *
+ * Kept as explicit lines rather than a loop: types cannot be generated from
+ * a runtime array.
+ */
+describe("type-level matcher agrees with the runtime corpus", () => {
+  it("matches the cases the runtime matcher matches", () => {
+    expectTypeOf<
+      RoutableRoutingKey<"order.created", "order.created">
+    >().toEqualTypeOf<"order.created">();
+    expectTypeOf<RoutableRoutingKey<"order", "order">>().toEqualTypeOf<"order">();
+    expectTypeOf<RoutableRoutingKey<"order.created", "order.*">>().toEqualTypeOf<"order.created">();
+    expectTypeOf<
+      RoutableRoutingKey<"order.created", "*.created">
+    >().toEqualTypeOf<"order.created">();
+    expectTypeOf<RoutableRoutingKey<"order.created", "*.*">>().toEqualTypeOf<"order.created">();
+    expectTypeOf<RoutableRoutingKey<"order", "*">>().toEqualTypeOf<"order">();
+    expectTypeOf<RoutableRoutingKey<"order.created", "#">>().toEqualTypeOf<"order.created">();
+    expectTypeOf<RoutableRoutingKey<"order", "#">>().toEqualTypeOf<"order">();
+    expectTypeOf<RoutableRoutingKey<"order.created", "order.#">>().toEqualTypeOf<"order.created">();
+    expectTypeOf<RoutableRoutingKey<"order", "order.#">>().toEqualTypeOf<"order">();
+    expectTypeOf<
+      RoutableRoutingKey<"order.created.v2", "order.#">
+    >().toEqualTypeOf<"order.created.v2">();
+    expectTypeOf<
+      RoutableRoutingKey<"order.created", "#.created">
+    >().toEqualTypeOf<"order.created">();
+    expectTypeOf<RoutableRoutingKey<"created", "#.created">>().toEqualTypeOf<"created">();
+    expectTypeOf<
+      RoutableRoutingKey<"order.created.v2", "order.#.v2">
+    >().toEqualTypeOf<"order.created.v2">();
+    expectTypeOf<RoutableRoutingKey<"order.v2", "order.#.v2">>().toEqualTypeOf<"order.v2">();
+    expectTypeOf<
+      RoutableRoutingKey<"order.a.b.v2", "order.#.v2">
+    >().toEqualTypeOf<"order.a.b.v2">();
+    expectTypeOf<
+      RoutableRoutingKey<"order.created.v2", "order.*.#">
+    >().toEqualTypeOf<"order.created.v2">();
+    expectTypeOf<
+      RoutableRoutingKey<"order.created", "order.*.#">
+    >().toEqualTypeOf<"order.created">();
+  });
+
+  it("rejects the cases the runtime matcher rejects", () => {
+    expectTypeOf<
+      RoutableRoutingKey<"order.created", "order.updated">
+    >().not.toEqualTypeOf<"order.created">();
+    expectTypeOf<
+      RoutableRoutingKey<"order.created.v2", "order.*">
+    >().not.toEqualTypeOf<"order.created.v2">();
+    expectTypeOf<RoutableRoutingKey<"order.created", "*">>().not.toEqualTypeOf<"order.created">();
+    expectTypeOf<
+      RoutableRoutingKey<"order.created", "order.#.v2">
+    >().not.toEqualTypeOf<"order.created">();
+    expectTypeOf<RoutableRoutingKey<"order", "order.*.#">>().not.toEqualTypeOf<"order">();
+    expectTypeOf<
+      RoutableRoutingKey<"user.created", "order.#">
+    >().not.toEqualTypeOf<"user.created">();
+    expectTypeOf<
+      RoutableRoutingKey<"order.created", "order.created.v2">
+    >().not.toEqualTypeOf<"order.created">();
+  });
+});

--- a/packages/contract/src/types.ts
+++ b/packages/contract/src/types.ts
@@ -939,6 +939,8 @@ export type EventPublisherConfigBase = {
   routingKey: string | undefined;
   /** Default binding arguments for this event's consumers (not publish arguments). */
   bindingArguments?: Record<string, unknown>;
+  /** Opt out of the define-time routability check — see {@link PublisherDefinition.externalConsumers}. */
+  externalConsumers?: boolean | undefined;
 };
 
 /**

--- a/packages/contract/src/types.ts
+++ b/packages/contract/src/types.ts
@@ -866,6 +866,16 @@ export type BindingDefinition = QueueBindingDefinition | ExchangeBindingDefiniti
 export type PublisherDefinition<TMessage extends MessageDefinition = MessageDefinition> = {
   /** The message definition including the payload schema */
   message: TMessage;
+  /**
+   * Declares that this publisher's consumers live outside this contract —
+   * a separate service or deployment owns the binding.
+   *
+   * Routability cannot be verified for such a publisher, so the define-time
+   * check is skipped. This is deliberately explicit: a heuristic ("no
+   * bindings at all means external") would silently miss the mistyped-key
+   * case the check exists to catch.
+   */
+  externalConsumers?: boolean | undefined;
 } & (
   | {
       /** Direct or topic exchange requiring a routing key */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,7 +76,7 @@ catalogs:
       specifier: 2.2.3
       version: 2.2.3
     fast-check:
-      specifier: ^4.3.0
+      specifier: 4.9.0
       version: 4.9.0
     knip:
       specifier: 6.27.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ catalogs:
     arktype:
       specifier: 2.2.3
       version: 2.2.3
+    fast-check:
+      specifier: ^4.3.0
+      version: 4.9.0
     knip:
       specifier: 6.27.0
       version: 6.27.0
@@ -507,6 +510,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.10(vitest@4.1.10)
+      fast-check:
+        specifier: 'catalog:'
+        version: 4.9.0
       publint:
         specifier: 'catalog:'
         version: 0.3.21
@@ -3767,6 +3773,10 @@ packages:
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
+  fast-check@4.9.0:
+    resolution: {integrity: sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==}
+    engines: {node: '>=12.17.0'}
+
   fast-copy@4.0.3:
     resolution: {integrity: sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==}
 
@@ -4745,6 +4755,9 @@ packages:
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
+
+  pure-rand@8.4.2:
+    resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
@@ -8599,6 +8612,10 @@ snapshots:
 
   extendable-error@0.1.7: {}
 
+  fast-check@4.9.0:
+    dependencies:
+      pure-rand: 8.4.2
+
   fast-copy@4.0.3: {}
 
   fast-deep-equal@3.1.3: {}
@@ -9634,6 +9651,8 @@ snapshots:
       once: 1.4.0
 
   punycode.js@2.3.1: {}
+
+  pure-rand@8.4.2: {}
 
   quansync@0.2.11: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,6 +35,7 @@ catalog:
   amqp-connection-manager: 5.0.0
   amqplib: 2.0.1
   arktype: 2.2.3
+  fast-check: ^4.3.0
   knip: 6.27.0
   lefthook: 2.1.10
   mermaid: 11.16.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,7 +35,7 @@ catalog:
   amqp-connection-manager: 5.0.0
   amqplib: 2.0.1
   arktype: 2.2.3
-  fast-check: ^4.3.0
+  fast-check: 4.9.0
   knip: 6.27.0
   lefthook: 2.1.10
   mermaid: 11.16.0

--- a/tests/src/unroutable-publish.spec.ts
+++ b/tests/src/unroutable-publish.spec.ts
@@ -1,0 +1,95 @@
+import { TypedAmqpClient } from "@amqp-contract/client";
+import {
+  defineContract,
+  defineExchange,
+  defineMessage,
+  definePublisher,
+} from "@amqp-contract/contract";
+import { it } from "@amqp-contract/testing/extension";
+import { describe, expect } from "vitest";
+import { z } from "zod";
+
+/**
+ * H1, proven end to end against a real broker.
+ *
+ * Test 1 demonstrates the hazard is genuine: an unroutable publish is
+ * confirmed by RabbitMQ and the message is gone. Test 2 demonstrates the
+ * define-time guard catches the same contract before it can run.
+ *
+ * The first test is the reason the second exists; if anyone ever weakens
+ * the guard, the pair reads as a complete argument for putting it back.
+ */
+describe("unroutable publish", () => {
+  const message = defineMessage(z.object({ orderId: z.string() }));
+
+  it("INVARIANT: an unroutable publish is confirmed by the broker and the message is lost", async ({
+    amqpChannel,
+    amqpConnectionUrl,
+  }) => {
+    // GIVEN a topic exchange whose only queue is bound with a pattern that
+    // cannot match the publisher's routing key.
+    const exchangeName = "orders";
+    const queueName = "audit";
+    await amqpChannel.assertExchange(exchangeName, "topic", { durable: false });
+    await amqpChannel.assertQueue(queueName, { durable: false });
+    await amqpChannel.bindQueue(queueName, exchangeName, "user.#");
+
+    const orders = defineExchange(exchangeName, { type: "topic", durable: false });
+    // Both publishers deliberately bypass the define-time guard: the binding
+    // above lives on the broker, not in the contract, so the raw broker
+    // behavior is what is under test here.
+    const orderCreated = definePublisher(orders, message, {
+      routingKey: "order.created",
+      externalConsumers: true,
+    });
+    // A sentinel on a key the binding DOES match. Published second on the same
+    // channel, so its arrival proves the broker finished routing the first
+    // message — the "we checked the queue too early" explanation is ruled out
+    // without a sleep.
+    const sentinel = definePublisher(orders, message, {
+      routingKey: "user.created",
+      externalConsumers: true,
+    });
+    const contract = defineContract({ publishers: { orderCreated, sentinel } });
+
+    const client = await TypedAmqpClient.create({
+      contract,
+      urls: [amqpConnectionUrl],
+    }).get();
+
+    try {
+      // WHEN the unroutable message is published, and then the sentinel.
+      const lost = await client.publish("orderCreated", { orderId: "lost" });
+      const delivered = await client.publish("sentinel", { orderId: "sentinel" });
+
+      // THEN the broker confirms BOTH — publish reports success either way.
+      expect(lost.isOk()).toBe(true);
+      expect(delivered.isOk()).toBe(true);
+
+      // ...and only the sentinel reached the queue. The unroutable message was
+      // acknowledged and discarded: at the API surface, loss is
+      // indistinguishable from success.
+      const stats = await amqpChannel.checkQueue(queueName);
+      expect(stats.messageCount).toBe(1);
+
+      const received = await amqpChannel.get(queueName, { noAck: true });
+      expect(received).not.toBe(false);
+      // `get` returns `false` when the queue is empty; the assertion above has
+      // already failed the test in that case.
+      const body = received === false ? undefined : JSON.parse(received.content.toString());
+      expect(body).toEqual({ orderId: "sentinel" });
+
+      // Nothing else is queued anywhere — the order message is simply gone.
+      expect(await amqpChannel.get(queueName, { noAck: true })).toBe(false);
+    } finally {
+      await client.close().get();
+    }
+  });
+
+  it("INVARIANT: the same contract is rejected at define time", () => {
+    const orders = defineExchange("orders-guarded", { type: "topic", durable: false });
+    const orderCreated = definePublisher(orders, message, { routingKey: "order.created" });
+
+    expect(() => defineContract({ publishers: { orderCreated } })).toThrow(/unroutable/i);
+  });
+});


### PR DESCRIPTION
# Description

Closes a silent total-message-loss path: `defineContract` now throws when a publisher's routing key can reach no queue.

RabbitMQ publisher confirms mean *"the broker took responsibility"*, not *"a queue received it"*. A message routed to zero queues is confirmed and then discarded — so a mistyped binding pattern, or a consumer deployed without its topology, loses **every** message while the publishing code observes `Ok`. No error, no log, no metric.

This library can catch that at define time because the contract knows the whole topology — a generic AMQP client structurally cannot.

## The hazard, proven not asserted

`tests/src/unroutable-publish.spec.ts` publishes to an unbound routing key against a real broker and shows `publish()` returning `Ok` while the message is absent, then shows the guard rejecting the same contract. The test was falsified during development — widening the binding to `#` flipped the queue count 1→2 and failed it — so it cannot pass vacuously.

## It found real bugs

Of 20 publisher sites the new check flagged, **9 were genuinely unroutable** — publisher/consumer pairs meant to talk to each other with no binding between them. Three AsyncAPI snapshots changed from `"AMQP Queue: order-processing"` to `"… (bound to exchange 'orders' with routing key 'order.created')"`: the generator had been documenting unbound queues. The other 11 are legitimate publish-only fixtures, now explicitly marked.

## What's included

- **Runtime topic matcher** (`*` / `#` with backtracking) + property tests
- **Routability resolver** — walks queue bindings *and* exchange-to-exchange forwards with a cycle guard, so bridged publishers resolve correctly; treats `alternate-exchange` as routable
- **Define-time throw** naming the failing *hop*, not just the publisher: *"The key matches on `orders` and is forwarded on to `billing`, but no queue binding downstream accepts it"*
- **`externalConsumers: true`** escape hatch for publish-only services, honored across all five publisher-producing builders
- **`RoutableRoutingKey`** exported for manual compile-time validation
- **rung-3 spike findings** — a committed decision document on runtime `basic.return` detection

## Two things to know

**Compile-time checking does not yet bite.** `RoutableRoutingKey` works, but wiring it into `defineContract` would be a provable no-op: `QueueBindingDefinition.routingKey` is plain `string`, so binding patterns widen before the check sees them. Making it bite needs literal generics threaded through five exported types — breaking and false-positive-prone. The runtime throw carries the safety; the changeset says this plainly.

**Breaking change.** A contract with an unroutable publisher now fails at `defineContract`. The remedy is to add the missing binding, or set `externalConsumers: true` when another service owns it. Documented in `docs/how-to/troubleshoot.md`.

## Checklist

- [x] Tests added/updated for new functionality
- [x] `pnpm test` passes — 12/12 packages; contract package 257 tests
- [x] `pnpm typecheck` passes — 17/17
- [x] **Changeset added** — major, plus a minor for the additive type
- [x] Commit messages follow Conventional Commits

Integration suites verified locally against a real broker (`rabbitmq:4.2.1-management-alpine`), all four:
`core` 33 · `client` 14 · `worker` 33 · `tests` 39.

> **Note on one late fix.** The initial push failed CI on `client#test:integration`. The fixture sweep had missed the
> integration vitest project entirely — root `pnpm test` runs only `--project unit`, and Docker was unavailable when the
> sweep ran. Ten contracts in `packages/client/src/__tests__/client.spec.ts` bind their queues via the `initConsumer`
> test fixture, i.e. at the broker, outside the contract; all ten are now marked `externalConsumers: true`, which is that
> option's intended meaning rather than a workaround. Every `defineContract(` call site in the repo has since been
> confirmed reachable by a command that actually executes it.

Design: `docs/superpowers/specs/2026-08-01-robustness-hardening-design.md` · Plan: `docs/superpowers/plans/2026-08-01-h1-unroutable-publish.md`

