### PR TITLE
fix: stop rejecting binding patterns that match at runtime

### DIFF
--- a/.changeset/binding-pattern-literal-guard.md
+++ b/.changeset/binding-pattern-literal-guard.md
@@ -14,6 +14,16 @@ The three matcher types — `MatchingBindingPattern`, `MatchingRoutingKey`, and
 `RoutableRoutingKey` — now share one test for whether a string is fully known at
 compile time, and skip the match when it is not. `MatchingRoutingKey` also loses
 an asymmetry where a plain-`string` pattern collapsed to `never` while a
-plain-`string` key did not. Undecidable cases defer to the define-time
-routability check in `defineContract`, which runs on concrete strings; patterns
-that genuinely cannot match are still rejected exactly as before.
+plain-`string` key did not.
+
+A pattern fully known at compile time and unable to match is still rejected
+exactly as before. The guard gives up a narrower class in exchange: a pattern
+with a hole and a literal tail, such as `` `user.${string}` `` against
+`order.created`, could in principle be shown unmatchable and is now accepted.
+That trade is deliberate — rejecting a valid contract is the costlier error.
+
+The define-time routability check in `defineContract` covers the publisher
+side — it fails a contract whose publisher reaches no queue. It does not cover
+`MatchingBindingPattern` or `MatchingRoutingKey`'s undecidable cases: a
+consumer binding that receives nothing while a sibling binding keeps the
+publisher routable gets no compile-time and no define-time signal.

--- a/.changeset/binding-pattern-literal-guard.md
+++ b/.changeset/binding-pattern-literal-guard.md
@@ -16,11 +16,19 @@ compile time, and skip the match when it is not. `MatchingRoutingKey` also loses
 an asymmetry where a plain-`string` pattern collapsed to `never` while a
 plain-`string` key did not.
 
-A pattern fully known at compile time and unable to match is still rejected
-exactly as before. The guard gives up a narrower class in exchange: a pattern
-with a hole and a literal tail, such as `` `user.${string}` `` against
-`order.created`, could in principle be shown unmatchable and is now accepted.
-That trade is deliberate — rejecting a valid contract is the costlier error.
+Rejection is unchanged only when both the pattern and the publisher routing
+key are fully known at compile time. When either side is not — a hole
+anywhere in the type, a union containing one, or a type carrying extra
+structure such as a brand — the check is skipped, even when the known side
+alone already proves no match is possible. ``MatchingBindingPattern<"user.x",
+`${string}.created`>`` is one such case: `"user.x"` can never equal any
+string ending in `.created`, and this used to fail the build; it is accepted
+now, unchecked, because the key side is not fully known. The same happens
+when the pattern side is the undecidable one — a pattern with a hole and a
+literal tail, such as `` `${string}.updated` ``, or a pattern narrowed by an
+intersection such as `"user.*" & {__b: "x"}`, is accepted against a fully
+known key for the same reason. That trade is deliberate — rejecting a valid
+contract is the costlier error.
 
 The define-time routability check in `defineContract` covers the publisher
 side — it fails a contract whose publisher reaches no queue. It does not cover

--- a/.changeset/binding-pattern-literal-guard.md
+++ b/.changeset/binding-pattern-literal-guard.md
@@ -1,0 +1,19 @@
+---
+"@amqp-contract/contract": patch
+---
+
+Fixed `defineEventConsumer` rejecting a routing-key override typed as a template
+literal. A pattern such as `` `${string}.created` `` matches `order.created` at
+runtime, but `MatchingBindingPattern` treated any type that was not plain
+`string` as decidable, could not decide it, and failed the build with
+"binding pattern '${string}.created' can never match the publisher routing key
+'order.created'". Tenant- and environment-prefixed routing keys are the common
+way to hit this.
+
+The three matcher types — `MatchingBindingPattern`, `MatchingRoutingKey`, and
+`RoutableRoutingKey` — now share one test for whether a string is fully known at
+compile time, and skip the match when it is not. `MatchingRoutingKey` also loses
+an asymmetry where a plain-`string` pattern collapsed to `never` while a
+plain-`string` key did not. Undecidable cases defer to the define-time
+routability check in `defineContract`, which runs on concrete strings; patterns
+that genuinely cannot match are still rejected exactly as before.

--- a/.changeset/routable-routing-key-type.md
+++ b/.changeset/routable-routing-key-type.md
@@ -11,6 +11,7 @@ compile time. Plain `string`, template-literal types such as
 `` `order.${string}` ``, unions containing either, and an empty pattern union
 all skip the check and resolve to `Key` — an undecidable case defers to the
 define-time check rather than being guessed at.
+
 The type is exported for direct use; `defineContract`'s signature is
 deliberately not constrained by it (binding patterns are widened to `string` by
 the time they reach `defineContract`, so the constraint would be a no-op). The

--- a/.changeset/routable-routing-key-type.md
+++ b/.changeset/routable-routing-key-type.md
@@ -6,11 +6,11 @@ Add the `RoutableRoutingKey<Key, Patterns>` type. It resolves to `Key` when the
 routing key matches at least one of the declared binding patterns and to a
 readable `` `Error: routing key '…' matches none of the declared binding
 patterns; …` `` string type otherwise — the same convention as
