### PR TITLE
chore(deps): bump @btravstack/theme to 2.0.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ catalogs:
       specifier: 0.2.1
       version: 0.2.1
     '@btravstack/theme':
-      specifier: 1.7.0
-      version: 1.7.0
+      specifier: 2.0.0
+      version: 2.0.0
     '@btravstack/tsconfig':
       specifier: 0.2.0
       version: 0.2.0
@@ -219,7 +219,7 @@ importers:
     devDependencies:
       '@btravstack/theme':
         specifier: 'catalog:'
-        version: 1.7.0(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@26.1.1)(jiti@2.7.0)(postcss@8.5.23)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
+        version: 2.0.0(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@26.1.1)(jiti@2.7.0)(postcss@8.5.23)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
       '@types/node':
         specifier: 26.1.1
         version: 26.1.1
@@ -905,8 +905,8 @@ packages:
     peerDependencies:
       oxlint: '>=1'
 
-  '@btravstack/theme@1.7.0':
-    resolution: {integrity: sha512-EcBvQruZdsiL/zuNsu7Y1r2FeMDv0J5LZJx7ikO6cFvNRzKCc63A7582gVmfJNQlGJIg0cUCjQXB4Tm1YHtyug==}
+  '@btravstack/theme@2.0.0':
+    resolution: {integrity: sha512-tEhaBntwON0PpDWoSsp1cwxmFAXlBk4sLld2U3/MRKWFxAl8/E0ZHtUyy/Bd5rShi7caI7dwq4PzC0mqh7psJA==}
     peerDependencies:
       vitepress: ^1.6.0
       vue: ^3.3.0
@@ -5845,7 +5845,7 @@ snapshots:
     dependencies:
       oxlint: 1.76.0
 
-  '@btravstack/theme@1.7.0(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@26.1.1)(jiti@2.7.0)(postcss@8.5.23)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))':
+  '@btravstack/theme@2.0.0(vitepress@1.6.4(@algolia/client-search@5.53.0)(@types/node@26.1.1)(jiti@2.7.0)(postcss@8.5.23)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       vitepress: 1.6.4(@algolia/client-search@5.53.0)(@types/node@26.1.1)(jiti@2.7.0)(postcss@8.5.23)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,8 +151,9 @@ overrides:
   brace-expansion@1: 1.1.18
   brace-expansion@2: 2.1.4
   brace-expansion@5: 5.0.9
-  js-yaml@3: 3.15.0
-  js-yaml@4: 4.3.0
+  js-yaml@3: 3.15.1
+  js-yaml@4: 4.3.1
+  nanoid@<3.3.17: 3.3.17
   vite@<6.4.3: 6.4.3
   dompurify: 3.4.12
   protobufjs: 7.6.5
