### PR TITLE
chore(deps): patch undici and fast-uri advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,7 +146,8 @@ catalogs:
       version: 4.4.3
 
 overrides:
-  fast-uri@<3.1.4: 3.1.4
+  fast-uri@<3.1.5: 3.1.5
+  undici@<8.9.0: 8.9.0
   brace-expansion@1: 1.1.18
   brace-expansion@2: 2.1.4
   brace-expansion@5: 5.0.9
@@ -3838,8 +3839,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -5345,8 +5346,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@8.5.0:
-    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
+  undici@8.9.0:
+    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
     engines: {node: '>=22.19.0'}
 
   unicode-emoji-modifier-base@1.0.0:
@@ -7843,7 +7844,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -8756,7 +8757,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.20.1:
     dependencies:
@@ -10275,7 +10276,7 @@ snapshots:
       ssh-remote-port-forward: 1.0.4
       tar-fs: 3.1.2
       tmp: 0.2.7
-      undici: 8.5.0
+      undici: 8.9.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -10448,7 +10449,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@8.5.0: {}
+  undici@8.9.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -70,10 +70,17 @@ peerDependencyRules:
 # dev/build/test tooling.
 overrides:
   # GHSA-v2hh-gcrm-f6hx (High): fast-uri host confusion via literal backslash
-  # authority delimiter. Only the vulnerable <3.1.4 line is present (transitive,
-  # via ajv under commitlint/prisma tooling); 3.1.4 is the first patched release.
-  # Reaches us only through dev/build tooling.
-  "fast-uri@<3.1.4": "3.1.4"
+  # authority delimiter, and GHSA-7p8r-x3mc-p8w7 (High): the same class of host
+  # confusion via backslash, which 3.1.4 did not fully close. Only the
+  # vulnerable line is present (transitive, via ajv under commitlint/prisma
+  # tooling); 3.1.5 is the first release patched against both. Reaches us only
+  # through dev/build tooling.
+  "fast-uri@<3.1.5": "3.1.5"
+  # GHSA-4cwx-7wf7-3272 (High): undici cross-user information disclosure.
+  # Reaches us only through packages/testing > testcontainers, i.e. the
+  # integration-test harness, never a published package's runtime. 8.9.0 is the
+  # first patched release.
+  "undici@<8.9.0": "8.9.0"
   # GHSA-3jxr-9vmj-r5cp (High, ReDoS) + GHSA-mh99-v99m-4gvg (High, DoS via
   # unbounded expansion length) + GHSA-rgw5-rvv9-x895 (High, DoS via unbounded
   # intermediate arrays, bypassing the CVE-2026-14257 mitigation):
@@ -136,6 +143,12 @@ minimumReleaseAgeExclude:
   # overrides above) are younger than the 7-day cutoff (all published
   # 2026-07-30). Remove once they are 7 days old (i.e. after 2026-08-06).
   - brace-expansion
+  # Temporary: fast-uri 3.1.5 (the GHSA-7p8r-x3mc-p8w7 override above) was
+  # published 2026-07-31, inside the 7-day cutoff. It is the only release
+  # patched against that advisory, so the choice was a young release or a known
+  # High. Remove this entry once it is 7 days old (i.e. after 2026-08-07).
+  # undici 8.9.0 needs no entry — published 2026-07-24, already past the cutoff.
+  - fast-uri
 
 # GHSA-mh99-v99m-4gvg (brace-expansion DoS via unbounded expansion length) has a
 # patched release ONLY on the 5.x line (>=5.0.8); the 1.x/2.x lines resolved


### PR DESCRIPTION
## Why

`ci / Security Audit` is failing on `main` and therefore on every open PR. Two High advisories published after main's last green run:

| Advisory | Package | Patched | Reaches us via |
| --- | --- | --- | --- |
| [GHSA-4cwx-7wf7-3272](https://github.com/advisories/GHSA-4cwx-7wf7-3272) | `undici` | `>=8.9.0` | `packages/testing > testcontainers` |
| [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) | `fast-uri` | `>=3.1.5` | `@btravstack/commitlint > @commitlint/cli > … > ajv` |

Both are transitive and reach only dev/build/test tooling — neither is in a published package's runtime path.

The `fast-uri` one is a follow-up to [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx), which this repo already overrides to 3.1.4. Same class of host confusion via backslash; 3.1.4 did not fully close it.

## What

Follows the existing `overrides:` pattern in `pnpm-workspace.yaml`:

- `fast-uri@<3.1.4` → `fast-uri@<3.1.5`, comment updated to name both advisories.
- New `undici@<8.9.0` override.

## The release-age exception, stated plainly

This repo enforces a 7-day release-age cutoff. Measured against it today:

- **`undici` 8.9.0** — published 2026-07-24, 10 days old. Passes cleanly, **no allowlist entry**.
- **`fast-uri` 3.1.5** — published 2026-07-31, **3 days old**. Inside the cutoff.

3.1.5 is the only release patched against GHSA-7p8r, so the choice was a young release or a known High. I took the young release and added a temporary allowlist entry with a removal date, following the `brace-expansion` precedent already in the file:

```yaml
  # Temporary: fast-uri 3.1.5 (the GHSA-7p8r-x3mc-p8w7 override above) was
  # published 2026-07-31, inside the 7-day cutoff. ...
  # Remove this entry once it is 7 days old (i.e. after 2026-08-07).
  - fast-uri
```

**This weakens the supply-chain policy for four days and should be reverted on 2026-08-07.** It was an explicit decision, not a default — the alternative was leaving a High advisory unpatched and the audit red until then.

## Verification

`pnpm audit --audit-level high` → **No known vulnerabilities found** (was 6).

`pnpm build`, `typecheck`, `test --concurrency=1` (13/13 tasks), `lint`, `oxfmt --check` all clean after a full `pnpm install` — the `undici` bump sits under testcontainers, so the integration harness was the thing worth re-running. Docker-backed integration suites were not run locally; CI covers them.
