### PR TITLE
fix(tests): prune excluded directories before descending in snippet discovery

### DIFF
--- a/tests/src/snippets/discover.ts
+++ b/tests/src/snippets/discover.ts
@@ -43,7 +43,12 @@ function matchesExcludedFragment(rel: string, fragment: string): boolean {
   );
 }
 
-function walk(absolute: string, out: string[]): void {
+/** True when `rel` sits under any excluded fragment. */
+function isExcluded(rel: string): boolean {
+  return EXCLUDED.some((fragment) => matchesExcludedFragment(rel, fragment));
+}
+
+function walk(absolute: string, out: string[], repoRoot: string): void {
   let entries: string[];
   try {
     entries = readdirSync(absolute);
@@ -61,7 +66,13 @@ function walk(absolute: string, out: string[]): void {
       continue;
     }
     if (stats.isDirectory()) {
-      walk(child, out);
+      // Prune before descending, not after collecting. The excluded fragments
+      // include `node_modules`, and this repo has 344 of those directories
+      // holding ~70 000 files — walking them to find ~60 markdown files and
+      // then filtering them back out cost enough wall-clock to time this
+      // suite out in CI while passing locally on a warm cache.
+      if (isExcluded(relative(repoRoot, child))) continue;
+      walk(child, out, repoRoot);
     } else if (entry.endsWith(".md")) {
       out.push(child);
     }
@@ -78,7 +89,7 @@ export function discoverMarkdownFiles(repoRoot: string): readonly string[] {
   for (const root of ROOTS) {
     const absolute = join(repoRoot, root);
     try {
-      if (statSync(absolute).isDirectory()) walk(absolute, found);
+      if (statSync(absolute).isDirectory()) walk(absolute, found, repoRoot);
       else if (absolute.endsWith(".md")) found.push(absolute);
     } catch {
       continue;
@@ -87,7 +98,7 @@ export function discoverMarkdownFiles(repoRoot: string): readonly string[] {
   return found
     .filter((file) => {
       const rel = relative(repoRoot, file);
-      if (EXCLUDED.some((fragment) => matchesExcludedFragment(rel, fragment))) return false;
+      if (isExcluded(rel)) return false;
       // From packages, only the package READMEs.
       if (rel.startsWith(`packages${sep}`))
         return rel.split(sep).length === 3 && rel.endsWith("README.md");


### PR DESCRIPTION
## The failure

`tests/src/snippets/extract.spec.ts > discoverMarkdownFiles > finds hand-written docs and excludes generated and planning ones` timed out at 5000 ms in CI, on a branch that changed only markdown. The same job passed on Node 22.19 in the same run — a timing race, not a deterministic break.

## The cause

`walk()` descended into **every** directory unconditionally and applied `EXCLUDED` afterwards, as a `.filter()` over the collected results. `EXCLUDED` contains `node_modules`.

So discovery walked the entire dependency tree and then threw it away. Measured on this repo:

```
dirs=7014  files=70434  node_modules_dirs_entered=344  ms=373
```

70 434 files stat'd to find ~60 markdown files. 373 ms on a warm local cache — which is why it always passed locally, and why it tipped over 5 s on CI's cold filesystem.

## The fix

Prune before descending instead of filtering after collecting. The `EXCLUDED` check moves into `walk()`, applied to directories on the way down, and both call sites now share one `isExcluded()` predicate rather than repeating the `.some(...)` expression.

The post-collection filter stays: it still enforces the separate rule that only `packages/<name>/README.md` is wanted from `packages`, which is about file position rather than directory exclusion.

## Result

| | before | after |
|---|---|---|
| `extract.spec.ts` | 7696 ms in CI (timeout at 5000 ms) | **22 ms** |

Same corpus discovered — all 13 tests in that file pass, including the one asserting the discovered set contains the expected pages and excludes `docs/api/`, `docs/superpowers/` and `node_modules`. The full `@amqp-contract/tests` suite is 107/107, with the snippet corpus still pinned at exactly 31, which is the real proof discovery is unchanged: a pruning bug that dropped a directory would move that number.

## Provenance

Mine, from the snippet-execution guard branch. The walk was written to collect first and filter second, and the exclusion list was documented as if it governed traversal. Nothing failed until the dependency tree grew enough to cross a timeout on a slower filesystem.

## Not included

The `ci / Security Audit` failure seen alongside this is unrelated and already present on `main`: new `undici` (`GHSA-4cwx-7wf7-3272`) and `fast-uri` (`GHSA-7p8r-x3mc-p8w7`) advisories, reaching us transitively through `packages/testing > testcontainers`. That needs a dependency bump, not this change.