@@ -4243,12 +4244,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsep@1.4.0:
@@ -4519,8 +4520,8 @@ packages:
   nan@2.27.0:
     resolution: {integrity: sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5790,7 +5791,7 @@ snapshots:
       ajv-errors: 3.0.0(ajv@8.20.0)
       ajv-formats: 2.1.1
       avsc: 5.7.9
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       jsonpath-plus: 10.4.0
       node-fetch: 2.6.7
     transitivePeerDependencies:
@@ -5966,7 +5967,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -8213,7 +8214,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -9152,12 +9153,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -9433,7 +9434,7 @@ snapshots:
   nan@2.27.0:
     optional: true
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   nimma@0.2.3:
     dependencies:
@@ -9718,7 +9719,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -9792,7 +9793,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       pify: 4.0.1
       strip-bom: 3.0.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -97,8 +97,16 @@ overrides:
   # quadratic-CPU / merge-key issues. The legacy 3.x line arrives via
   # @changesets/cli > read-yaml-file; the 4.x line via @changesets/cli >
   # @changesets/parse and @asyncapi/parser. Both pulled to their patched release.
-  "js-yaml@3": "3.15.0"
-  "js-yaml@4": "4.3.0"
+  #
+  # Raised to 3.15.1 / 4.3.1 for GHSA-5p4m-2wfm-xmqj (High), a later advisory on
+  # the same package that 3.15.0 / 4.3.0 predate.
+  "js-yaml@3": "3.15.1"
+  "js-yaml@4": "4.3.1"
+  # GHSA-2v37-7h3g-55p8 (High): nanoid custom generators can loop indefinitely
+  # when size is zero. Reaches us only through the docs build —
+  # docs > @btravstack/theme > vitepress > postcss > nanoid — never the shipped
+  # package. Pinned to its first patched release.
+  "nanoid@<3.3.17": "3.3.17"
   # GHSA-fx2h-pf6j-xcff (High) + GHSA-v6wh-96g9-6wx3 / GHSA-4w7w-66w2-5vf9 /
   # GHSA-67mh-4wv8-2f99 (moderate): vite `server.fs.deny` bypass + esbuild
   # dev-server CORS (dev-server only; the docs ship as static HTML). Reaches us

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,7 @@ catalog:
   "@btravstack/commitlint": 0.1.0
   "@btravstack/lefthook": 0.1.1
   "@btravstack/oxlint": 0.2.1
-  "@btravstack/theme": 1.7.0
+  "@btravstack/theme": 2.0.0
   "@btravstack/tsconfig": 0.2.0
   "@btravstack/typedoc": 0.1.0
   "@changesets/cli": 2.31.1


### PR DESCRIPTION
Two commits: the theme bump this PR was opened for, and a security-override refresh needed to get CI green.

## 1. `@btravstack/theme` 1.7.0 → 2.0.0

`@btravstack/theme@2.0.0` shipped from btravstack/btravstack.github.io#41, releasing three changesets that had queued up: the new `--pkg-di` accent, plus `--pkg-unthrown` teal and `--pkg-entity` amber, which had been merged but unreleased.

**The major does not reach this repo.** 2.0.0 is major solely because it removes the retired `--pkg-demesne` and `--pkg-start` tokens — `tokens.css` is a published export, so its custom properties are public API even though the projects they named are gone. Grepping this repo returns **zero** references to either. This site's own `--accent` (orange `#ff6600`) is untouched and already matches its token, so nothing changes visually.

pnpm added no pinned `minimumReleaseAgeExclude` entry, since the unversioned `@btravstack/theme` exclusion already covers it.

## 2. js-yaml pins raised, nanoid override added

`pnpm audit --audit-level=high` fails on three advisories. **This is pre-existing, not caused by the bump** — I ran the audit on this branch and on `main` and got byte-identical results (9 vulnerabilities, 1 low / 5 moderate / 3 high). The last green run predates the disclosures. It is fixed here rather than left blocking the branch.

| advisory | patched | was | now |
|---|---|---|---|
| js-yaml `GHSA-5p4m-2wfm-xmqj` (High) | ≥3.15.1 | `3.15.0` | `3.15.1` |
| js-yaml `GHSA-5p4m-2wfm-xmqj` (High) | ≥4.3.1 | `4.3.0` | `4.3.1` |
| nanoid `GHSA-2v37-7h3g-55p8` (High) | ≥3.3.17 | *(no override)* | `nanoid@<3.3.17` |

The existing js-yaml pins were chosen for `GHSA-52cp-r559-cp3m` and simply predate this later advisory on the same package; that original rationale comment is kept and the new advisory noted beside it. nanoid reaches us only through the docs build — `docs > @btravstack/theme > vitepress > postcss > nanoid` — never the shipped package.

These are the pins `unthrown` already carries, which is why its audit passes and this one's did not.

## Verified

Audit now reports 6 (1 low, 5 moderate), all below the `high` gate. Format, lint, typecheck, tests and build all pass locally. Docs build emits `--pkg-di: #3E7FD4` (proving 2.0.0 resolved), both retired tokens absent, `--accent` still `#ff6600`.
