### PR TITLE
chore(testing): mark the testing package private — internal by intention

### DIFF
--- a/.changeset/testing-internal.md
+++ b/.changeset/testing-internal.md
@@ -1,0 +1,7 @@
+---
+"@amqp-contract/testing": patch
+---
+
+The testing package is now private — internal by intention. It was built for
+this repository's own suites and never designed as a public API; the published
+versions are deprecated on npm and no further versions will be published.

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -6,12 +6,9 @@
 > The previously published versions are deprecated on npm; do not depend on
 > them from other repositories.
 
-
 **Testing utilities for AMQP contracts using testcontainers.**
 
 [![CI](https://github.com/btravstack/amqp-contract/actions/workflows/ci.yml/badge.svg)](https://github.com/btravstack/amqp-contract/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/npm/v/@amqp-contract/testing.svg?logo=npm)](https://www.npmjs.com/package/@amqp-contract/testing)
-[![npm downloads](https://img.shields.io/npm/dm/@amqp-contract/testing.svg)](https://www.npmjs.com/package/@amqp-contract/testing)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue?logo=typescript)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -26,9 +23,9 @@
 
 ## Installation
 
-```bash
-pnpm add -D @amqp-contract/testing
-```
+None — this package is consumed only inside this workspace, as
+`"@amqp-contract/testing": "workspace:*"` in a sibling package's
+`devDependencies`.
 
 ## Usage
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,5 +1,12 @@
 # @amqp-contract/testing
 
+> [!IMPORTANT]
+> **Internal package — no longer published.** These utilities were built for
+> this repository's own test suites and were never designed as a public API.
+> The previously published versions are deprecated on npm; do not depend on
+> them from other repositories.
+
+
 **Testing utilities for AMQP contracts using testcontainers.**
 
 [![CI](https://github.com/btravstack/amqp-contract/actions/workflows/ci.yml/badge.svg)](https://github.com/btravstack/amqp-contract/actions/workflows/ci.yml)

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@amqp-contract/testing",
   "version": "3.0.0-beta.6",
+  "private": true,
   "description": "Testing utilities for AMQP contracts with testcontainers",
   "keywords": [
     "amqp",


### PR DESCRIPTION
Decision (Benoit, 2026-08-13): the testing package was built for this repo's own suites and was never designed as a public API — external repos should not depend on it.

- `private: true` stops future publishes. changesets keeps versioning it inside the fixed group (`privatePackages` versions but never publishes), so the pending changesets and the beta train are unaffected.
- README gets an internal-package banner.
- The already-published npm versions are being deprecated separately with a pointer to this decision.

The one known external consumer — btravstack/start — is being migrated off it (test helpers absorbed into a private workspace package there).

Possible follow-up, deliberately not in this PR: the docs site still renders this package's API pages, which advertises it publicly; say the word and I'll drop it from the docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)