### PR TITLE
chore: point CodeRabbit at this repository's own conventions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+
+reviews:
+  path_filters:
+    - "!**/src/generated/**"
+    - "!**/docs/.vitepress/dist/**"
+    - "!pnpm-lock.yaml"
+  path_instructions:
+    - path: "**/*.ts"
+      instructions: |
+        The authoritative spec is the root `AGENTS.md` (`CLAUDE.md` is a symlink to it) — read it first, and treat a suggestion it has already rejected as noise.
+
+        Errors are values here (`unthrown`), not exceptions. Suggestions that
+        assume otherwise are wrong rather than debatable:
+
+        - No `try`/`catch` around a `Result` pipeline. Every combinator catches
+          a thrown callback and converts it to a `Defect`; the `defect` arm of
+          the final `match` is the catch. A `try` in the diff is either a
+          boundary around a foreign throwing API — legitimate, and they carry a
+          reason — or a mistake.
+        - There is no `mapErr`. The error combinators are `mapErrCases`,
+          `flatMapErrCases`, `recoverErrCases` and `tapErrCases`, and they are
+          exhaustive by design: `P._` is a lint error outside a helper generic
+          in `E`.
+        - Every async surface returns `AsyncResult`, never a bare `Promise` —
+          the infallible ones included (`AsyncResult<T, never>`).
+        - `Ok(v).toAsync()` is `OkAsync(v)`; `Err(e).toAsync()` is
+          `ErrAsync(e)`. A `flatMap` returning the value it was handed is
+          `ensure`. A nullable lookup is `fromNullable`, not a ternary.
+        - `E` is never `unknown`, `any` or `Error`; a `Defect` never appears
+          in it.
+
+        Comments are sparse by convention: rationale lives in the spec file,
+        not beside the code. Do not ask for more comments, or for TSDoc on a
+        private symbol.
+
+        `type` not `interface`, `unknown` not `any`, and every relative import
+        carries `.js` — `moduleResolution: NodeNext`.
+
+    - path: "**/{CLAUDE,AGENTS}.md"
+      instructions: |
+        This is the spec, not commentary. Check its claims against the code in
+        the same diff: a sentence that counts call sites or describes a
+        signature is a claim that can go stale silently.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,8 +2,6 @@
 
 reviews:
   path_filters:
-    - "!**/src/generated/**"
-    - "!**/docs/.vitepress/dist/**"
     - "!pnpm-lock.yaml"
   path_instructions:
     - path: "**/*.ts"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,7 +8,10 @@ reviews:
   path_instructions:
     - path: "**/*.ts"
       instructions: |
-        The authoritative spec is the root `AGENTS.md` (`CLAUDE.md` is a symlink to it) — read it first, and treat a suggestion it has already rejected as noise.
+        When the same diff also changes a `CLAUDE.md`, an `AGENTS.md` or a
+        README, check what it now claims against this code. A sentence that
+        counts call sites, names "the one such site" or describes a signature is
+        a claim that goes stale silently, and one already had.
 
         Errors are values here (`unthrown`), not exceptions. Suggestions that
         assume otherwise are wrong rather than debatable:
@@ -36,9 +39,3 @@ reviews:
 
         `type` not `interface`, `unknown` not `any`, and every relative import
         carries `.js` — `moduleResolution: NodeNext`.
-
-    - path: "**/{CLAUDE,AGENTS}.md"
-      instructions: |
-        This is the spec, not commentary. Check its claims against the code in
-        the same diff: a sentence that counts call sites or describes a
-        signature is a claim that can go stale silently.


### PR DESCRIPTION
Adds a `.coderabbit.yaml` now that CodeRabbit is installed on the org.

**It points at this repository's spec rather than restating it.** The
conventions are already written down and already reviewed; a second copy in
YAML would be a fifth copy with no gate, which is the drift this org keeps
meeting. So `path_instructions` say *read the spec file, hold the diff to it*,
and spell out only the handful of things a generic reviewer gets actively
wrong — the ones where a suggestion is not debatable but simply not how this
codebase works.

`path_filters` keep generated output and the lockfile out of what it reads.

Nothing else is configured. Every other key stays at its default, deliberately:
`profile: chill`, no `poem`, no `request_changes_workflow`, no `tools` block —
the linters CodeRabbit runs are the ones whose config it finds, and this repo's
gate already runs them in CI.

Two knobs worth knowing about rather than setting blind:

- `reviews.profile: assertive` raises the nitpick volume. Worth trying once
  there is a review or two to judge it against.
- `reviews.request_changes_workflow: true` makes CodeRabbit block a PR until
  its comments are resolved. Off by default, and it should probably stay off
  until the instructions have been tuned.

The GitHub App install itself is a click in the CodeRabbit dashboard — this file
does nothing until the app can see the repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository review guidance to validate claims in concurrently changed TypeScript and project documentation.
  * Consolidated Markdown review instructions for project guidance files.
  * No changes were made to exported or public application entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->