-`MatchingBindingPattern`. The check runs only when both the key and the patterns are fully known at
-compile time. Plain `string`, template-literal types such as
-`` `order.${string}` ``, unions containing either, and an empty pattern union
-all skip the check and resolve to `Key` — an undecidable case defers to the
-define-time check rather than being guessed at.
+`MatchingBindingPattern`. The check runs only when both the key and the
+patterns are fully known at compile time. Plain `string`, template-literal
+types such as `` `order.${string}` ``, unions containing either, and an empty
+pattern union all skip the check and resolve to `Key` — an undecidable case
+defers to the define-time check rather than being guessed at.
 
 The type is exported for direct use; `defineContract`'s signature is
 deliberately not constrained by it (binding patterns are widened to `string` by

--- a/.changeset/routable-routing-key-type.md
+++ b/.changeset/routable-routing-key-type.md
@@ -6,14 +6,11 @@ Add the `RoutableRoutingKey<Key, Patterns>` type. It resolves to `Key` when the
 routing key matches at least one of the declared binding patterns and to a
 readable `` `Error: routing key '…' matches none of the declared binding
 patterns; …` `` string type otherwise — the same convention as
-`MatchingBindingPattern`. Non-literal inputs and an empty pattern union skip the
-check and resolve to `Key`.
-
-Matching is over literal segments only: a pattern built from a template literal
-(`` `order.${string}` ``) is not recognised as matching, so a key it would
-accept at runtime still resolves to the error string. Use concrete literal
-patterns, or leave the key unconstrained and rely on the define-time check.
-
+`MatchingBindingPattern`. The check runs only when both the key and the patterns are fully known at
+compile time. Plain `string`, template-literal types such as
+`` `order.${string}` ``, unions containing either, and an empty pattern union
+all skip the check and resolve to `Key` — an undecidable case defers to the
+define-time check rather than being guessed at.
 The type is exported for direct use; `defineContract`'s signature is
 deliberately not constrained by it (binding patterns are widened to `string` by
 the time they reach `defineContract`, so the constraint would be a no-op). The

--- a/docs/how-to/define-a-contract.md
+++ b/docs/how-to/define-a-contract.md
@@ -268,7 +268,7 @@ type NoMatch = MatchingRoutingKey<"order.*", "user.created">; // never
 
 Keys are dot-separated segments of alphanumerics, hyphens and underscores. The `defineEvent*` and `defineCommand*` functions apply these internally; use them directly when writing your own routing helpers.
 
-The examples above use fully literal types, where `MatchingRoutingKey` can decide the match. When either side is not fully known at compile time — plain `string`, a template-literal type such as `` `${string}.created` ``, or a union containing either — the check is skipped and the key is returned unchecked rather than guessed at.
+The examples above use fully literal types, where `MatchingRoutingKey` can decide the match. When either side is not a fully resolved string literal — a plain `string`, a template-literal type such as `` `${string}.created` ``, a union containing either, or a branded string type, among others — the check is skipped and the key is returned unchecked rather than guessed at.
 
 TypeScript's recursion limit means very long keys fall back to `string`. That affects compile-time checking only, never runtime behaviour.
 

--- a/docs/how-to/define-a-contract.md
+++ b/docs/how-to/define-a-contract.md
@@ -268,7 +268,7 @@ type NoMatch = MatchingRoutingKey<"order.*", "user.created">; // never
 
 Keys are dot-separated segments of alphanumerics, hyphens and underscores. The `defineEvent*` and `defineCommand*` functions apply these internally; use them directly when writing your own routing helpers.
 
-The examples above use fully literal types, where `MatchingRoutingKey` can decide the match. When either side is not a fully resolved string literal — a plain `string`, a template-literal type such as `` `${string}.created` ``, a union containing either, or a branded string type, among others — the check is skipped and the key is returned unchecked rather than guessed at.
+The examples above use fully literal types, where `MatchingRoutingKey` can decide the match. Each side's own validity — `RoutingKey<K>` and `BindingPattern<P>` — is enforced no matter what the other side looks like, since that's decidable from one side alone. Only the _match between_ a valid pattern and a valid key is skipped when either side is not a fully resolved string literal — a plain `string`, a template-literal type such as `` `${string}.created` ``, a union containing either, or a branded string type, among others — in which case the key is returned unchecked rather than guessed at.
 
 TypeScript's recursion limit means very long keys fall back to `string`. That affects compile-time checking only, never runtime behaviour.
 

--- a/docs/how-to/define-a-contract.md
+++ b/docs/how-to/define-a-contract.md
@@ -268,6 +268,8 @@ type NoMatch = MatchingRoutingKey<"order.*", "user.created">; // never
 
 Keys are dot-separated segments of alphanumerics, hyphens and underscores. The `defineEvent*` and `defineCommand*` functions apply these internally; use them directly when writing your own routing helpers.
 
+The examples above use fully literal types, where `MatchingRoutingKey` can decide the match. When either side is not fully known at compile time — plain `string`, a template-literal type such as `` `${string}.created` ``, or a union containing either — the check is skipped and the key is returned unchecked rather than guessed at.
+
 TypeScript's recursion limit means very long keys fall back to `string`. That affects compile-time checking only, never runtime behaviour.
 
 ## Publish to a consumer you do not own

--- a/docs/reference/topology-options.md
+++ b/docs/reference/topology-options.md
@@ -306,7 +306,7 @@ import type { BindingPattern, MatchingRoutingKey, RoutingKey } from "@amqp-contr
 
 Keys are dot-separated segments of alphanumerics, hyphens and underscores. `*` matches one segment, `#` matches zero or more, and both are valid only in patterns.
 
-`MatchingRoutingKey` can only decide a match when both `P` and `K` are fully known at compile time — a plain `string`, a template-literal type, or a union containing either skips the check and resolves to `K` unchecked rather than guessing.
+`MatchingRoutingKey` can only decide a match when both `P` and `K` are fully resolved string literals at compile time — a plain `string`, a template-literal type, a union containing either, or a branded string type, among others, skips the check and resolves to `K` unchecked rather than guessing.
 
 TypeScript's recursion limit means very long keys fall back to `string`. Compile-time checking only; runtime behaviour is unaffected.
 

--- a/docs/reference/topology-options.md
+++ b/docs/reference/topology-options.md
@@ -298,13 +298,15 @@ The `middleware` array form composes at runtime like `composeMiddleware(…)` (f
 import type { BindingPattern, MatchingRoutingKey, RoutingKey } from "@amqp-contract/contract";
 ```
 
-| Type                       | Purpose                                    |
-| -------------------------- | ------------------------------------------ |
-| `RoutingKey<K>`            | `K` if it is a valid key, else `never`     |
-| `BindingPattern<P>`        | `P` if it is a valid pattern, else `never` |
-| `MatchingRoutingKey<P, K>` | `K` if it matches `P`, else `never`        |
+| Type                       | Purpose                                               |
+| -------------------------- | ----------------------------------------------------- |
+| `RoutingKey<K>`            | `K` if it is a valid key, else `never`                |
+| `BindingPattern<P>`        | `P` if it is a valid pattern, else `never`            |
+| `MatchingRoutingKey<P, K>` | `K` if it matches `P`, `never` if it provably doesn't |
 
 Keys are dot-separated segments of alphanumerics, hyphens and underscores. `*` matches one segment, `#` matches zero or more, and both are valid only in patterns.
+
+`MatchingRoutingKey` can only decide a match when both `P` and `K` are fully known at compile time — a plain `string`, a template-literal type, or a union containing either skips the check and resolves to `K` unchecked rather than guessing.
 
 TypeScript's recursion limit means very long keys fall back to `string`. Compile-time checking only; runtime behaviour is unaffected.
 

--- a/docs/reference/topology-options.md
+++ b/docs/reference/topology-options.md
@@ -306,7 +306,7 @@ import type { BindingPattern, MatchingRoutingKey, RoutingKey } from "@amqp-contr
 
 Keys are dot-separated segments of alphanumerics, hyphens and underscores. `*` matches one segment, `#` matches zero or more, and both are valid only in patterns.
 
-`MatchingRoutingKey` can only decide a match when both `P` and `K` are fully resolved string literals at compile time — a plain `string`, a template-literal type, a union containing either, or a branded string type, among others, skips the check and resolves to `K` unchecked rather than guessing.
+`MatchingRoutingKey` always enforces each side's own validity — `RoutingKey<K>`, `BindingPattern<P>` — since that's decidable from one side alone, regardless of the other side's shape. It can only decide the _match_ between a valid pattern and a valid key when both `P` and `K` are fully resolved string literals at compile time; a plain `string`, a template-literal type, a union containing either, or a branded string type, among others, skips the match and resolves to `K` unchecked rather than guessing.
 
 TypeScript's recursion limit means very long keys fall back to `string`. Compile-time checking only; runtime behaviour is unaffected.
 

--- a/docs/superpowers/plans/2026-08-02-binding-pattern-type-correctness.md
+++ b/docs/superpowers/plans/2026-08-02-binding-pattern-type-correctness.md
@@ -1,0 +1,674 @@
+# Binding-Pattern Type Correctness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the library rejecting binding patterns that match at runtime, by deciding "is this knowable at compile time?" in one shared type instead of three drifting expressions of it.
+
+**Architecture:** Add one internal conditional type, `IsStringLiteral`, to `packages/contract/src/builder/routing-types.ts`. Replace the `string extends X` skip arms in `MatchingBindingPattern` and `RoutableRoutingKey` with it, and give `MatchingRoutingKey` the skip arms it never had. Nothing else changes: the matcher itself, the runtime matcher, and the define-time routability check are untouched.
+
+**Tech Stack:** TypeScript 5.x conditional types, Vitest type-testing (`*.test-d.ts`, run via `typecheck.enabled` in `packages/contract/vitest.config.ts`), Changesets.
+
+## Global Constraints
+
+- No `any` — use `unknown` and narrow (enforced by oxlint).
+- Type aliases over interfaces — `type Foo = {}`, not `interface Foo {}`.
+- `.js` extensions required in all imports (ESM).
+- The governing rule of this program: **a false negative is acceptable; rejecting a valid contract is not.** Every change here must move behavior in that direction, never the other.
+- `IsStringLiteral` must NOT be added to `packages/contract/src/builder/index.ts` or `packages/contract/src/index.ts`. It is internal; exporting it from the package entry would make it public API and require a `minor` changeset.
+- Do not weaken any existing assertion to make a change pass. If an existing `test-d` expectation now fails, that is a real regression — stop and report it, do not edit the expectation.
+- Conventional commits required (`feat`, `fix`, `docs`, `chore`, `test`, `refactor`).
+- Run `pnpm --filter @amqp-contract/contract typecheck` before claiming any task done; it is not in the pre-commit hook.
+
+**Commands used throughout:**
+
+- Type tests: `pnpm --filter @amqp-contract/contract test`
+- Typecheck: `pnpm --filter @amqp-contract/contract typecheck`
+- Integration-suite tests (Task 5 only): `pnpm --filter @amqp-contract/tests test`
+
+---
+
+## File Structure
+
+| File                                                        | Responsibility                                                                                        | Task    |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------- |
+| `packages/contract/src/builder/routing-types.ts`            | All three matcher types plus the new `IsStringLiteral` guard                                          | 1, 2, 3 |
+| `packages/contract/src/builder/is-string-literal.test-d.ts` | Direct type tests for the guard (new file)                                                            | 1       |
+| `packages/contract/src/builder.test-d.ts`                   | Type tests for `MatchingBindingPattern`, `MatchingRoutingKey`, and `defineEventConsumer` reachability | 2, 3    |
+| `packages/contract/src/routability.test-d.ts`               | Type tests for `RoutableRoutingKey`                                                                   | 3       |
+| `.changeset/routable-routing-key-type.md`                   | Pending changeset whose limitation paragraph becomes false                                            | 4       |
+| `.changeset/binding-pattern-literal-guard.md`               | New changeset for the fix (new file)                                                                  | 4       |
+| `tests/src/docs/rule-paths.spec.ts`                         | Asserts every backticked path in the agent rule docs resolves (new file)                              | 5       |
+
+---
+
+### Task 1: The `IsStringLiteral` guard
+
+Adds the shared decision procedure and proves it in isolation. No existing type changes behavior in this task — the guard is added and tested, nothing calls it yet. A reviewer can accept or reject this on its own.
+
+**Files:**
+
+- Modify: `packages/contract/src/builder/routing-types.ts` (add the type after `BindingPattern`, around line 52)
+- Create: `packages/contract/src/builder/is-string-literal.test-d.ts`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: `export type IsStringLiteral<S extends string>` from `packages/contract/src/builder/routing-types.ts`, resolving to `true` when every member of `S` is a fully-known string literal and `false` otherwise. Tasks 2 and 3 apply it.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/contract/src/builder/is-string-literal.test-d.ts`:
+
+```ts
+import { describe, expectTypeOf, it } from "vitest";
+
+import type { IsStringLiteral } from "./routing-types.js";
+
+/**
+ * The single decision procedure behind all three matcher types: can this
+ * string be reasoned about at compile time?
+ *
+ * Answering it wrong in the "yes" direction is the expensive failure — the
+ * matcher then runs on a type it cannot decide and reports a valid contract
+ * as an error. Every case below that resolves to `false` is a case the
+ * matchers must skip rather than guess at.
+ */
+describe("IsStringLiteral", () => {
+  it("decides fully-known literals", () => {
+    expectTypeOf<IsStringLiteral<"order.created">>().toEqualTypeOf<true>();
+    expectTypeOf<IsStringLiteral<"">>().toEqualTypeOf<true>();
+    expectTypeOf<IsStringLiteral<"order.*">>().toEqualTypeOf<true>();
+    expectTypeOf<IsStringLiteral<"a" | "b">>().toEqualTypeOf<true>();
+  });
+
+  it("skips plain string", () => {
+    expectTypeOf<IsStringLiteral<string>>().toEqualTypeOf<false>();
+  });
+
+  it("skips template literals, wherever the hole sits", () => {
+    expectTypeOf<IsStringLiteral<`order.${string}`>>().toEqualTypeOf<false>();
+    expectTypeOf<IsStringLiteral<`${string}.orders`>>().toEqualTypeOf<false>();
+    expectTypeOf<IsStringLiteral<`a.${string}.b`>>().toEqualTypeOf<false>();
+    expectTypeOf<IsStringLiteral<`${string}.orders.#`>>().toEqualTypeOf<false>();
+    expectTypeOf<IsStringLiteral<`v${number}`>>().toEqualTypeOf<false>();
+  });
+
+  it("skips a union in which any member is not a literal", () => {
+    // Without distribution this resolves to `true` and the templated member
+    // reaches the matcher, which is the exact defect being fixed.
+    expectTypeOf<IsStringLiteral<"a" | `b.${string}`>>().toEqualTypeOf<false>();
+  });
+
+  it("skips the empty union", () => {
+    // `never` is vacuously assignable everywhere; without an explicit arm it
+    // reports as a literal.
+    expectTypeOf<IsStringLiteral<never>>().toEqualTypeOf<false>();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @amqp-contract/contract test`
+
+Expected: FAIL — `Module '"./routing-types.js"' has no exported member 'IsStringLiteral'`.
+
+- [ ] **Step 3: Add the type**
+
+In `packages/contract/src/builder/routing-types.ts`, immediately after the `BindingPattern` type (the line `export type BindingPattern<S extends string> = S extends "" ? never : S;`), insert:
+
+```ts
+/**
+ * True when every member of `S` is a string literal fully known at compile
+ * time; false for `string`, for template-literal types with a `${…}` hole, for
+ * a union containing either, and for the empty union.
+ *
+ * The matcher types below can only decide a match when both sides are fully
+ * known. `string extends S` alone does not establish that: a partially literal
+ * type such as `` `${string}.orders` `` is not `string`, so it passes that test
+ * and then reaches a matcher that cannot decide it — which reports a pattern
+ * that matches at runtime as an error. Deciding it here, once, is what keeps
+ * the three matchers from drifting apart again.
+ *
+ * `Record<S, 1>` yields a concrete property for a literal key and a pattern
+ * index signature for a template-literal key. `{}` is assignable to the latter
+ * and not the former, which separates them in one step — no per-character
+ * recursion, so no instantiation-depth risk on long routing keys.
+ *
+ * @internal
+ */
+export type IsStringLiteral<S extends string> = string extends S
+  ? false
+  : [S] extends [never]
+    ? false
+    : (S extends string ? ({} extends Record<S, 1> ? false : true) : never) extends true
+      ? true
+      : false;
+```
+
+Note on the inner conditional: `S extends string ? … : never` is what makes it distribute over a union, so each member is tested separately. The results are then collected and compared against `true` — a union of `true | false` fails that comparison, which is the conservative answer. Do not "simplify" the distribution away.
+
+If oxlint rejects the bare `{}` type, replace `{} extends Record<S, 1>` with `Record<never, never> extends Record<S, 1>` — it is the same check — and note the substitution in the task report.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm --filter @amqp-contract/contract test`
+
+Expected: PASS — all five `IsStringLiteral` cases green.
+
+- [ ] **Step 5: Typecheck and lint**
+
+Run: `pnpm --filter @amqp-contract/contract typecheck && pnpm lint`
+
+Expected: both clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/contract/src/builder/routing-types.ts packages/contract/src/builder/is-string-literal.test-d.ts
+git commit -m "feat: add the IsStringLiteral compile-time decidability guard"
+```
+
+---
+
+### Task 2: Fix `MatchingBindingPattern` — the live defect
+
+This is the only type wired into a signature, so this is the task that fixes a user's broken build. It ends with a test that goes through `defineEventConsumer` itself, not just the type.
+
+**Files:**
+
+- Modify: `packages/contract/src/builder/routing-types.ts` (the `MatchingBindingPattern` type and its doc comment)
+- Modify: `packages/contract/src/builder.test-d.ts` (the `MatchingBindingPattern` describe block around line 159, and the `defineEventConsumer topic routing-key override enforcement` describe block around line 191)
+
+**Interfaces:**
+
+- Consumes: `IsStringLiteral<S extends string>` from `./routing-types.js` (same file — no import needed).
+- Produces: no new exports. `MatchingBindingPattern<Pattern, PublisherKey>` keeps its signature and now resolves to `BindingPattern<Pattern>` whenever either side is non-literal.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `packages/contract/src/builder.test-d.ts`, inside the existing `describe("MatchingBindingPattern (topic consumer override enforcement)", …)` block, add this test immediately after the existing test named `"skips the check for non-literal strings"`. Leave that existing test exactly as it is — do not edit or replace it.
+
+```ts
+test("skips the check for template-literal patterns", () => {
+  // These all match at runtime. Deciding them at compile time is not
+  // possible, so the check must defer to `defineContract` rather than
+  // guess — guessing here rejected a valid contract.
+  expectTypeOf<
+    MatchingBindingPattern<`${string}.created`, "order.created">
+  >().toEqualTypeOf<`${string}.created`>();
+  expectTypeOf<
+    MatchingBindingPattern<`order.${string}`, "order.created">
+  >().toEqualTypeOf<`order.${string}`>();
+  expectTypeOf<
+    MatchingBindingPattern<`${string}.orders.#`, "acme.orders.created">
+  >().toEqualTypeOf<`${string}.orders.#`>();
+  expectTypeOf<MatchingBindingPattern<"order.#", `order.${string}`>>().toEqualTypeOf<"order.#">();
+  // A union with one undecidable member is undecidable as a whole.
+  expectTypeOf<MatchingBindingPattern<"order.*" | `x.${string}`, "order.created">>().toEqualTypeOf<
+    "order.*" | `x.${string}`
+  >();
+});
+```
+
+Then, inside the existing `describe("defineEventConsumer topic routing-key override enforcement", …)` block, add this test after the existing `"accepts patterns that can match the publisher routing key"` test:
+
+```ts
+test("accepts a template-literal pattern through the public API", () => {
+  // The defect this suite exists to prevent, reproduced end-to-end: a
+  // tenant-prefixed pattern matches 'order.created' at runtime, and the
+  // library used to fail the build with
+  //   "binding pattern '${string}.created' can never match the publisher
+  //    routing key 'order.created'".
+  const tenantPattern = "acme.created" as `${string}.created`;
+  defineEventConsumer(orderCreated, allOrdersQueue, { routingKey: tenantPattern });
+
+  const suffixPattern = "order.created" as `order.${string}`;
+  defineEventConsumer(orderCreated, allOrdersQueue, { routingKey: suffixPattern });
+
+  defineEventConsumer(orderCreated, allOrdersQueue, {
+    bridgeExchange,
+    routingKey: tenantPattern,
+  });
+});
+```
+
+Leave every other test in both blocks exactly as it is. In particular the `"rejects patterns that can never match the publisher routing key"` test and its five `@ts-expect-error` comments must remain untouched — they are what proves this fix has not turned the guard into a blanket skip. If any `@ts-expect-error` there starts reporting "unused", that is a regression: stop and report it.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @amqp-contract/contract test`
+
+Expected: FAIL. The `MatchingBindingPattern<...>` template-literal assertions resolve to `` `Error: binding pattern '…' can never match the publisher routing key '…'` `` instead of the pattern, and the `defineEventConsumer` calls report "No overload matches this call" with that same error string as the expected type.
+
+- [ ] **Step 3: Apply the guard**
+
+In `packages/contract/src/builder/routing-types.ts`, change the head of `MatchingBindingPattern` from:
+
+```ts
+> = string extends Pattern
+  ? BindingPattern<Pattern>
+  : string extends PublisherKey
+    ? BindingPattern<Pattern>
+    : [BindingPattern<Pattern>] extends [never]
+```
+
+to:
+
+```ts
+> = IsStringLiteral<Pattern> extends false
+  ? BindingPattern<Pattern>
+  : IsStringLiteral<PublisherKey> extends false
+    ? BindingPattern<Pattern>
+    : [BindingPattern<Pattern>] extends [never]
+```
+
+Everything below that line is unchanged — the empty-pattern rejection, the match, and the error-string branch all stay exactly as they are. `""` is a literal, so it still reaches the `[BindingPattern<Pattern>] extends [never]` arm and is still rejected.
+
+- [ ] **Step 4: Fix the doc comment**
+
+In the same file, in the JSDoc block above `MatchingBindingPattern`, replace this paragraph:
+
+```
+ * Non-literal strings (plain `string` on either side) skip the check — the
+ * match cannot be decided at compile time, so runtime behavior is preserved.
+```
+
+with:
+
+```
+ * The check runs only when both sides are fully known at compile time. Plain
+ * `string`, a template-literal type with a `${…}` hole (`` `${string}.created` ``),
+ * and any union containing either are skipped: the match cannot be decided, and
+ * guessing would reject a pattern that matches at runtime. Those contracts are
+ * covered by the define-time routability check in `defineContract`, which runs
+ * on concrete strings.
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pnpm --filter @amqp-contract/contract test`
+
+Expected: PASS, including every pre-existing assertion in both describe blocks.
+
+- [ ] **Step 6: Typecheck and lint**
+
+Run: `pnpm --filter @amqp-contract/contract typecheck && pnpm lint`
+
+Expected: both clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/contract/src/builder/routing-types.ts packages/contract/src/builder.test-d.ts
+git commit -m "fix: stop rejecting template-literal binding patterns that match at runtime"
+```
+
+---
+
+### Task 3: Apply the guard to `RoutableRoutingKey` and `MatchingRoutingKey`
+
+Neither type is wired into a signature, so neither can break a build today — but both are exported for users to apply to their own helpers, where the same wrong answer surfaces as `never` or as an error string. Fixing them is what makes the rule live in one place.
+
+**Files:**
+
+- Modify: `packages/contract/src/builder/routing-types.ts` (the `RoutableRoutingKey` and `MatchingRoutingKey` types, and `MatchingRoutingKey`'s doc comment)
+- Modify: `packages/contract/src/routability.test-d.ts` (the `RoutableRoutingKey` describe block)
+- Modify: `packages/contract/src/builder.test-d.ts` (the `MatchingRoutingKey pattern matching` describe block around line 87)
+
+**Interfaces:**
+
+- Consumes: `IsStringLiteral<S extends string>` from `./routing-types.js` (same file — no import needed).
+- Produces: no new exports. Both types keep their signatures.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `packages/contract/src/routability.test-d.ts`, add this test inside the existing `describe("RoutableRoutingKey", …)` block:
+
+```ts
+it("skips the check when either side is not a compile-time literal", () => {
+  expectTypeOf<
+    RoutableRoutingKey<`order.${string}`, "order.#">
+  >().toEqualTypeOf<`order.${string}`>();
+  expectTypeOf<
+    RoutableRoutingKey<"order.created", `order.${string}`>
+  >().toEqualTypeOf<"order.created">();
+  expectTypeOf<
+    RoutableRoutingKey<"order.created", "order.#" | `x.${string}`>
+  >().toEqualTypeOf<"order.created">();
+});
+```
+
+In `packages/contract/src/builder.test-d.ts`, add this test inside the existing `describe("MatchingRoutingKey pattern matching", …)` block:
+
+```ts
+test("skips the check when either side is not a compile-time literal", () => {
+  // Previously asymmetric: a plain-`string` pattern collapsed to `never`
+  // while a plain-`string` key did not. Both now skip.
+  expectTypeOf<MatchingRoutingKey<string, "order.created">>().toEqualTypeOf<"order.created">();
+  expectTypeOf<MatchingRoutingKey<"order.#", string>>().toEqualTypeOf<string>();
+  expectTypeOf<
+    MatchingRoutingKey<`order.${string}`, "order.created">
+  >().toEqualTypeOf<"order.created">();
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @amqp-contract/contract test`
+
+Expected: FAIL — the `RoutableRoutingKey` cases resolve to the `` `Error: routing key '…' matches none of the declared binding patterns; …` `` string, and the `MatchingRoutingKey<string, "order.created">` and ``MatchingRoutingKey<`order.${string}`, "order.created">`` cases resolve to `never`.
+
+Note: `MatchingRoutingKey<"order.#", string>` may already pass before the change — the type is asymmetric today. Do not treat that single passing assertion as a reason to skip the task.
+
+- [ ] **Step 3: Apply the guard to `RoutableRoutingKey`**
+
+In `packages/contract/src/builder/routing-types.ts`, change the head of `RoutableRoutingKey` from:
+
+```ts
+export type RoutableRoutingKey<Key extends string, Patterns extends string> = string extends Key
+  ? Key
+  : string extends Patterns
+    ? Key
+    : [Patterns] extends [never]
+```
+
+to:
+
+```ts
+export type RoutableRoutingKey<Key extends string, Patterns extends string> =
+  IsStringLiteral<Key> extends false
+    ? Key
+    : IsStringLiteral<Patterns> extends false
+      ? Key
+      : [Patterns] extends [never]
+```
+
+The `[Patterns] extends [never]` arm becomes unreachable — `IsStringLiteral<never>` is `false`, so the empty union is already returned by the arm above it. Keep the arm anyway: it documents the intent locally and costs nothing. Do not add a comment claiming it is reachable.
+
+Its doc comment already says "non-literal" and needs no change.
+
+- [ ] **Step 4: Apply the guard to `MatchingRoutingKey`**
+
+In the same file, change `MatchingRoutingKey` from:
+
+```ts
+export type MatchingRoutingKey<Pattern extends string, Key extends string> =
+  RoutingKey<Key> extends never
+    ? never // Invalid routing key
+    : BindingPattern<Pattern> extends never
+      ? never // Invalid pattern
+      : MatchesPattern<Key, Pattern> extends true
+        ? Key
+        : never;
+```
+
+to:
+
+```ts
+export type MatchingRoutingKey<Pattern extends string, Key extends string> =
+  IsStringLiteral<Pattern> extends false
+    ? Key // Undecidable at compile time — defer rather than guess
+    : IsStringLiteral<Key> extends false
+      ? Key
+      : RoutingKey<Key> extends never
+        ? never // Invalid routing key
+        : BindingPattern<Pattern> extends never
+          ? never // Invalid pattern
+          : MatchesPattern<Key, Pattern> extends true
+            ? Key
+            : never;
+```
+
+- [ ] **Step 5: Document the new behavior on `MatchingRoutingKey`**
+
+In its JSDoc block, immediately after the line `* Returns the routing key if it's valid and matches the pattern, `never` otherwise.`, add:
+
+```
+ *
+ * The check runs only when both the pattern and the key are fully known at
+ * compile time. Plain `string`, template-literal types, and unions containing
+ * either resolve to `Key` unchecked — the match cannot be decided, and
+ * guessing would reject a key that routes at runtime.
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `pnpm --filter @amqp-contract/contract test`
+
+Expected: PASS. Every pre-existing assertion in both files must still pass — in particular `routability.test-d.ts`'s mismatch cases (`RoutableRoutingKey<"user.created", "order.#">` and friends) and `builder.test-d.ts`'s `MatchingRoutingKey<"order.*", "user.created">` collapsing to `never`. Those prove the guard has not become a blanket skip.
+
+- [ ] **Step 7: Typecheck and lint**
+
+Run: `pnpm --filter @amqp-contract/contract typecheck && pnpm lint`
+
+Expected: both clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/contract/src/builder/routing-types.ts packages/contract/src/routability.test-d.ts packages/contract/src/builder.test-d.ts
+git commit -m "fix: skip the routing-key match when either side is not a compile-time literal"
+```
+
+---
+
+### Task 4: Changesets
+
+The pending `RoutableRoutingKey` changeset documents the template-literal limitation as intended behavior. It is unreleased, so it must be corrected rather than shipped alongside a release that removes the limitation.
+
+**Files:**
+
+- Modify: `.changeset/routable-routing-key-type.md`
+- Create: `.changeset/binding-pattern-literal-guard.md`
+
+**Interfaces:**
+
+- Consumes: the behavior changes from Tasks 2 and 3.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Correct the pending changeset**
+
+In `.changeset/routable-routing-key-type.md`, delete this paragraph entirely:
+
+```
+Matching is over literal segments only: a pattern built from a template literal
+(`` `order.${string}` ``) is not recognised as matching, so a key it would
+accept at runtime still resolves to the error string. Use concrete literal
+patterns, or leave the key unconstrained and rely on the define-time check.
+```
+
+and replace the sentence
+
+```
+Non-literal inputs and an empty pattern union skip the
+check and resolve to `Key`.
+```
+
+with
+
+```
+The check runs only when both the key and the patterns are fully known at
+compile time. Plain `string`, template-literal types such as
+`` `order.${string}` ``, unions containing either, and an empty pattern union
+all skip the check and resolve to `Key` — an undecidable case defers to the
+define-time check rather than being guessed at.
+```
+
+Leave the final paragraph (about `defineContract` deliberately not being constrained) unchanged — it is still accurate.
+
+- [ ] **Step 2: Add the changeset for the fix**
+
+Create `.changeset/binding-pattern-literal-guard.md`:
+
+```markdown
+---
+"@amqp-contract/contract": patch
+---
+
+Fixed `defineEventConsumer` rejecting a routing-key override typed as a template
+literal. A pattern such as `` `${string}.created` `` matches `order.created` at
+runtime, but `MatchingBindingPattern` treated any type that was not plain
+`string` as decidable, could not decide it, and failed the build with
+"binding pattern '${string}.created' can never match the publisher routing key
+'order.created'". Tenant- and environment-prefixed routing keys are the common
+way to hit this.
+
+The three matcher types — `MatchingBindingPattern`, `MatchingRoutingKey`, and
+`RoutableRoutingKey` — now share one test for whether a string is fully known at
+compile time, and skip the match when it is not. `MatchingRoutingKey` also loses
+an asymmetry where a plain-`string` pattern collapsed to `never` while a
+plain-`string` key did not. Undecidable cases defer to the define-time
+routability check in `defineContract`, which runs on concrete strings; patterns
+that genuinely cannot match are still rejected exactly as before.
+```
+
+- [ ] **Step 3: Verify the changeset is picked up**
+
+Run: `git add -A && git commit -m "docs: changesets for the binding-pattern literal guard"`
+
+Then run: `pnpm changeset status --since=origin/main`
+
+Expected: it reports `@amqp-contract/contract` (and the rest of the fixed group) with pending changes, and exits 0. `changeset status` diffs committed state, so the commit must happen first — that is why the commit is part of this step rather than a separate one at the end.
+
+---
+
+### Task 5: Assert every backticked path in the agent rule docs resolves
+
+Separable from the rest of this plan — it touches no library code. The snippet-execution branch broke nine `AGENTS.md` path references while adding a tenth, under a line instructing the reader to extend the mapping, and nothing caught it for three tasks.
+
+Scope note: the design spec named `AGENTS.md`. This task covers `AGENTS.md` **and** `.agents/rules/*.md`, because it is the same loop over the same class of reference and the rule files carry more paths than the index does. Say so in the task report.
+
+**Files:**
+
+- Create: `tests/src/docs/rule-paths.spec.ts`
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Write the test**
+
+Create `tests/src/docs/rule-paths.spec.ts`:
+
+```ts
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * A path in the agent rules that no longer resolves is worse than no
+ * reference: it sends a reader looking for a guarantee that has moved.
+ *
+ * This is not hypothetical. The snippet-execution branch relocated eleven spec
+ * files and left nine `AGENTS.md` invariant references pointing at nothing —
+ * while the same edit added a tenth invariant, directly under a line telling
+ * the reader to extend the mapping. Three task reviews did not notice.
+ */
+
+const repoRoot = join(import.meta.dirname, "..", "..", "..");
+
+/** Backticked tokens that look like a repo path: contain a slash and end in a known extension. */
+const PATH_LIKE = /^[\w@./-]+\.(?:ts|tsx|js|mjs|cjs|md|json|ya?ml)(?::\d+)?$/;
+
+function pathsIn(markdown: string): readonly string[] {
+  return [...markdown.matchAll(/`([^`\n]+)`/g)]
+    .map((match) => match[1] ?? "")
+    .filter((token) => token.includes("/") && !token.includes("*"))
+    .filter((token) => PATH_LIKE.test(token))
+    .map((token) => token.replace(/:\d+$/, ""));
+}
+
+const sources: readonly string[] = [
+  "AGENTS.md",
+  ...readdirSync(join(repoRoot, ".agents", "rules"))
+    .filter((name) => name.endsWith(".md"))
+    .map((name) => join(".agents", "rules", name)),
+];
+
+describe("agent rule docs", () => {
+  // `CLAUDE.md` is a symlink to `AGENTS.md`; listing only `AGENTS.md` avoids
+  // asserting the same corpus twice.
+  it("has rule files to check", () => {
+    expect(sources.length).toBeGreaterThan(5);
+  });
+
+  for (const source of sources) {
+    const paths = pathsIn(readFileSync(join(repoRoot, source), "utf8"));
+
+    // Per-file rather than a total count: if the extraction regex ever breaks,
+    // every file yields zero and this fails immediately, with no number to
+    // keep bumped as the docs change. A total floor would stay green while one
+    // file silently stopped contributing.
+    it(`${source}: extracts path references`, () => {
+      expect(paths.length).toBeGreaterThan(0);
+    });
+
+    for (const path of paths) {
+      it(`${source}: ${path} resolves`, () => {
+        expect(
+          existsSync(join(repoRoot, path)),
+          `${source} references ${path}, which does not exist`,
+        ).toBe(true);
+      });
+    }
+  }
+});
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `pnpm --filter @amqp-contract/tests test`
+
+Expected: the `unit` project runs the new file. Every extracted path should resolve — the six dead `AGENTS.md` paths were fixed on the snippet branch. If any path fails, that is a real dead reference: fix the doc, do not loosen the regex.
+
+If the `has rule files to check` or an `extracts path references` case fails, the extraction is broken — fix the regex, do not delete the assertion.
+
+- [ ] **Step 3: Prove the test can fail**
+
+Temporarily append this line to `AGENTS.md`:
+
+```markdown
+See `packages/contract/src/builder/does-not-exist.ts` for details.
+```
+
+Run: `pnpm --filter @amqp-contract/tests test`
+
+Expected: FAIL, with `AGENTS.md references packages/contract/src/builder/does-not-exist.ts, which does not exist`.
+
+Then remove the line and re-run. Expected: PASS. Confirm with `git status --short` that `AGENTS.md` is unmodified before committing — a leaked scratch edit to the rules file is worse than the bug being fixed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/src/docs/rule-paths.spec.ts
+git commit -m "test: assert every backticked path in the agent rule docs resolves"
+```
+
+---
+
+## Final verification
+
+- [ ] **Step 1: Full build and test**
+
+Run from the repo root:
+
+```bash
+pnpm build && pnpm typecheck && pnpm test --concurrency=1 && pnpm lint && pnpm knip && pnpm exec oxfmt --check .
+```
+
+Expected: all green. `pnpm knip` matters here: `IsStringLiteral` is a new export consumed only by its own module and a `*.test-d.ts` file, which is exactly the shape knip flags as unused. If it does, do not delete the export — report it, and the fix is a knip config entry, not removing the guard's direct tests. `--concurrency=1` matters: several projects start their own testcontainer and a parallel run fails on Docker contention, which is a pre-existing environment issue and not a signal about this branch.
+
+- [ ] **Step 2: Confirm the public API surface did not change**
+
+Run: `grep -rn "IsStringLiteral" packages/contract/src/index.ts packages/contract/src/builder/index.ts packages/contract/src/builder.ts`
+
+Expected: no matches. `IsStringLiteral` is internal; if it appears in an entry point, remove the export — a public type addition would need a `minor` changeset, not the `patch` written in Task 4.
+
+- [ ] **Step 3: Confirm nothing weakened**
+
+Run: `git diff main -- packages/contract/src/builder.test-d.ts packages/contract/src/routability.test-d.ts | grep '^-' | grep -v '^---'`
+
+Expected: no output at all. Every change to these two files is an addition. If any line was removed, an assertion was weakened — stop and report it. In particular no `@ts-expect-error` and no `toEqualTypeOf<never>()` may appear.

--- a/docs/superpowers/plans/2026-08-02-binding-pattern-type-correctness.md
+++ b/docs/superpowers/plans/2026-08-02-binding-pattern-type-correctness.md
@@ -575,11 +575,25 @@ const repoRoot = join(import.meta.dirname, "..", "..", "..");
 /** Backticked tokens that look like a repo path: contain a slash and end in a known extension. */
 const PATH_LIKE = /^[\w@./-]+\.(?:ts|tsx|js|mjs|cjs|md|json|ya?ml)(?::\d+)?$/;
 
+/**
+ * Top-level entries of the repo. A citation is rooted at one of these; an
+ * illustrative path is not.
+ *
+ * Without this test, `` `path/to/file.ts` `` (a placeholder in a code-style
+ * example) and `` `src/index.ts` `` (package-relative, in "add this to your
+ * package" instructions) both read as dead references, and the suite fails on
+ * documentation that is perfectly correct. Deriving the set from the
+ * filesystem rather than hardcoding it means a new top-level directory needs
+ * no edit here.
+ */
+const repoRootEntries = new Set(readdirSync(repoRoot));
+
 function pathsIn(markdown: string): readonly string[] {
   return [...markdown.matchAll(/`([^`\n]+)`/g)]
     .map((match) => match[1] ?? "")
     .filter((token) => token.includes("/") && !token.includes("*"))
     .filter((token) => PATH_LIKE.test(token))
+    .filter((token) => repoRootEntries.has(token.split("/")[0] ?? ""))
     .map((token) => token.replace(/:\d+$/, ""));
 }
 
@@ -590,6 +604,11 @@ const sources: readonly string[] = [
     .map((name) => join(".agents", "rules", name)),
 ];
 
+const extracted = sources.map((source) => ({
+  source,
+  paths: pathsIn(readFileSync(join(repoRoot, source), "utf8")),
+}));
+
 describe("agent rule docs", () => {
   // `CLAUDE.md` is a symlink to `AGENTS.md`; listing only `AGENTS.md` avoids
   // asserting the same corpus twice.
@@ -597,17 +616,23 @@ describe("agent rule docs", () => {
     expect(sources.length).toBeGreaterThan(5);
   });
 
-  for (const source of sources) {
-    const paths = pathsIn(readFileSync(join(repoRoot, source), "utf8"));
+  // These two floors detect a broken extractor, nothing more. They sit far
+  // below the real counts on purpose, so ordinary doc edits never trip them
+  // and nobody is tempted to loosen them. They are deliberately NOT coverage
+  // pins: several rule files legitimately cite no repo-rooted paths at all
+  // (they link with Markdown syntax instead), so a per-file floor would fail
+  // on correct documentation.
+  it("extracts path references across the corpus", () => {
+    expect(extracted.reduce((total, entry) => total + entry.paths.length, 0)).toBeGreaterThan(20);
+  });
 
-    // Per-file rather than a total count: if the extraction regex ever breaks,
-    // every file yields zero and this fails immediately, with no number to
-    // keep bumped as the docs change. A total floor would stay green while one
-    // file silently stopped contributing.
-    it(`${source}: extracts path references`, () => {
-      expect(paths.length).toBeGreaterThan(0);
-    });
+  it("extracts path references from AGENTS.md", () => {
+    // The index cites every guarded invariant by file; it can never be empty.
+    const agents = extracted.find((entry) => entry.source === "AGENTS.md");
+    expect(agents?.paths.length ?? 0).toBeGreaterThan(10);
+  });
 
+  for (const { source, paths } of extracted) {
     for (const path of paths) {
       it(`${source}: ${path} resolves`, () => {
         expect(

--- a/docs/superpowers/plans/2026-08-02-binding-pattern-type-correctness.md
+++ b/docs/superpowers/plans/2026-08-02-binding-pattern-type-correctness.md
@@ -384,7 +384,9 @@ export type RoutableRoutingKey<Key extends string, Patterns extends string> =
       : [Patterns] extends [never]
 ```
 
-The `[Patterns] extends [never]` arm becomes unreachable — `IsStringLiteral<never>` is `false`, so the empty union is already returned by the arm above it. Keep the arm anyway: it documents the intent locally and costs nothing. Do not add a comment claiming it is reachable.
+Then delete the now-dead `[Patterns] extends [never] ? Key :` arm and its comment, so the type reads `… : IsStringLiteral<Patterns> extends false ? Key : MatchesAnyPattern<Key, Patterns> extends true ? Key : …`.
+
+That arm is unreachable once the guard is in place: `IsStringLiteral<never>` is `false`, so the empty union already returns `Key` one arm earlier. Behavior is identical — the existing assertion `RoutableRoutingKey<"order.created", never>` resolving to `"order.created"` must still pass, and it is what proves the deletion is safe. Leaving a dead arm in place to "document intent" is how a reader later concludes the guard does not cover `never`.
 
 Its doc comment already says "non-literal" and needs no change.
 

--- a/docs/superpowers/specs/2026-08-02-binding-pattern-type-correctness-design.md
+++ b/docs/superpowers/specs/2026-08-02-binding-pattern-type-correctness-design.md
@@ -1,0 +1,176 @@
+# Binding-Pattern Type Correctness — Design
+
+**Date:** 2026-08-02
+**Status:** approved
+
+## Problem
+
+`MatchingBindingPattern` guards the routing-key override on
+`defineEventConsumer`'s topic overloads
+(`packages/contract/src/builder/event.ts:448` and `:581`). On a pattern that
+cannot match the publisher's routing key it resolves to a readable error-message
+string type, so the binding fails to compile instead of silently receiving
+nothing at runtime.
+
+It rejects patterns that **do** match at runtime.
+
+The type skips its check when either side is non-literal — but it tests for that
+with `string extends Pattern`, which is true only for plain `string`. A
+_partially_ literal type such as `` `${string}.orders` `` is not plain `string`,
+so the check runs, `MatchesPattern` cannot decide it, and the type resolves to
+the error string. Reproduced through the public API:
+
+```
+Type '`${string}.orders`' is not assignable to type
+  '`Error: binding pattern '${string}.orders' can never match
+    the publisher routing key 'acme.orders'`'
+```
+
+`` `${string}.orders` `` matches `acme.orders` at runtime. The contract is valid
+and the library rejects it. This violates the governing rule of the robustness
+program: **a false negative is acceptable; rejecting a valid contract is not.**
+Template-literal routing keys are the natural encoding for a tenant or
+environment prefix, so this is reachable in ordinary use, not a curiosity.
+
+The type's own doc comment states the intended behavior correctly —
+"Non-literal strings (plain `string` on either side) skip the check" — while
+naming only the case the code actually handles. The comment and the defect are
+the same sentence.
+
+## Scope of the defect
+
+Three exported types perform this match. All three share the hole, and each
+mitigates it differently:
+
+| Type                     | Applied to                   | Plain `string`                                        | Template literal      |
+| ------------------------ | ---------------------------- | ----------------------------------------------------- | --------------------- |
+| `MatchingBindingPattern` | `defineEventConsumer` (live) | skipped                                               | **rejected**          |
+| `RoutableRoutingKey`     | nothing — opt-in utility     | skipped                                               | rejected (documented) |
+| `MatchingRoutingKey`     | nothing — opt-in utility     | rejected on the pattern side, skipped on the key side | rejected              |
+
+Only `MatchingBindingPattern` is wired into a signature, so only it can break a
+user's build today. The other two are exported utilities a user may apply to
+their own helpers, where the same wrong answer appears as `never`.
+
+`RoutableRoutingKey`'s limitation is documented in its pending changeset
+(`.changeset/routable-routing-key-type.md`) and was a deliberate trade at the
+time. That changeset is unreleased, so the text can be corrected rather than
+shipped.
+
+This is the program's second recurring pattern — _a rule expressed in more than
+one place drifts_ — with three expressions and three different drifts. The fix
+consolidates rather than patching each site.
+
+## Solution
+
+One internal type answers "can this be decided at compile time?", and all three
+matchers call it.
+
+```ts
+type IsStringLiteral<S extends string> = string extends S
+  ? false
+  : [S] extends [never]
+    ? false
+    : (S extends string ? ({} extends Record<S, 1> ? false : true) : never) extends true
+      ? true
+      : false;
+```
+
+`Record<S, 1>` produces a concrete property for a literal key and a _pattern
+index signature_ for a template-literal key. `{}` is assignable to the latter
+and not the former, which distinguishes them in one step — no per-character
+recursion, so no instantiation-depth risk.
+
+The conditional distributes over `S`, so every member of a union must itself be
+a literal. A mixed union such as `` "a" | `b.${string}` `` resolves to `false`
+and skips. Without distribution it resolves to `true` and the templated member
+produces the original false positive.
+
+`[S] extends [never]` guards the empty union: `never` is vacuously assignable
+everywhere, and without the guard it would report as literal.
+
+### Application
+
+In `MatchingBindingPattern` and `RoutableRoutingKey`, replace the two
+`string extends X ? …` skip arms with `IsStringLiteral<X> extends false ? …`.
+The rest of each type is unchanged — in particular
+`[BindingPattern<Pattern>] extends [never]` still rejects the empty pattern,
+since `""` is a literal and reaches that arm.
+
+`MatchingRoutingKey` has no skip arm at all; it gains the same two, returning
+`Key` when either side is undecidable. This also fixes its asymmetry, where a
+plain-`string` pattern collapsed to `never` but a plain-`string` key did not.
+
+### Consequence
+
+An undecidable pattern becomes a false negative: nothing is rejected at compile
+time, and the case falls through to the define-time routability check in
+`defineContract`, which runs on concrete strings with the whole binding graph in
+view. That check is unaffected by this change.
+
+## Verification performed during design
+
+`IsStringLiteral` was checked against 12 cases: `"order.created"`, `""`,
+`"order.*"` and literal unions decide; plain `string`,
+`` `order.${string}` ``, `` `${string}.orders` ``, `` `${string}.orders.#` ``,
+`` `a.${string}.b` ``, `` `v${number}` ``, mixed unions and `never` skip.
+
+The full fix was applied to a scratch copy of `routing-types.ts` and checked
+against 18 assertions: the three confirmed false positives are accepted, a
+fourth templated case that was already correct stays correct, and all ten
+existing `test-d` expectations still hold — including that genuine mismatches
+still produce their exact error strings, which is what proves the guard has not
+degraded into a blanket skip.
+
+These are design-time probes, not deliverables. The implementation must land
+them as committed `test-d` cases.
+
+## Documentation and release
+
+- Three doc comments say "plain `string`" where they mean "non-literal". That
+  phrasing is the defect written down; each becomes an accurate statement that
+  any type not fully known at compile time — including a template literal —
+  skips the check and defers to the define-time check.
+- `.changeset/routable-routing-key-type.md` contains a paragraph presenting the
+  template-literal limitation as intended behavior. It is unreleased; the
+  paragraph is removed and the surrounding text corrected.
+- A new patch changeset covers the fix, naming the user-visible effect: a
+  template-literal binding pattern no longer fails to compile.
+
+## Testing
+
+Type-level only. The runtime matcher (`builder/topic-match.ts`) always receives
+concrete strings, so it has no analogue of this case; `MATCH_CORPUS` and the
+invariant that the two implementations agree are untouched.
+
+New `test-d` cases in `builder.test-d.ts` and `routability.test-d.ts`:
+
+- the skip path on both sides of all three types, covering plain `string`,
+  template literals with the hole in leading, trailing and middle position, and
+  a mixed union;
+- the existing mismatch assertions retained, so a regression to a blanket skip
+  fails rather than passing quietly;
+- `MatchingRoutingKey`'s new skip arms, including the asymmetry that is being
+  removed.
+
+## Out of scope
+
+- **Rejecting a wildcard in a direct-exchange binding key at define time.**
+  Considered and rejected: binding a direct exchange with key `order.*` and
+  publishing the literal key `order.*` is legal AMQP and works. The guard would
+  reject a valid contract, which the governing rule forbids. The existing
+  routability check already catches the case where it actually loses messages.
+- **Duplicate delivery (H5).** Exactly-once delivery is not achievable over
+  AMQP; the ack can always be lost after the work is done. Exactly-once _effect_
+  requires an idempotent consumer keyed on application state, which needs a
+  transaction boundary shared with the user's database. That is out of this
+  library's scope. The eventual answer is documentation: state that delivery is
+  at-least-once, enumerate when redelivery happens, and show the
+  idempotency-key pattern as the consumer's responsibility.
+
+## Separable addition
+
+A test asserting that every backticked path in `AGENTS.md` resolves on disk.
+The snippet-execution branch broke nine such paths while adding a tenth, under a
+line instructing the reader to extend the mapping, and nothing caught it for
+three tasks. Unrelated to binding patterns and independently droppable.

--- a/docs/superpowers/specs/2026-08-02-binding-pattern-type-correctness-design.md
+++ b/docs/superpowers/specs/2026-08-02-binding-pattern-type-correctness-design.md
@@ -127,10 +127,16 @@ them as committed `test-d` cases.
 
 ## Documentation and release
 
-- Three doc comments say "plain `string`" where they mean "non-literal". That
-  phrasing is the defect written down; each becomes an accurate statement that
-  any type not fully known at compile time — including a template literal —
-  skips the check and defers to the define-time check.
+- `MatchingBindingPattern`'s doc comment says "Non-literal strings (plain
+  `string` on either side) skip the check". The parenthetical is the defect
+  written down — it narrows "non-literal" to the one case the code handled. It
+  becomes an accurate statement that any type not fully known at compile time,
+  including a template literal, skips the check and defers to the define-time
+  check.
+- `RoutableRoutingKey`'s doc comment already says "non-literal" and needs no
+  change; only its code disagreed with it.
+- `MatchingRoutingKey` documents no skip behavior at all. It gains a sentence
+  describing the new arms.
 - `.changeset/routable-routing-key-type.md` contains a paragraph presenting the
   template-literal limitation as intended behavior. It is unreleased; the
   paragraph is removed and the surrounding text corrected.

--- a/packages/contract/src/builder.test-d.ts
+++ b/packages/contract/src/builder.test-d.ts
@@ -164,6 +164,15 @@ describe("MatchingRoutingKey pattern matching", () => {
       MatchingRoutingKey<`order.${string}`, "order.created">
     >().toEqualTypeOf<"order.created">();
   });
+
+  test("still rejects a side that is invalid on its own", () => {
+    // Each side's validity is decidable from that side alone; only the match
+    // between them becomes undecidable. Deferring the match must not defer
+    // these — a wildcard is illegal in a routing key, and "" is not a pattern.
+    expectTypeOf<MatchingRoutingKey<string, "order.*">>().toEqualTypeOf<never>();
+    expectTypeOf<MatchingRoutingKey<`order.${string}`, "order.*">>().toEqualTypeOf<never>();
+    expectTypeOf<MatchingRoutingKey<"", string>>().toEqualTypeOf<never>();
+  });
 });
 
 describe("MatchingBindingPattern (topic consumer override enforcement)", () => {

--- a/packages/contract/src/builder.test-d.ts
+++ b/packages/contract/src/builder.test-d.ts
@@ -183,6 +183,26 @@ describe("MatchingBindingPattern (topic consumer override enforcement)", () => {
     expectTypeOf<MatchingBindingPattern<"order.*", string>>().toEqualTypeOf<"order.*">();
   });
 
+  test("skips the check for template-literal patterns", () => {
+    // These all match at runtime. Deciding them at compile time is not
+    // possible, so the check must defer to `defineContract` rather than
+    // guess — guessing here rejected a valid contract.
+    expectTypeOf<
+      MatchingBindingPattern<`${string}.created`, "order.created">
+    >().toEqualTypeOf<`${string}.created`>();
+    expectTypeOf<
+      MatchingBindingPattern<`order.${string}`, "order.created">
+    >().toEqualTypeOf<`order.${string}`>();
+    expectTypeOf<
+      MatchingBindingPattern<`${string}.orders.#`, "acme.orders.created">
+    >().toEqualTypeOf<`${string}.orders.#`>();
+    expectTypeOf<MatchingBindingPattern<"order.#", `order.${string}`>>().toEqualTypeOf<"order.#">();
+    // A union with one undecidable member is undecidable as a whole.
+    expectTypeOf<
+      MatchingBindingPattern<"order.*" | `x.${string}`, "order.created">
+    >().toEqualTypeOf<"order.*" | `x.${string}`>();
+  });
+
   test("still rejects empty patterns", () => {
     expectTypeOf<MatchingBindingPattern<"", "order.created">>().toEqualTypeOf<never>();
   });
@@ -205,6 +225,24 @@ describe("defineEventConsumer topic routing-key override enforcement", () => {
     defineEventConsumer(orderCreated, allOrdersQueue, { routingKey: "#" });
     defineEventConsumer(orderCreated, allOrdersQueue, { routingKey: "order.created.#" });
     defineEventConsumer(orderCreated, allOrdersQueue, { routingKey: "*.created" });
+  });
+
+  test("accepts a template-literal pattern through the public API", () => {
+    // The defect this suite exists to prevent, reproduced end-to-end: a
+    // tenant-prefixed pattern matches 'order.created' at runtime, and the
+    // library used to fail the build with
+    //   "binding pattern '${string}.created' can never match the publisher
+    //    routing key 'order.created'".
+    const tenantPattern = "acme.created" as `${string}.created`;
+    defineEventConsumer(orderCreated, allOrdersQueue, { routingKey: tenantPattern });
+
+    const suffixPattern = "order.created" as `order.${string}`;
+    defineEventConsumer(orderCreated, allOrdersQueue, { routingKey: suffixPattern });
+
+    defineEventConsumer(orderCreated, allOrdersQueue, {
+      bridgeExchange,
+      routingKey: tenantPattern,
+    });
   });
 
   test("rejects patterns that can never match the publisher routing key", () => {

--- a/packages/contract/src/builder.test-d.ts
+++ b/packages/contract/src/builder.test-d.ts
@@ -154,6 +154,16 @@ describe("MatchingRoutingKey pattern matching", () => {
       MatchingRoutingKey<"order.*.#", "order.created">
     >().toEqualTypeOf<"order.created">();
   });
+
+  test("skips the check when either side is not a compile-time literal", () => {
+    // Previously asymmetric: a plain-`string` pattern collapsed to `never`
+    // while a plain-`string` key did not. Both now skip.
+    expectTypeOf<MatchingRoutingKey<string, "order.created">>().toEqualTypeOf<"order.created">();
+    expectTypeOf<MatchingRoutingKey<"order.#", string>>().toEqualTypeOf<string>();
+    expectTypeOf<
+      MatchingRoutingKey<`order.${string}`, "order.created">
+    >().toEqualTypeOf<"order.created">();
+  });
 });
 
 describe("MatchingBindingPattern (topic consumer override enforcement)", () => {

--- a/packages/contract/src/builder/is-string-literal.test-d.ts
+++ b/packages/contract/src/builder/is-string-literal.test-d.ts
@@ -1,0 +1,45 @@
+import { describe, expectTypeOf, it } from "vitest";
+
+import type { IsStringLiteral } from "./routing-types.js";
+
+/**
+ * The single decision procedure behind all three matcher types: can this
+ * string be reasoned about at compile time?
+ *
+ * Answering it wrong in the "yes" direction is the expensive failure — the
+ * matcher then runs on a type it cannot decide and reports a valid contract
+ * as an error. Every case below that resolves to `false` is a case the
+ * matchers must skip rather than guess at.
+ */
+describe("IsStringLiteral", () => {
+  it("decides fully-known literals", () => {
+    expectTypeOf<IsStringLiteral<"order.created">>().toEqualTypeOf<true>();
+    expectTypeOf<IsStringLiteral<"">>().toEqualTypeOf<true>();
+    expectTypeOf<IsStringLiteral<"order.*">>().toEqualTypeOf<true>();
+    expectTypeOf<IsStringLiteral<"a" | "b">>().toEqualTypeOf<true>();
+  });
+
+  it("skips plain string", () => {
+    expectTypeOf<IsStringLiteral<string>>().toEqualTypeOf<false>();
+  });
+
+  it("skips template literals, wherever the hole sits", () => {
+    expectTypeOf<IsStringLiteral<`order.${string}`>>().toEqualTypeOf<false>();
+    expectTypeOf<IsStringLiteral<`${string}.orders`>>().toEqualTypeOf<false>();
+    expectTypeOf<IsStringLiteral<`a.${string}.b`>>().toEqualTypeOf<false>();
+    expectTypeOf<IsStringLiteral<`${string}.orders.#`>>().toEqualTypeOf<false>();
+    expectTypeOf<IsStringLiteral<`v${number}`>>().toEqualTypeOf<false>();
+  });
+
+  it("skips a union in which any member is not a literal", () => {
+    // Without distribution this resolves to `true` and the templated member
+    // reaches the matcher, which is the exact defect being fixed.
+    expectTypeOf<IsStringLiteral<"a" | `b.${string}`>>().toEqualTypeOf<false>();
+  });
+
+  it("skips the empty union", () => {
+    // `never` is vacuously assignable everywhere; without an explicit arm it
+    // reports as a literal.
+    expectTypeOf<IsStringLiteral<never>>().toEqualTypeOf<false>();
+  });
+});

--- a/packages/contract/src/builder/routing-types.ts
+++ b/packages/contract/src/builder/routing-types.ts
@@ -52,6 +52,33 @@ export type RoutingKey<S extends string> = S extends ""
 export type BindingPattern<S extends string> = S extends "" ? never : S;
 
 /**
+ * True when every member of `S` is a string literal fully known at compile
+ * time; false for `string`, for template-literal types with a `${…}` hole, for
+ * a union containing either, and for the empty union.
+ *
+ * The matcher types below can only decide a match when both sides are fully
+ * known. `string extends S` alone does not establish that: a partially literal
+ * type such as `` `${string}.orders` `` is not `string`, so it passes that test
+ * and then reaches a matcher that cannot decide it — which reports a pattern
+ * that matches at runtime as an error. Deciding it here, once, is what keeps
+ * the three matchers from drifting apart again.
+ *
+ * `Record<S, 1>` yields a concrete property for a literal key and a pattern
+ * index signature for a template-literal key. `{}` is assignable to the latter
+ * and not the former, which separates them in one step — no per-character
+ * recursion, so no instantiation-depth risk on long routing keys.
+ *
+ * @internal
+ */
+export type IsStringLiteral<S extends string> = string extends S
+  ? false
+  : [S] extends [never]
+    ? false
+    : (S extends string ? ({} extends Record<S, 1> ? false : true) : never) extends true
+      ? true
+      : false;
+
+/**
  * True when a pattern remainder consists only of `#` segments (`#`, `#.#`, …).
  * Such a remainder can match zero words, which matters once the routing key
  * has been fully consumed (e.g. pattern `order.created.#` vs key

--- a/packages/contract/src/builder/routing-types.ts
+++ b/packages/contract/src/builder/routing-types.ts
@@ -146,6 +146,11 @@ type MatchesPattern<
  *
  * Returns the routing key if it's valid and matches the pattern, `never` otherwise.
  *
+ * The check runs only when both the pattern and the key are fully known at
+ * compile time. Plain `string`, template-literal types, and unions containing
+ * either resolve to `Key` unchecked — the match cannot be decided, and
+ * guessing would reject a key that routes at runtime.
+ *
  * @example
  * ```typescript
  * type ValidKey = MatchingRoutingKey<"order.*", "order.created">; // "order.created"
@@ -156,13 +161,17 @@ type MatchesPattern<
  * @template Key - The routing key to validate
  */
 export type MatchingRoutingKey<Pattern extends string, Key extends string> =
-  RoutingKey<Key> extends never
-    ? never // Invalid routing key
-    : BindingPattern<Pattern> extends never
-      ? never // Invalid pattern
-      : MatchesPattern<Key, Pattern> extends true
-        ? Key
-        : never;
+  IsStringLiteral<Pattern> extends false
+    ? Key // Undecidable at compile time — defer rather than guess
+    : IsStringLiteral<Key> extends false
+      ? Key
+      : RoutingKey<Key> extends never
+        ? never // Invalid routing key
+        : BindingPattern<Pattern> extends never
+          ? never // Invalid pattern
+          : MatchesPattern<Key, Pattern> extends true
+            ? Key
+            : never;
 
 /**
  * Binding pattern for a topic consumer, validated against the publisher's
@@ -245,11 +254,10 @@ type MatchesAnyPattern<Key extends string, Patterns extends string> = [Patterns]
  * //  patterns; the broker would confirm and discard every message"
  * ```
  */
-export type RoutableRoutingKey<Key extends string, Patterns extends string> = string extends Key
-  ? Key
-  : string extends Patterns
+export type RoutableRoutingKey<Key extends string, Patterns extends string> =
+  IsStringLiteral<Key> extends false
     ? Key
-    : [Patterns] extends [never]
+    : IsStringLiteral<Patterns> extends false
       ? Key
       : MatchesAnyPattern<Key, Patterns> extends true
         ? Key

--- a/packages/contract/src/builder/routing-types.ts
+++ b/packages/contract/src/builder/routing-types.ts
@@ -150,10 +150,14 @@ type MatchesPattern<
  * `MatchingRoutingKey<"order.*", "order.*">` is `never`: the key matches the
  * pattern textually, but a routing key may not itself contain a wildcard.
  *
- * The check runs only when both the pattern and the key are fully known at
- * compile time. Plain `string`, template-literal types, and unions containing
- * either resolve to `Key` unchecked — the match cannot be decided, and
- * guessing would reject a key that routes at runtime.
+ * Each side's validity ({@link RoutingKey} for `Key`, {@link BindingPattern}
+ * for `Pattern`) is always enforced, even when the other side is not fully
+ * known — validity is decidable from one side alone. Only the *match* between
+ * the two is skipped when either side is not a fully known compile-time
+ * literal: plain `string`, a template-literal type, or a union containing
+ * either resolves to `Key` unchecked once both sides pass their own validity
+ * check — the match cannot be decided, and guessing would reject a key that
+ * routes at runtime.
  *
  * @example
  * ```typescript
@@ -165,14 +169,14 @@ type MatchesPattern<
  * @template Key - The routing key to validate
  */
 export type MatchingRoutingKey<Pattern extends string, Key extends string> =
-  IsStringLiteral<Pattern> extends false
-    ? Key // Undecidable at compile time — defer rather than guess
-    : IsStringLiteral<Key> extends false
-      ? Key
-      : RoutingKey<Key> extends never
-        ? never // Invalid routing key
-        : BindingPattern<Pattern> extends never
-          ? never // Invalid pattern
+  RoutingKey<Key> extends never
+    ? never // Invalid routing key — decidable from the key alone
+    : BindingPattern<Pattern> extends never
+      ? never // Invalid pattern — decidable from the pattern alone
+      : IsStringLiteral<Pattern> extends false
+        ? Key // The match is undecidable — defer rather than guess
+        : IsStringLiteral<Key> extends false
+          ? Key
           : MatchesPattern<Key, Pattern> extends true
             ? Key
             : never;

--- a/packages/contract/src/builder/routing-types.ts
+++ b/packages/contract/src/builder/routing-types.ts
@@ -144,7 +144,8 @@ type MatchesPattern<
  * {@link MatchingBindingPattern} (which surfaces a readable error-message
  * string type instead of `never`).
  *
- * Returns the routing key if it's valid and matches the pattern, `never` otherwise.
+ * Returns the routing key when it is known to match the pattern, and `never`
+ * when it is known not to.
  *
  * The check runs only when both the pattern and the key are fully known at
  * compile time. Plain `string`, template-literal types, and unions containing
@@ -192,9 +193,12 @@ export type MatchingRoutingKey<Pattern extends string, Key extends string> =
  * The check runs only when both sides are fully known at compile time. Plain
  * `string`, a template-literal type with a `${…}` hole (`` `${string}.created` ``),
  * and any union containing either are skipped: the match cannot be decided, and
- * guessing would reject a pattern that matches at runtime. Those contracts are
- * covered by the define-time routability check in `defineContract`, which runs
- * on concrete strings.
+ * guessing would reject a pattern that matches at runtime. The define-time
+ * routability check in `defineContract` does not cover the gap this leaves:
+ * it fails a contract whose *publisher* reaches no queue, but it does not
+ * detect a consumer binding like this one that receives nothing while a
+ * sibling binding keeps the publisher routable. There is no compile-time or
+ * define-time backstop for that case.
  *
  * @template Pattern - The consumer's binding pattern (can contain * and # wildcards)
  * @template PublisherKey - The publisher's concrete routing key
@@ -218,11 +222,11 @@ export type MatchingBindingPattern<Pattern extends string, PublisherKey extends 
  * of by the number of bindings.
  * @internal
  */
-type MatchesAnyPattern<Key extends string, Patterns extends string> = [Patterns] extends [never]
-  ? false
-  : true extends (Patterns extends string ? MatchesPattern<Key, Patterns> : never)
-    ? true
-    : false;
+type MatchesAnyPattern<Key extends string, Patterns extends string> = true extends (
+  Patterns extends string ? MatchesPattern<Key, Patterns> : never
+)
+  ? true
+  : false;
 
 /**
  * A publisher routing key validated against the binding patterns declared on

--- a/packages/contract/src/builder/routing-types.ts
+++ b/packages/contract/src/builder/routing-types.ts
@@ -144,8 +144,11 @@ type MatchesPattern<
  * {@link MatchingBindingPattern} (which surfaces a readable error-message
  * string type instead of `never`).
  *
- * Returns the routing key when it is known to match the pattern, and `never`
- * when it is known not to.
+ * Returns the routing key when both the pattern and the key are valid (see
+ * {@link RoutingKey} and {@link BindingPattern}) and the key matches the
+ * pattern; `never` when either is invalid or the key does not match — so
+ * `MatchingRoutingKey<"order.*", "order.*">` is `never`: the key matches the
+ * pattern textually, but a routing key may not itself contain a wildcard.
  *
  * The check runs only when both the pattern and the key are fully known at
  * compile time. Plain `string`, template-literal types, and unions containing

--- a/packages/contract/src/builder/routing-types.ts
+++ b/packages/contract/src/builder/routing-types.ts
@@ -180,24 +180,26 @@ export type MatchingRoutingKey<Pattern extends string, Key extends string> =
  *   "Error: binding pattern 'user.*' can never match the publisher routing key 'order.created'"
  * ```
  *
- * Non-literal strings (plain `string` on either side) skip the check — the
- * match cannot be decided at compile time, so runtime behavior is preserved.
+ * The check runs only when both sides are fully known at compile time. Plain
+ * `string`, a template-literal type with a `${…}` hole (`` `${string}.created` ``),
+ * and any union containing either are skipped: the match cannot be decided, and
+ * guessing would reject a pattern that matches at runtime. Those contracts are
+ * covered by the define-time routability check in `defineContract`, which runs
+ * on concrete strings.
  *
  * @template Pattern - The consumer's binding pattern (can contain * and # wildcards)
  * @template PublisherKey - The publisher's concrete routing key
  */
-export type MatchingBindingPattern<
-  Pattern extends string,
-  PublisherKey extends string,
-> = string extends Pattern
-  ? BindingPattern<Pattern>
-  : string extends PublisherKey
+export type MatchingBindingPattern<Pattern extends string, PublisherKey extends string> =
+  IsStringLiteral<Pattern> extends false
     ? BindingPattern<Pattern>
-    : [BindingPattern<Pattern>] extends [never]
-      ? never // Empty pattern — same rejection as BindingPattern
-      : MatchesPattern<PublisherKey, Pattern> extends true
-        ? Pattern
-        : `Error: binding pattern '${Pattern}' can never match the publisher routing key '${PublisherKey}'`;
+    : IsStringLiteral<PublisherKey> extends false
+      ? BindingPattern<Pattern>
+      : [BindingPattern<Pattern>] extends [never]
+        ? never // Empty pattern — same rejection as BindingPattern
+        : MatchesPattern<PublisherKey, Pattern> extends true
+          ? Pattern
+          : `Error: binding pattern '${Pattern}' can never match the publisher routing key '${PublisherKey}'`;
 
 /**
  * True when `Key` matches at least one pattern in the `Patterns` union.

--- a/packages/contract/src/routability.test-d.ts
+++ b/packages/contract/src/routability.test-d.ts
@@ -34,6 +34,18 @@ describe("RoutableRoutingKey", () => {
   it("skips the check when there are no patterns", () => {
     expectTypeOf<RoutableRoutingKey<"order.created", never>>().toEqualTypeOf<"order.created">();
   });
+
+  it("skips the check when either side is not a compile-time literal", () => {
+    expectTypeOf<
+      RoutableRoutingKey<`order.${string}`, "order.#">
+    >().toEqualTypeOf<`order.${string}`>();
+    expectTypeOf<
+      RoutableRoutingKey<"order.created", `order.${string}`>
+    >().toEqualTypeOf<"order.created">();
+    expectTypeOf<
+      RoutableRoutingKey<"order.created", "order.#" | `x.${string}`>
+    >().toEqualTypeOf<"order.created">();
+  });
 });
 
 /**

--- a/tests/src/docs/rule-paths.spec.ts
+++ b/tests/src/docs/rule-paths.spec.ts
@@ -1,0 +1,88 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * A path in the agent rules that no longer resolves is worse than no
+ * reference: it sends a reader looking for a guarantee that has moved.
+ *
+ * This is not hypothetical. The snippet-execution branch relocated eleven spec
+ * files and left nine `AGENTS.md` invariant references pointing at nothing —
+ * while the same edit added a tenth invariant, directly under a line telling
+ * the reader to extend the mapping. Three task reviews did not notice.
+ */
+
+const repoRoot = join(import.meta.dirname, "..", "..", "..");
+
+/** Backticked tokens that look like a repo path: contain a slash and end in a known extension. */
+const PATH_LIKE = /^[\w@./-]+\.(?:ts|tsx|js|mjs|cjs|md|json|ya?ml)(?::\d+)?$/;
+
+/**
+ * Top-level entries of the repo. A citation is rooted at one of these; an
+ * illustrative path is not.
+ *
+ * Without this test, `` `path/to/file.ts` `` (a placeholder in a code-style
+ * example) and `` `src/index.ts` `` (package-relative, in "add this to your
+ * package" instructions) both read as dead references, and the suite fails on
+ * documentation that is perfectly correct. Deriving the set from the
+ * filesystem rather than hardcoding it means a new top-level directory needs
+ * no edit here.
+ */
+const repoRootEntries = new Set(readdirSync(repoRoot));
+
+function pathsIn(markdown: string): readonly string[] {
+  return [...markdown.matchAll(/`([^`\n]+)`/g)]
+    .map((match) => match[1] ?? "")
+    .filter((token) => token.includes("/") && !token.includes("*"))
+    .filter((token) => PATH_LIKE.test(token))
+    .filter((token) => repoRootEntries.has(token.split("/")[0] ?? ""))
+    .map((token) => token.replace(/:\d+$/, ""));
+}
+
+const sources: readonly string[] = [
+  "AGENTS.md",
+  ...readdirSync(join(repoRoot, ".agents", "rules"))
+    .filter((name) => name.endsWith(".md"))
+    .map((name) => join(".agents", "rules", name)),
+];
+
+const extracted = sources.map((source) => ({
+  source,
+  paths: pathsIn(readFileSync(join(repoRoot, source), "utf8")),
+}));
+
+describe("agent rule docs", () => {
+  // `CLAUDE.md` is a symlink to `AGENTS.md`; listing only `AGENTS.md` avoids
+  // asserting the same corpus twice.
+  it("has rule files to check", () => {
+    expect(sources.length).toBeGreaterThan(5);
+  });
+
+  // These two floors detect a broken extractor, nothing more. They sit far
+  // below the real counts on purpose, so ordinary doc edits never trip them
+  // and nobody is tempted to loosen them. They are deliberately NOT coverage
+  // pins: several rule files legitimately cite no repo-rooted paths at all
+  // (they link with Markdown syntax instead), so a per-file floor would fail
+  // on correct documentation.
+  it("extracts path references across the corpus", () => {
+    expect(extracted.reduce((total, entry) => total + entry.paths.length, 0)).toBeGreaterThan(20);
+  });
+
+  it("extracts path references from AGENTS.md", () => {
+    // The index cites every guarded invariant by file; it can never be empty.
+    const agents = extracted.find((entry) => entry.source === "AGENTS.md");
+    expect(agents?.paths.length ?? 0).toBeGreaterThan(10);
+  });
+
+  for (const { source, paths } of extracted) {
+    for (const path of paths) {
+      it(`${source}: ${path} resolves`, () => {
+        expect(
+          existsSync(join(repoRoot, path)),
+          `${source} references ${path}, which does not exist`,
+        ).toBe(true);
+      });
+    }
+  }
+});

--- a/tests/src/docs/rule-paths.spec.ts
+++ b/tests/src/docs/rule-paths.spec.ts
@@ -15,8 +15,28 @@ import { describe, expect, it } from "vitest";
 
 const repoRoot = join(import.meta.dirname, "..", "..", "..");
 
-/** Backticked tokens that look like a repo path: contain a slash and end in a known extension. */
-const PATH_LIKE = /^[\w@./-]+\.(?:ts|tsx|js|mjs|cjs|md|json|ya?ml)(?::\d+)?$/;
+/**
+ * Backticked tokens that look like a repo path: contain a slash and either
+ * end in a known extension (a file, optionally with a `:LINE` suffix) or have
+ * no extension on their final path segment (a directory, e.g. `packages/contract`
+ * or `docs/`).
+ */
+const FILE_PATH_LIKE = /^[\w@./-]+\.(?:ts|tsx|js|mjs|cjs|md|json|ya?ml)(?::\d+)?$/;
+
+/** Character class shared with `FILE_PATH_LIKE`, without the extension requirement. */
+const PATH_CHARS = /^[\w@./-]+$/;
+
+/**
+ * True when `token`'s final path segment has no extension — i.e. it names a
+ * directory, not a file. A leading dot (`.agents`, a hidden directory) does
+ * not count as an extension marker: only a `.` preceded by at least one
+ * character does.
+ */
+function isDirectoryLike(token: string): boolean {
+  const withoutTrailingSlash = token.endsWith("/") ? token.slice(0, -1) : token;
+  const lastSegment = withoutTrailingSlash.split("/").at(-1) ?? "";
+  return lastSegment !== "" && lastSegment.lastIndexOf(".") <= 0;
+}
 
 /**
  * Top-level entries of the repo. A citation is rooted at one of these; an
@@ -35,7 +55,9 @@ function pathsIn(markdown: string): readonly string[] {
   return [...markdown.matchAll(/`([^`\n]+)`/g)]
     .map((match) => match[1] ?? "")
     .filter((token) => token.includes("/") && !token.includes("*"))
-    .filter((token) => PATH_LIKE.test(token))
+    .filter(
+      (token) => FILE_PATH_LIKE.test(token) || (PATH_CHARS.test(token) && isDirectoryLike(token)),
+    )
     .filter((token) => repoRootEntries.has(token.split("/")[0] ?? ""))
     .map((token) => token.replace(/:\d+$/, ""));
 }


### PR DESCRIPTION
## The defect

`MatchingBindingPattern` types the `routingKey` override on `defineEventConsumer`'s topic overloads. It resolves to a readable error-message string when a pattern can never match the publisher's key, so an unmatchable binding fails to compile instead of silently receiving nothing.

It also rejected patterns that match perfectly well at runtime:

```
Type '`${string}.created`' is not assignable to type
  '`Error: binding pattern '${string}.created' can never match
    the publisher routing key 'order.created'`'
```

The skip condition was `string extends Pattern`, true only for plain `string`. A *partially* literal type is not plain `string`, so the check ran, the matcher could not decide it, and a valid contract failed the build. Tenant- and environment-prefixed routing keys are the ordinary way to hit this.

That breaks the governing rule of this program: **a false negative is acceptable; rejecting a valid contract is not.**

The type's own doc comment said "Non-literal strings (plain `string` on either side) skip the check" — naming only the case the code handled. The comment and the defect were the same sentence.

## Scope

Three exported types run this match. All three shared the hole, each drifted differently:

| Type | Applied to | Plain `string` | Template literal |
| --- | --- | --- | --- |
| `MatchingBindingPattern` | `defineEventConsumer` — **live** | skipped | **rejected** |
| `RoutableRoutingKey` | opt-in utility | skipped | rejected (documented) |
| `MatchingRoutingKey` | opt-in utility | rejected on the pattern side, skipped on the key side | rejected |

Only the first could break a build today. This is the program's second recurring pattern — *a rule expressed in more than one place drifts* — with three expressions and three drifts.

## The fix

One internal guard, `IsStringLiteral`, answers "is this knowable at compile time?" and all three matchers call it. `Record<S, 1>` yields a concrete property for a literal key and a pattern index signature for a template-literal key; `{}` is assignable to the latter and not the former, so one step separates them — no per-character recursion, no instantiation-depth risk. The conditional distributes, so a union with one non-literal member is undecidable as a whole.

Undecidable inputs now skip the check — a false negative, the direction the rule prefers.

## What did NOT change

Every pre-existing assertion still passes untouched, including the five `@ts-expect-error` lines proving unmatchable patterns are still rejected, and the empty-pattern rejection. `git diff main -- '*.test-d.ts' | grep '^-'` is empty: every test change is an addition. That is what keeps this from being a blanket skip.

## Also here

- **A test asserting every path cited in the agent rule docs resolves** (`tests/src/docs/rule-paths.spec.ts`). The snippet-execution branch broke nine `AGENTS.md` invariant references while adding a tenth, directly under a line telling readers to extend the mapping, and three task reviews missed it. 59 citations checked; falsifiability proven by injecting a bad path and watching it fail.
- **The pending `RoutableRoutingKey` changeset corrected.** It documented this limitation as intended behavior. Unreleased, so it is fixed rather than shipped.

## Review found what tests could not

Every defect that survived here was text claiming a stronger guarantee than the code delivers — the same class the branch fixes. Tests never catch these, because the code is internally consistent; only a second reader is:

- The final review **measured** that `` `user.${string}` `` against `order.created` was rejected before this branch and is accepted now, while my changeset claimed rejection power was unchanged. The trade is deliberate and correct; the sentence was false.
- It also disproved "covered by the define-time check in `defineContract`" by building a real contract: with a sibling binding keeping the publisher routable, a consumer binding that receives nothing draws no signal at all. That claim now names the publisher side only.
- The scoped re-review then caught that my *replacement* sentence was **also** false — it required only the pattern to be known, not both sides — with `` MatchingBindingPattern<"user.x", `${string}.created`> `` as the counter-example. Third pass on one sentence.

Process note: that last correction is a second fix wave, which the workflow forbids. I judged the deviation worth naming rather than hiding — it is text-only, in an unreleased changeset, and shipping a false guarantee in release notes is the exact thing this branch exists to stop. Easily reverted if you disagree.

## Deliberately out of scope

- **Rejecting a wildcard in a direct-exchange binding key.** Binding `order.*` on a direct exchange and publishing that literal key is legal AMQP and works. A guard would reject a valid contract. Your call, and the right one.
- **Duplicate delivery.** Exactly-once is not achievable over AMQP — the ack can always be lost after the work is done. Exactly-once *effect* needs an idempotent consumer keyed on application state, sharing a transaction boundary with the user's database. Out of this library's scope; the answer is documentation, not machinery.

## Verification

`pnpm build`, `typecheck`, `test --concurrency=1` (13/13 tasks, 612 unit tests), `lint`, `knip`, `oxfmt --check` all clean. Integration suites requiring Docker were not run locally; CI covers them.
