### PR TITLE
feat(worker)!: the handler leaf takes helpers first, message second

### DIFF
--- a/.agents/rules/code-style.md
+++ b/.agents/rules/code-style.md
@@ -84,14 +84,14 @@ const contract = defineContract({
 
 ```typescript
 // Bad — using async handlers
-processOrder: async (_, { payload }) => {
+processOrder: async ({ input: { payload } }) => {
   await process(payload);
 };
 
 // Good — use the AsyncResult pattern from unthrown.
 // fromPromise REQUIRES the error mapper as the second argument; chaining
 // .mapErr afterwards is a type error since fromPromise has no `unknown` overload.
-processOrder: (_, { payload }) =>
+processOrder: ({ input: { payload } }) =>
   fromPromise(
     process(payload),
     (e) => new RetryableError("Failed", e),
@@ -103,7 +103,7 @@ processOrder: (message) => {
 };
 
 // Good — destructure payload
-processOrder: (_, { payload }) => {
+processOrder: ({ input: { payload } }) => {
   console.log(payload.orderId);
 };
 

--- a/.agents/rules/code-style.md
+++ b/.agents/rules/code-style.md
@@ -84,14 +84,14 @@ const contract = defineContract({
 
 ```typescript
 // Bad — using async handlers
-processOrder: async ({ payload }) => {
+processOrder: async (_, { payload }) => {
   await process(payload);
 };
 
 // Good — use the AsyncResult pattern from unthrown.
 // fromPromise REQUIRES the error mapper as the second argument; chaining
 // .mapErr afterwards is a type error since fromPromise has no `unknown` overload.
-processOrder: ({ payload }) =>
+processOrder: (_, { payload }) =>
   fromPromise(
     process(payload),
     (e) => new RetryableError("Failed", e),
@@ -103,7 +103,7 @@ processOrder: (message) => {
 };
 
 // Good — destructure payload
-processOrder: ({ payload }) => {
+processOrder: (_, { payload }) => {
   console.log(payload.orderId);
 };
 

--- a/.agents/rules/handlers.md
+++ b/.agents/rules/handlers.md
@@ -4,20 +4,20 @@ This project uses [unthrown](https://github.com/btravstack/unthrown) for explici
 
 ## Regular consumer handler
 
-A consumer handler receives `({ payload, headers }, rawMessage)` and returns `AsyncResult<void, HandlerError>`:
+A consumer handler receives `({ context, errors, raw }, { payload, headers })` — helpers first, the validated message second — and returns `AsyncResult<void, HandlerError>`:
 
 ```typescript
 import { fromPromise, OkAsync } from "unthrown";
 import { RetryableError, NonRetryableError } from "@amqp-contract/worker";
 
 // Sync OK case — lift a sync Result into an AsyncResult with .toAsync()
-const handler = ({ payload }, rawMessage) => {
-  console.log(payload.orderId);
+const handler = ({ raw }, { payload }) => {
+  console.log(payload.orderId, raw.fields.deliveryTag);
   return OkAsync(undefined);
 };
 
 // Async case — fromPromise REQUIRES the qualify mapper as the second arg
-const asyncHandler = ({ payload }) =>
+const asyncHandler = (_, { payload }) =>
   fromPromise(processPayment(payload), (error) => new RetryableError("Payment failed", error)).map(
     () => undefined,
   );
@@ -25,16 +25,23 @@ const asyncHandler = ({ payload }) =>
 
 ### Parameters
 
-1. **`message`** — `{ payload, headers }`
+1. **`helpers`** — `{ context, errors, raw }`
+   - `context`: seeded by `createContext`, accumulated by the middleware chain
+   - `errors`: typed constructors for the RPC's declared errors (empty for consumers)
+   - `raw`: the raw amqplib `ConsumeMessage` (e.g. `raw.fields.deliveryTag`, `raw.properties.messageId`)
+2. **`message`** — `{ payload, headers }`
    - `payload`: validated against the message's payload schema
    - `headers`: validated against the message's optional headers schema (otherwise `undefined`)
-2. **`rawMessage`** — the raw amqplib `ConsumeMessage` (e.g. `msg.fields.deliveryTag`, `msg.properties.messageId`)
+
+Helpers first is oRPC's parameter order, which this family converged on
+(temporal-contract's activity leaf moved with it). A handler that needs none of
+them still names the position: `(_, { payload }) => ...`.
 
 ## RPC handler
 
 `defineRpc` creates a request-reply slot. RPC handlers return `AsyncResult<TResponse, HandlerError | WorkerInferRpcErrors<...>>` — the worker validates the response against the RPC's response schema and publishes it back to the caller's `replyTo` with the same `correlationId`.
 
-All handlers (consumer and RPC) receive a third `helpers` argument — `{ context, errors }`. `context` is seeded by `createContext` and accumulated by the middleware chain (`TypedAmqpWorker.create({ createContext, middleware: composeMiddleware(...) })`); `errors` carries typed constructors for the RPC's declared errors (`ErrAsync(errors.CODE({ ... }))`), empty for consumers. Middleware `next({ payload })` substitutes the payload with re-validation before the handler. See `packages/worker/src/middleware.ts`, `packages/worker/src/worker.ts` (`runHandler`), and [docs/guide/middleware-and-interceptors.md](../../docs/guide/middleware-and-interceptors.md).
+All handlers (consumer and RPC) receive the `helpers` record first — `{ context, errors, raw }`. `context` is seeded by `createContext` and accumulated by the middleware chain (`TypedAmqpWorker.create({ createContext, middleware: composeMiddleware(...) })`); `errors` carries typed constructors for the RPC's declared errors (`ErrAsync(errors.CODE({ ... }))`), empty for consumers. Middleware `next({ payload })` substitutes the payload with re-validation before the handler. See `packages/worker/src/middleware.ts`, `packages/worker/src/worker.ts` (`runHandler`), and [docs/guide/middleware-and-interceptors.md](../../docs/guide/middleware-and-interceptors.md).
 
 When the RPC declares an `errors` map (`defineRpc(queue, { request, response, errors })`), the handler may also return `Err(rpcError(code, data))` for a declared code — the worker validates `data` against the declared schema, publishes an error reply (marked by the `RPC_ERROR_CODE_HEADER` header), and **acks the request**; typed business errors never enter the retry/DLQ pipeline. Undeclared codes or invalid error data are contract violations routed to the DLQ. See `packages/worker/src/worker.ts` (`publishRpcErrorReply`) and [docs/guide/error-model.md](../../docs/guide/error-model.md#typed-rpc-errors-rpcerror).
 
@@ -48,13 +55,13 @@ const result = await TypedAmqpWorker.create({
   contract,
   handlers: {
     // Regular consumer — `payload` typed from the consumer's message schema
-    processOrder: ({ payload }) => OkAsync(undefined),
+    processOrder: (_, { payload }) => OkAsync(undefined),
 
     // RPC handler — must return the typed response payload
-    calculate: ({ payload }) => OkAsync({ sum: payload.a + payload.b }),
+    calculate: (_, { payload }) => OkAsync({ sum: payload.a + payload.b }),
 
     // RPC with async work
-    lookupUser: ({ payload }) =>
+    lookupUser: (_, { payload }) =>
       fromPromise(
         db.users.findById(payload.userId),
         (error) => new RetryableError("DB unavailable", error),
@@ -99,7 +106,7 @@ Use `declareHandler` (single) or `declareHandlers` (object) for full type infere
 import { declareHandler, RetryableError, NonRetryableError } from "@amqp-contract/worker";
 import { ErrAsync, fromPromise, OkAsync } from "unthrown";
 
-const processOrderHandler = declareHandler(contract, "processOrder", ({ payload }) =>
+const processOrderHandler = declareHandler(contract, "processOrder", (_, { payload }) =>
   fromPromise(
     processPayment(payload.orderId),
     (error) => new RetryableError("Payment service unavailable", error),
@@ -107,7 +114,7 @@ const processOrderHandler = declareHandler(contract, "processOrder", ({ payload 
 );
 
 // Permanent failures use NonRetryableError → DLQ, never retried
-const validateOrderHandler = declareHandler(contract, "validateOrder", ({ payload }) => {
+const validateOrderHandler = declareHandler(contract, "validateOrder", (_, { payload }) => {
   if (payload.amount < 1) {
     return ErrAsync(new NonRetryableError("Invalid amount"));
   }
@@ -149,7 +156,7 @@ Helpers: `qualifyRetryable(message)` / `qualifyNonRetryable(message)` build `fro
 
 ```typescript
 // Conditional error mapping inside fromPromise's qualify
-({ payload }) =>
+(_, { payload }) =>
   fromPromise(process(payload), (error) => {
     if (error instanceof ValidationError) return new NonRetryableError("Invalid data");
     return new RetryableError("Temporary failure", error);

--- a/.agents/rules/handlers.md
+++ b/.agents/rules/handlers.md
@@ -25,13 +25,13 @@ const asyncHandler = ({ input: { payload } }) =>
 
 ### Parameters
 
-1. **`helpers`** — `{ message, context, errors, raw, retryable, nonRetryable }`
+1. **`helpers`** — `{ input, context, errors, raw, retryable, nonRetryable }`
    - `input`: the validated `{ payload, headers }`, the same value the second parameter carries — oRPC's shape and its word for it, so `({ errors, input }) => ...` and `({ errors }, message) => ...` are the same call, and the same name is destructured on all three transports
    - `context`: seeded by `createContext`, accumulated by the middleware chain
    - `errors`: typed constructors for the RPC's declared errors (empty for consumers)
    - `raw`: the raw amqplib `ConsumeMessage` (e.g. `raw.fields.deliveryTag`, `raw.properties.messageId`)
    - `retryable` / `nonRetryable`: the two modeled failures as factories — `ErrAsync(retryable("db down", cause))` is `new RetryableError(...)` without the import. They sit beside `errors` rather than inside it: `errors` is the contract's declared map, which is what the name means on the other two transports.
-2. **`message`** — `{ payload, headers }`
+2. **`message`** (positional) — the same `{ payload, headers }` as `helpers.input`
    - `payload`: validated against the message's payload schema
    - `headers`: validated against the message's optional headers schema (otherwise `undefined`)
 

--- a/.agents/rules/handlers.md
+++ b/.agents/rules/handlers.md
@@ -25,10 +25,11 @@ const asyncHandler = (_, { payload }) =>
 
 ### Parameters
 
-1. **`helpers`** — `{ context, errors, raw }`
+1. **`helpers`** — `{ context, errors, raw, retryable, nonRetryable }`
    - `context`: seeded by `createContext`, accumulated by the middleware chain
    - `errors`: typed constructors for the RPC's declared errors (empty for consumers)
    - `raw`: the raw amqplib `ConsumeMessage` (e.g. `raw.fields.deliveryTag`, `raw.properties.messageId`)
+   - `retryable` / `nonRetryable`: the two modeled failures as factories — `ErrAsync(retryable("db down", cause))` is `new RetryableError(...)` without the import. They sit beside `errors` rather than inside it: `errors` is the contract's declared map, which is what the name means on the other two transports.
 2. **`message`** — `{ payload, headers }`
    - `payload`: validated against the message's payload schema
    - `headers`: validated against the message's optional headers schema (otherwise `undefined`)

--- a/.agents/rules/handlers.md
+++ b/.agents/rules/handlers.md
@@ -25,7 +25,8 @@ const asyncHandler = (_, { payload }) =>
 
 ### Parameters
 
-1. **`helpers`** — `{ context, errors, raw, retryable, nonRetryable }`
+1. **`helpers`** — `{ message, context, errors, raw, retryable, nonRetryable }`
+   - `message`: the validated `{ payload, headers }`, the same value the second parameter carries — oRPC's shape, so `({ errors, message }) => ...` and `({ errors }, message) => ...` are the same call
    - `context`: seeded by `createContext`, accumulated by the middleware chain
    - `errors`: typed constructors for the RPC's declared errors (empty for consumers)
    - `raw`: the raw amqplib `ConsumeMessage` (e.g. `raw.fields.deliveryTag`, `raw.properties.messageId`)

--- a/.agents/rules/handlers.md
+++ b/.agents/rules/handlers.md
@@ -4,20 +4,20 @@ This project uses [unthrown](https://github.com/btravstack/unthrown) for explici
 
 ## Regular consumer handler
 
-A consumer handler receives `({ context, errors, raw }, { payload, headers })` — helpers first, the validated message second — and returns `AsyncResult<void, HandlerError>`:
+A consumer handler receives one record — `{ input, context, errors, raw, retryable, nonRetryable }`, where `input` is the validated `{ payload, headers }` — and returns `AsyncResult<void, HandlerError>`. The message is repeated as a second positional parameter, oRPC's shape, for a caller who prefers it:
 
 ```typescript
 import { fromPromise, OkAsync } from "unthrown";
 import { RetryableError, NonRetryableError } from "@amqp-contract/worker";
 
 // Sync OK case — lift a sync Result into an AsyncResult with .toAsync()
-const handler = ({ raw }, { payload }) => {
+const handler = ({ raw, input: { payload } }) => {
   console.log(payload.orderId, raw.fields.deliveryTag);
   return OkAsync(undefined);
 };
 
 // Async case — fromPromise REQUIRES the qualify mapper as the second arg
-const asyncHandler = (_, { payload }) =>
+const asyncHandler = ({ input: { payload } }) =>
   fromPromise(processPayment(payload), (error) => new RetryableError("Payment failed", error)).map(
     () => undefined,
   );
@@ -26,7 +26,7 @@ const asyncHandler = (_, { payload }) =>
 ### Parameters
 
 1. **`helpers`** — `{ message, context, errors, raw, retryable, nonRetryable }`
-   - `message`: the validated `{ payload, headers }`, the same value the second parameter carries — oRPC's shape, so `({ errors, message }) => ...` and `({ errors }, message) => ...` are the same call
+   - `input`: the validated `{ payload, headers }`, the same value the second parameter carries — oRPC's shape and its word for it, so `({ errors, input }) => ...` and `({ errors }, message) => ...` are the same call, and the same name is destructured on all three transports
    - `context`: seeded by `createContext`, accumulated by the middleware chain
    - `errors`: typed constructors for the RPC's declared errors (empty for consumers)
    - `raw`: the raw amqplib `ConsumeMessage` (e.g. `raw.fields.deliveryTag`, `raw.properties.messageId`)
@@ -37,7 +37,7 @@ const asyncHandler = (_, { payload }) =>
 
 Helpers first is oRPC's parameter order, which this family converged on
 (temporal-contract's activity leaf moved with it). A handler that needs none of
-them still names the position: `(_, { payload }) => ...`.
+them still names the position: `({ input: { payload } }) => ...`.
 
 ## RPC handler
 
@@ -57,13 +57,13 @@ const result = await TypedAmqpWorker.create({
   contract,
   handlers: {
     // Regular consumer — `payload` typed from the consumer's message schema
-    processOrder: (_, { payload }) => OkAsync(undefined),
+    processOrder: ({ input: { payload } }) => OkAsync(undefined),
 
     // RPC handler — must return the typed response payload
-    calculate: (_, { payload }) => OkAsync({ sum: payload.a + payload.b }),
+    calculate: ({ input: { payload } }) => OkAsync({ sum: payload.a + payload.b }),
 
     // RPC with async work
-    lookupUser: (_, { payload }) =>
+    lookupUser: ({ input: { payload } }) =>
       fromPromise(
         db.users.findById(payload.userId),
         (error) => new RetryableError("DB unavailable", error),
@@ -108,7 +108,7 @@ Use `declareHandler` (single) or `declareHandlers` (object) for full type infere
 import { declareHandler, RetryableError, NonRetryableError } from "@amqp-contract/worker";
 import { ErrAsync, fromPromise, OkAsync } from "unthrown";
 
-const processOrderHandler = declareHandler(contract, "processOrder", (_, { payload }) =>
+const processOrderHandler = declareHandler(contract, "processOrder", ({ input: { payload } }) =>
   fromPromise(
     processPayment(payload.orderId),
     (error) => new RetryableError("Payment service unavailable", error),
@@ -116,7 +116,7 @@ const processOrderHandler = declareHandler(contract, "processOrder", (_, { paylo
 );
 
 // Permanent failures use NonRetryableError → DLQ, never retried
-const validateOrderHandler = declareHandler(contract, "validateOrder", (_, { payload }) => {
+const validateOrderHandler = declareHandler(contract, "validateOrder", ({ input: { payload } }) => {
   if (payload.amount < 1) {
     return ErrAsync(new NonRetryableError("Invalid amount"));
   }
@@ -158,7 +158,7 @@ Helpers: `qualifyRetryable(message)` / `qualifyNonRetryable(message)` build `fro
 
 ```typescript
 // Conditional error mapping inside fromPromise's qualify
-(_, { payload }) =>
+({ input: { payload } }) =>
   fromPromise(process(payload), (error) => {
     if (error instanceof ValidationError) return new NonRetryableError("Invalid data");
     return new RetryableError("Temporary failure", error);

--- a/.agents/rules/recipes.md
+++ b/.agents/rules/recipes.md
@@ -8,7 +8,7 @@ End-to-end how-tos for the changes that come up most. Each recipe lists the exac
 2. **Queue** — `defineQueue(...)` with a `deadLetter` and a `retry` mode (immediate-requeue or ttl-backoff). Quorum by default; classic only if you need priority/exclusive/auto-delete.
 3. **Consumer entry** — `defineEventConsumer(eventPublisher, queue, { routingKey: ... })`. The queue↔exchange binding is auto-generated.
 4. **Add to `defineContract`** under `consumers: { ... }`. Don't add the queue or binding yourself — they're auto-extracted.
-5. **Handler** — implement with `declareHandler(contract, "yourConsumerName", ({ payload, headers }) => …)` returning `AsyncResult<void, HandlerError>`. See [handlers.md](./handlers.md).
+5. **Handler** — implement with `declareHandler(contract, "yourConsumerName", (_, { payload, headers }) => …)` returning `AsyncResult<void, HandlerError>`. See [handlers.md](./handlers.md).
 6. **Tests** — integration test in `src/__tests__/<consumer>.spec.ts` using `it` from `@amqp-contract/testing/extension`. Mock the handler with `vi.fn().mockReturnValue(OkAsync(undefined))`.
 7. **Changeset** — `pnpm changeset` with a minor bump. Public API surface grew.
 
@@ -18,7 +18,7 @@ End-to-end how-tos for the changes that come up most. Each recipe lists the exac
 2. **Queue** — `defineQueue(...)` for the RPC. Quorum by default. **Configure a `deadLetter`** even though replies, not the queue, drive most failure modes: missing `replyTo` / `correlationId` and response-schema mismatches are surfaced as `NonRetryableError` and the worker `nack`s them without requeue, so without a DLX they're dropped silently.
 3. **RPC entry** — `defineRpc(queue, { request, response })`. Typed business errors go in an optional `errors` map whose entries are `{ data: schema, message?: string }` (the raw Standard Schema, NOT `defineMessage`); the optional `message` is the default human message when the handler constructs the error without one.
 4. **Add to `defineContract`** under `rpcs: { ... }`.
-5. **Server-side handler** — define it with `declareHandler(contract, "yourRpcName", ({ payload }) => OkAsync({ /* response */ }))`, via `declareHandlers`, or inline in the `handlers` object passed to `TypedAmqpWorker.create({ handlers: { … } })`. All three are RPC-aware: `declareHandler` / `declareHandlers` are overloaded against `InferRpcNames` and validate the name against both `contract.consumers` and `contract.rpcs`. The worker validates the response against the response schema and publishes back automatically.
+5. **Server-side handler** — define it with `declareHandler(contract, "yourRpcName", (_, { payload }) => OkAsync({ /* response */ }))`, via `declareHandlers`, or inline in the `handlers` object passed to `TypedAmqpWorker.create({ handlers: { … } })`. All three are RPC-aware: `declareHandler` / `declareHandlers` are overloaded against `InferRpcNames` and validate the name against both `contract.consumers` and `contract.rpcs`. The worker validates the response against the response schema and publishes back automatically.
 6. **Client call** — `client.call("yourRpcName", request, { timeoutMs: 5_000 })`. `timeoutMs` is required.
 7. **Tests** — round-trip integration test (worker + client both wired up). For "no server" scenarios, just create the client without a worker; for "request validation fails", pass a deliberately wrong payload through `as unknown as ...`.
 8. **Changeset** — minor bump.
@@ -51,7 +51,7 @@ If you're spinning up a new `@amqp-contract/*` package:
 Old shape (now banned):
 
 ```typescript
-processOrder: async ({ payload }) => {
+processOrder: async (_, { payload }) => {
   await processPayment(payload);
 };
 ```
@@ -59,7 +59,7 @@ processOrder: async ({ payload }) => {
 New shape:
 
 ```typescript
-processOrder: ({ payload }) =>
+processOrder: (_, { payload }) =>
   fromPromise(processPayment(payload), (error) => new RetryableError("Payment failed", error)).map(
     () => undefined,
   );

--- a/.agents/rules/recipes.md
+++ b/.agents/rules/recipes.md
@@ -8,7 +8,7 @@ End-to-end how-tos for the changes that come up most. Each recipe lists the exac
 2. **Queue** — `defineQueue(...)` with a `deadLetter` and a `retry` mode (immediate-requeue or ttl-backoff). Quorum by default; classic only if you need priority/exclusive/auto-delete.
 3. **Consumer entry** — `defineEventConsumer(eventPublisher, queue, { routingKey: ... })`. The queue↔exchange binding is auto-generated.
 4. **Add to `defineContract`** under `consumers: { ... }`. Don't add the queue or binding yourself — they're auto-extracted.
-5. **Handler** — implement with `declareHandler(contract, "yourConsumerName", (_, { payload, headers }) => …)` returning `AsyncResult<void, HandlerError>`. See [handlers.md](./handlers.md).
+5. **Handler** — implement with `declareHandler(contract, "yourConsumerName", ({ input: { payload, headers } }) => …)` returning `AsyncResult<void, HandlerError>`. See [handlers.md](./handlers.md).
 6. **Tests** — integration test in `src/__tests__/<consumer>.spec.ts` using `it` from `@amqp-contract/testing/extension`. Mock the handler with `vi.fn().mockReturnValue(OkAsync(undefined))`.
 7. **Changeset** — `pnpm changeset` with a minor bump. Public API surface grew.
 
@@ -18,7 +18,7 @@ End-to-end how-tos for the changes that come up most. Each recipe lists the exac
 2. **Queue** — `defineQueue(...)` for the RPC. Quorum by default. **Configure a `deadLetter`** even though replies, not the queue, drive most failure modes: missing `replyTo` / `correlationId` and response-schema mismatches are surfaced as `NonRetryableError` and the worker `nack`s them without requeue, so without a DLX they're dropped silently.
 3. **RPC entry** — `defineRpc(queue, { request, response })`. Typed business errors go in an optional `errors` map whose entries are `{ data: schema, message?: string }` (the raw Standard Schema, NOT `defineMessage`); the optional `message` is the default human message when the handler constructs the error without one.
 4. **Add to `defineContract`** under `rpcs: { ... }`.
-5. **Server-side handler** — define it with `declareHandler(contract, "yourRpcName", (_, { payload }) => OkAsync({ /* response */ }))`, via `declareHandlers`, or inline in the `handlers` object passed to `TypedAmqpWorker.create({ handlers: { … } })`. All three are RPC-aware: `declareHandler` / `declareHandlers` are overloaded against `InferRpcNames` and validate the name against both `contract.consumers` and `contract.rpcs`. The worker validates the response against the response schema and publishes back automatically.
+5. **Server-side handler** — define it with `declareHandler(contract, "yourRpcName", ({ input: { payload } }) => OkAsync({ /* response */ }))`, via `declareHandlers`, or inline in the `handlers` object passed to `TypedAmqpWorker.create({ handlers: { … } })`. All three are RPC-aware: `declareHandler` / `declareHandlers` are overloaded against `InferRpcNames` and validate the name against both `contract.consumers` and `contract.rpcs`. The worker validates the response against the response schema and publishes back automatically.
 6. **Client call** — `client.call("yourRpcName", request, { timeoutMs: 5_000 })`. `timeoutMs` is required.
 7. **Tests** — round-trip integration test (worker + client both wired up). For "no server" scenarios, just create the client without a worker; for "request validation fails", pass a deliberately wrong payload through `as unknown as ...`.
 8. **Changeset** — minor bump.
@@ -51,7 +51,7 @@ If you're spinning up a new `@amqp-contract/*` package:
 Old shape (now banned):
 
 ```typescript
-processOrder: async (_, { payload }) => {
+processOrder: async ({ input: { payload } }) => {
   await processPayment(payload);
 };
 ```
@@ -59,7 +59,7 @@ processOrder: async (_, { payload }) => {
 New shape:
 
 ```typescript
-processOrder: (_, { payload }) =>
+processOrder: ({ input: { payload } }) =>
   fromPromise(processPayment(payload), (error) => new RetryableError("Payment failed", error)).map(
     () => undefined,
   );

--- a/.agents/rules/testing.md
+++ b/.agents/rules/testing.md
@@ -68,10 +68,10 @@ const mockHandler = vi.fn().mockReturnValue(OkAsync(undefined));
 
 // Assertion pattern
 expect(mockHandler).toHaveBeenCalledWith(
+  expect.anything(), // helpers: { context, errors, raw }
   expect.objectContaining({
     payload: expect.objectContaining({ orderId: "123" }),
   }),
-  expect.anything(), // rawMessage
 );
 ```
 

--- a/.changeset/handler-helpers-first.md
+++ b/.changeset/handler-helpers-first.md
@@ -49,7 +49,7 @@ is oRPC's own shape — `ProcedureHandlerOptions` carries `input` and the handle
 still takes it positionally — so both spellings are the same call:
 
 ```ts
-getOrder: ({ errors, message }) => lookup(message.payload, errors),
+getOrder: ({ errors, input }) => lookup(input.payload, errors),
 getOrder: ({ errors, input: { payload } }) => lookup(payload, errors),
 ```
 

--- a/.changeset/handler-helpers-first.md
+++ b/.changeset/handler-helpers-first.md
@@ -40,6 +40,15 @@ called `retryable`.
 + getOrder: ({ errors }, { payload }) => lookup(payload, errors),
 ```
 
+The message is on the helpers record as well as in the second parameter, which
+is oRPC's own shape — `ProcedureHandlerOptions` carries `input` and the handler
+still takes it positionally — so both spellings are the same call:
+
+```ts
+getOrder: ({ errors, message }) => lookup(message.payload, errors),
+getOrder: ({ errors }, { payload }) => lookup(payload, errors),
+```
+
 A handler that reads its payload fails to compile until it is swapped, since
 the first parameter is the helpers record now; one that ignores its message
 keeps compiling with a parameter whose name lies — grep the handlers object for

--- a/.changeset/handler-helpers-first.md
+++ b/.changeset/handler-helpers-first.md
@@ -2,15 +2,19 @@
 "@amqp-contract/worker": major
 ---
 
-Handlers take the **helpers record first and the validated message second** —
-`({ context, errors, raw }, { payload, headers })` where it was
-`({ payload, headers }, rawMessage, { context, errors })`. The raw amqplib
-delivery moved from a third parameter into `raw` on the helpers.
+Handlers take **one record** — `{ input, context, errors, raw, retryable,
+nonRetryable }`, where `input` is the validated `{ payload, headers }` — with
+that message repeated as a second positional parameter. It was
+`({ payload, headers }, rawMessage, { context, errors })`: the raw amqplib
+delivery moved onto the record as `raw`, and the message is reachable from
+either place.
 
 oRPC is the reference shape for this family, being the most widely used of the
 three transports a `@btravstack/*` application composes: a developer arriving
-here has more likely seen `({ errors, context }, input)` than either of the
-others. The mint and compose calls already agreed across the three; the leaf a
+here has more likely seen `({ errors, input })` than either of the others —
+down to the word, since oRPC's `ProcedureHandlerOptions` carries `input` and
+its handler still takes it positionally, which is exactly the pair of spellings
+offered here. The mint and compose calls already agreed across the three; the leaf a
 developer types by hand did not, and it is the one they relearn per transport.
 `@temporal-contract`'s activity leaf moves with it.
 
@@ -21,7 +25,7 @@ reaches for the constructor it was handed instead of importing `RetryableError`
 and constructing it by hand.
 
 ```ts
-processOrder: ({ retryable }, { payload }) =>
+processOrder: ({ retryable, input: { payload } }) =>
   fromPromise(save(payload), (cause) => retryable("database unavailable", cause)),
 ```
 
@@ -33,11 +37,11 @@ called `retryable`.
 
 ```diff
 - processOrder: ({ payload }) => save(payload),
-+ processOrder: (_, { payload }) => save(payload),
++ processOrder: ({ input: { payload } }) => save(payload),
 - handleFailed: ({ payload }, rawMessage) => log(rawMessage.properties.headers),
-+ handleFailed: ({ raw }, { payload }) => log(raw.properties.headers),
++ handleFailed: ({ raw, input: { payload } }) => log(raw.properties.headers),
 - getOrder: ({ payload }, _raw, { errors }) => lookup(payload, errors),
-+ getOrder: ({ errors }, { payload }) => lookup(payload, errors),
++ getOrder: ({ errors, input: { payload } }) => lookup(payload, errors),
 ```
 
 The message is on the helpers record as well as in the second parameter, which
@@ -46,13 +50,13 @@ still takes it positionally — so both spellings are the same call:
 
 ```ts
 getOrder: ({ errors, message }) => lookup(message.payload, errors),
-getOrder: ({ errors }, { payload }) => lookup(payload, errors),
+getOrder: ({ errors, input: { payload } }) => lookup(payload, errors),
 ```
 
 A handler that reads its payload fails to compile until it is swapped, since
 the first parameter is the helpers record now; one that ignores its message
 keeps compiling with a parameter whose name lies — grep the handlers object for
 a leaf whose first parameter is neither `_` nor a helpers destructuring. A
-handler that needs neither still names the position: `(_, { payload }) => ...`.
+handler that wants only its message is `({ input: { payload } }) => ...`, with no placeholder to spell.
 
 Closes #670.

--- a/.changeset/handler-helpers-first.md
+++ b/.changeset/handler-helpers-first.md
@@ -1,0 +1,36 @@
+---
+"@amqp-contract/worker": major
+---
+
+Handlers take the **helpers record first and the validated message second** —
+`({ context, errors, raw }, { payload, headers })` where it was
+`({ payload, headers }, rawMessage, { context, errors })`. The raw amqplib
+delivery moved from a third parameter into `raw` on the helpers.
+
+oRPC is the reference shape for this family, being the most widely used of the
+three transports a `@btravstack/*` application composes: a developer arriving
+here has more likely seen `({ errors, context }, input)` than either of the
+others. The mint and compose calls already agreed across the three; the leaf a
+developer types by hand did not, and it is the one they relearn per transport.
+`@temporal-contract`'s activity leaf moves with it.
+
+It is also what makes the AMQP triage site the same SHAPE as the other two: a
+handler that wants "infrastructure comes back" reaches for the helpers it was
+handed rather than importing `RetryableError` and constructing it by hand.
+
+```diff
+- processOrder: ({ payload }) => save(payload),
++ processOrder: (_, { payload }) => save(payload),
+- handleFailed: ({ payload }, rawMessage) => log(rawMessage.properties.headers),
++ handleFailed: ({ raw }, { payload }) => log(raw.properties.headers),
+- getOrder: ({ payload }, _raw, { errors }) => lookup(payload, errors),
++ getOrder: ({ errors }, { payload }) => lookup(payload, errors),
+```
+
+A handler that reads its payload fails to compile until it is swapped, since
+the first parameter is the helpers record now; one that ignores its message
+keeps compiling with a parameter whose name lies — grep the handlers object for
+a leaf whose first parameter is neither `_` nor a helpers destructuring. A
+handler that needs neither still names the position: `(_, { payload }) => ...`.
+
+Closes #670.

--- a/.changeset/handler-helpers-first.md
+++ b/.changeset/handler-helpers-first.md
@@ -14,9 +14,22 @@ others. The mint and compose calls already agreed across the three; the leaf a
 developer types by hand did not, and it is the one they relearn per transport.
 `@temporal-contract`'s activity leaf moves with it.
 
-It is also what makes the AMQP triage site the same SHAPE as the other two: a
-handler that wants "infrastructure comes back" reaches for the helpers it was
-handed rather than importing `RetryableError` and constructing it by hand.
+It is also what makes the AMQP triage site the same SHAPE as the other two, and
+that half is not cosmetic: `retryable` and `nonRetryable` ride the helpers
+record beside `errors`, so a handler that wants "infrastructure comes back"
+reaches for the constructor it was handed instead of importing `RetryableError`
+and constructing it by hand.
+
+```ts
+processOrder: ({ retryable }, { payload }) =>
+  fromPromise(save(payload), (cause) => retryable("database unavailable", cause)),
+```
+
+They sit BESIDE `errors` rather than inside it: `errors` is the
+contract-declared error map — `errors.ORDER_NOT_FOUND({ orderId })` — which is
+what it means on the other two transports, and folding the framework's own two
+into that namespace would both break the mirror and collide with a declared code
+called `retryable`.
 
 ```diff
 - processOrder: ({ payload }) => save(payload),

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ import { contract } from "./contract.js";
 const worker = await TypedAmqpWorker.create({
   contract,
   handlers: {
-    processOrder: ({ payload }) => {
+    processOrder: (_, { payload }) => {
       console.log(payload.orderId); // ✅ TypeScript knows!
       return OkAsync();
     },

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ import { contract } from "./contract.js";
 const worker = await TypedAmqpWorker.create({
   contract,
   handlers: {
-    processOrder: (_, { payload }) => {
+    processOrder: ({ input: { payload } }) => {
       console.log(payload.orderId); // ✅ TypeScript knows!
       return OkAsync();
     },

--- a/docs/examples/basic-order-processing.md
+++ b/docs/examples/basic-order-processing.md
@@ -447,7 +447,7 @@ const worker = await TypedAmqpWorker.create({
   contract: orderContract,
   handlers: declareHandlers(orderContract, {
     // Event handler for NEW orders (order.created) — headers are typed
-    processOrder: (_, { payload, headers }) => {
+    processOrder: ({ input: { payload, headers } }) => {
       console.log(`[PROCESSING] Order ${payload.orderId}`, {
         customer: payload.customerId,
         total: payload.totalAmount,
@@ -460,7 +460,7 @@ const worker = await TypedAmqpWorker.create({
     },
 
     // Event handler for ALL order events (order.#) — payload is the union type
-    notifyOrder: (_, { payload }) => {
+    notifyOrder: ({ input: { payload } }) => {
       if ("items" in payload) {
         console.log(`[NOTIFICATIONS] New order ${payload.orderId}`);
       } else {
@@ -472,7 +472,7 @@ const worker = await TypedAmqpWorker.create({
     },
 
     // Event handler for SHIPPED orders (order.shipped)
-    shipOrder: (_, { payload }) => {
+    shipOrder: ({ input: { payload } }) => {
       console.log(`[SHIPPING] Order ${payload.orderId} - ${payload.status}`);
       return fromPromise(prepareShipping(payload), qualifyRetryable("Shipping failed")).map(
         () => undefined,
@@ -480,7 +480,7 @@ const worker = await TypedAmqpWorker.create({
     },
 
     // Event handler for URGENT orders (order.*.urgent)
-    handleUrgentOrder: (_, { payload }) => {
+    handleUrgentOrder: ({ input: { payload } }) => {
       console.warn(`[URGENT] Order ${payload.orderId} - ${payload.status}`);
       return fromPromise(escalate(payload), qualifyRetryable("Urgent handling failed")).map(
         () => undefined,
@@ -488,7 +488,7 @@ const worker = await TypedAmqpWorker.create({
     },
 
     // Command handler (task queue): reaches exactly one worker
-    fulfillOrder: (_, { payload }) => {
+    fulfillOrder: ({ input: { payload } }) => {
       console.log(`[FULFILLMENT] Order ${payload.orderId} → ${payload.warehouseId}`);
       return fromPromise(fulfill(payload), qualifyRetryable("Fulfillment failed")).map(
         () => undefined,
@@ -496,7 +496,7 @@ const worker = await TypedAmqpWorker.create({
     },
 
     // Dead-letter handler: messages that failed in order-processing
-    handleFailedOrders: (_, { payload }) => {
+    handleFailedOrders: ({ input: { payload } }) => {
       console.error(`[DLX] Failed order ${payload.orderId}`);
       return fromPromise(recordFailure(payload), qualifyRetryable("DLX handling failed")).map(
         () => undefined,

--- a/docs/examples/basic-order-processing.md
+++ b/docs/examples/basic-order-processing.md
@@ -447,7 +447,7 @@ const worker = await TypedAmqpWorker.create({
   contract: orderContract,
   handlers: declareHandlers(orderContract, {
     // Event handler for NEW orders (order.created) — headers are typed
-    processOrder: ({ payload, headers }) => {
+    processOrder: (_, { payload, headers }) => {
       console.log(`[PROCESSING] Order ${payload.orderId}`, {
         customer: payload.customerId,
         total: payload.totalAmount,
@@ -460,7 +460,7 @@ const worker = await TypedAmqpWorker.create({
     },
 
     // Event handler for ALL order events (order.#) — payload is the union type
-    notifyOrder: ({ payload }) => {
+    notifyOrder: (_, { payload }) => {
       if ("items" in payload) {
         console.log(`[NOTIFICATIONS] New order ${payload.orderId}`);
       } else {
@@ -472,7 +472,7 @@ const worker = await TypedAmqpWorker.create({
     },
 
     // Event handler for SHIPPED orders (order.shipped)
-    shipOrder: ({ payload }) => {
+    shipOrder: (_, { payload }) => {
       console.log(`[SHIPPING] Order ${payload.orderId} - ${payload.status}`);
       return fromPromise(prepareShipping(payload), qualifyRetryable("Shipping failed")).map(
         () => undefined,
@@ -480,7 +480,7 @@ const worker = await TypedAmqpWorker.create({
     },
 
     // Event handler for URGENT orders (order.*.urgent)
-    handleUrgentOrder: ({ payload }) => {
+    handleUrgentOrder: (_, { payload }) => {
       console.warn(`[URGENT] Order ${payload.orderId} - ${payload.status}`);
       return fromPromise(escalate(payload), qualifyRetryable("Urgent handling failed")).map(
         () => undefined,
@@ -488,7 +488,7 @@ const worker = await TypedAmqpWorker.create({
     },
 
     // Command handler (task queue): reaches exactly one worker
-    fulfillOrder: ({ payload }) => {
+    fulfillOrder: (_, { payload }) => {
       console.log(`[FULFILLMENT] Order ${payload.orderId} → ${payload.warehouseId}`);
       return fromPromise(fulfill(payload), qualifyRetryable("Fulfillment failed")).map(
         () => undefined,
@@ -496,7 +496,7 @@ const worker = await TypedAmqpWorker.create({
     },
 
     // Dead-letter handler: messages that failed in order-processing
-    handleFailedOrders: ({ payload }) => {
+    handleFailedOrders: (_, { payload }) => {
       console.error(`[DLX] Failed order ${payload.orderId}`);
       return fromPromise(recordFailure(payload), qualifyRetryable("DLX handling failed")).map(
         () => undefined,

--- a/docs/examples/command-pattern.md
+++ b/docs/examples/command-pattern.md
@@ -118,7 +118,7 @@ import {
 import { fromPromise } from "unthrown";
 import { contract } from "@org/payment-contract";
 
-const chargeHandler = declareHandler(contract, "chargeCustomer", (_, { payload }) =>
+const chargeHandler = declareHandler(contract, "chargeCustomer", ({ input: { payload } }) =>
   fromPromise(
     chargeProvider({
       customerId: payload.customerId,

--- a/docs/examples/command-pattern.md
+++ b/docs/examples/command-pattern.md
@@ -118,7 +118,7 @@ import {
 import { fromPromise } from "unthrown";
 import { contract } from "@org/payment-contract";
 
-const chargeHandler = declareHandler(contract, "chargeCustomer", ({ payload }) =>
+const chargeHandler = declareHandler(contract, "chargeCustomer", (_, { payload }) =>
   fromPromise(
     chargeProvider({
       customerId: payload.customerId,

--- a/docs/explanation/core-concepts.md
+++ b/docs/explanation/core-concepts.md
@@ -113,7 +113,7 @@ const orderMessage = defineMessage(z.object({ orderId: z.string() }));
 When the worker asks for `handlers.processOrder`, it looks up that key and knows the payload is `{ orderId: string }`. Which is why this fails to compile:
 
 ```typescript
-processOrder: (_, { payload }) => {
+processOrder: ({ input: { payload } }) => {
   console.log(payload.orderNumber); // Property 'orderNumber' does not exist
   return OkAsync(undefined);
 };

--- a/docs/explanation/core-concepts.md
+++ b/docs/explanation/core-concepts.md
@@ -113,7 +113,7 @@ const orderMessage = defineMessage(z.object({ orderId: z.string() }));
 When the worker asks for `handlers.processOrder`, it looks up that key and knows the payload is `{ orderId: string }`. Which is why this fails to compile:
 
 ```typescript
-processOrder: ({ payload }) => {
+processOrder: (_, { payload }) => {
   console.log(payload.orderNumber); // Property 'orderNumber' does not exist
   return OkAsync(undefined);
 };

--- a/docs/explanation/delivery-guarantees.md
+++ b/docs/explanation/delivery-guarantees.md
@@ -58,7 +58,7 @@ await client
 A handler reads it from the raw message:
 
 ```typescript
-processOrder: ({ raw }, { payload }) => {
+processOrder: ({ raw, input: { payload } }) => {
   const { messageId } = raw.properties;
   const id = typeof messageId === "string" ? messageId : undefined;
   return upsertOrder(payload, id).map(() => undefined);

--- a/docs/explanation/delivery-guarantees.md
+++ b/docs/explanation/delivery-guarantees.md
@@ -58,8 +58,8 @@ await client
 A handler reads it from the raw message:
 
 ```typescript
-processOrder: ({ payload }, rawMessage) => {
-  const { messageId } = rawMessage.properties;
+processOrder: ({ raw }, { payload }) => {
+  const { messageId } = raw.properties;
   const id = typeof messageId === "string" ? messageId : undefined;
   return upsertOrder(payload, id).map(() => undefined);
 },

--- a/docs/explanation/the-retry-model.md
+++ b/docs/explanation/the-retry-model.md
@@ -22,7 +22,7 @@ Conflating them is the usual design, and it goes wrong in a familiar way: retry 
 So they are separated. The handler classifies:
 
 ```typescript
-processOrder: (_, { payload }) =>
+processOrder: ({ input: { payload } }) =>
   fromPromise(chargeCard(payload), (cause) =>
     cause instanceof CardDeclined
       ? new NonRetryableError("card declined", cause)

--- a/docs/explanation/the-retry-model.md
+++ b/docs/explanation/the-retry-model.md
@@ -22,7 +22,7 @@ Conflating them is the usual design, and it goes wrong in a familiar way: retry 
 So they are separated. The handler classifies:
 
 ```typescript
-processOrder: ({ payload }) =>
+processOrder: (_, { payload }) =>
   fromPromise(chargeCard(payload), (cause) =>
     cause instanceof CardDeclined
       ? new NonRetryableError("card declined", cause)

--- a/docs/explanation/why-amqp-contract.md
+++ b/docs/explanation/why-amqp-contract.md
@@ -101,7 +101,7 @@ An exception is a poor way to carry that decision. It has type `unknown`, it can
 So handlers return their outcome instead:
 
 ```typescript
-processOrder: (_, { payload }) =>
+processOrder: ({ input: { payload } }) =>
   fromPromise(chargeCard(payload), (cause) =>
     cause instanceof CardDeclined
       ? new NonRetryableError("declined", cause) // → dead letter

--- a/docs/explanation/why-amqp-contract.md
+++ b/docs/explanation/why-amqp-contract.md
@@ -101,7 +101,7 @@ An exception is a poor way to carry that decision. It has type `unknown`, it can
 So handlers return their outcome instead:
 
 ```typescript
-processOrder: ({ payload }) =>
+processOrder: (_, { payload }) =>
   fromPromise(chargeCard(payload), (cause) =>
     cause instanceof CardDeclined
       ? new NonRetryableError("declined", cause) // → dead letter

--- a/docs/how-to/add-logging.md
+++ b/docs/how-to/add-logging.md
@@ -102,7 +102,7 @@ const worker = await TypedAmqpWorker.create({
     }),
   }),
   handlers: {
-    processOrder: ({ context }, { payload }) => {
+    processOrder: ({ context, input: { payload } }) => {
       context.log.info({ orderId: payload.orderId }, "processing");
       return OkAsync(undefined);
     },

--- a/docs/how-to/add-logging.md
+++ b/docs/how-to/add-logging.md
@@ -102,7 +102,7 @@ const worker = await TypedAmqpWorker.create({
     }),
   }),
   handlers: {
-    processOrder: ({ payload }, _raw, { context }) => {
+    processOrder: ({ context }, { payload }) => {
       context.log.info({ orderId: payload.orderId }, "processing");
       return OkAsync(undefined);
     },

--- a/docs/how-to/add-middleware.md
+++ b/docs/how-to/add-middleware.md
@@ -14,7 +14,7 @@ Both take `(args, next)` and call `next()` to continue. Everything stays inside 
 
 ## Inject typed context into handlers
 
-A middleware proves something once and passes the result downstream. Handlers receive it as `helpers.context`, their third argument.
+A middleware proves something once and passes the result downstream. Handlers receive it as `helpers.context`, in their first argument.
 
 ```typescript
 import {
@@ -40,7 +40,7 @@ const worker = await TypedAmqpWorker.create({
   middleware: auth,
   handlers: {
     // context is typed { tenantId: string } — proven by the middleware
-    processOrder: ({ payload }, _raw, { context }) => processFor(context.tenantId, payload),
+    processOrder: ({ context }, { payload }) => processFor(context.tenantId, payload),
   },
   urls: ["amqp://localhost"],
 }).get();
@@ -84,7 +84,7 @@ const worker = await TypedAmqpWorker.create({
   middleware: auth, // seeded with { log, orderRepo }
   handlers: {
     // context: { log, orderRepo } & { tenantId: string }
-    processOrder: ({ payload }, _raw, { context }) => context.orderRepo.process(payload),
+    processOrder: ({ context }, { payload }) => context.orderRepo.process(payload),
   },
   urls: ["amqp://localhost"],
 }).get();
@@ -125,7 +125,7 @@ RPC handlers with a declared `errors` map get typed constructors in `helpers.err
 
 ```typescript
 handlers: {
-  getOrder: ({ payload }, _raw, { errors }) =>
+  getOrder: ({ errors }, { payload }) =>
     orders.has(payload.orderId)
       ? OkAsync(orders.get(payload.orderId))
       : ErrAsync(errors.ORDER_NOT_FOUND({ orderId: payload.orderId })),

--- a/docs/how-to/add-middleware.md
+++ b/docs/how-to/add-middleware.md
@@ -40,7 +40,7 @@ const worker = await TypedAmqpWorker.create({
   middleware: auth,
   handlers: {
     // context is typed { tenantId: string } — proven by the middleware
-    processOrder: ({ context }, { payload }) => processFor(context.tenantId, payload),
+    processOrder: ({ context, input: { payload } }) => processFor(context.tenantId, payload),
   },
   urls: ["amqp://localhost"],
 }).get();
@@ -84,7 +84,7 @@ const worker = await TypedAmqpWorker.create({
   middleware: auth, // seeded with { log, orderRepo }
   handlers: {
     // context: { log, orderRepo } & { tenantId: string }
-    processOrder: ({ context }, { payload }) => context.orderRepo.process(payload),
+    processOrder: ({ context, input: { payload } }) => context.orderRepo.process(payload),
   },
   urls: ["amqp://localhost"],
 }).get();
@@ -125,7 +125,7 @@ RPC handlers with a declared `errors` map get typed constructors in `helpers.err
 
 ```typescript
 handlers: {
-  getOrder: ({ errors }, { payload }) =>
+  getOrder: ({ errors, input: { payload } }) =>
     orders.has(payload.orderId)
       ? OkAsync(orders.get(payload.orderId))
       : ErrAsync(errors.ORDER_NOT_FOUND({ orderId: payload.orderId })),

--- a/docs/how-to/compress-messages.md
+++ b/docs/how-to/compress-messages.md
@@ -20,7 +20,7 @@ await client.publish("orderCreated", order, { compression: "gzip" });
 Nothing to do. The worker reads `contentEncoding`, decompresses, then validates and dispatches as usual:
 
 ```typescript
-processOrder: ({ payload }) => {
+processOrder: (_, { payload }) => {
   console.log(payload.items); // already decompressed
   return OkAsync(undefined);
 },

--- a/docs/how-to/compress-messages.md
+++ b/docs/how-to/compress-messages.md
@@ -20,7 +20,7 @@ await client.publish("orderCreated", order, { compression: "gzip" });
 Nothing to do. The worker reads `contentEncoding`, decompresses, then validates and dispatches as usual:
 
 ```typescript
-processOrder: (_, { payload }) => {
+processOrder: ({ input: { payload } }) => {
   console.log(payload.items); // already decompressed
   return OkAsync(undefined);
 },

--- a/docs/how-to/consume-messages.md
+++ b/docs/how-to/consume-messages.md
@@ -17,7 +17,7 @@ import { contract } from "./contract.js";
 const worker = await TypedAmqpWorker.create({
   contract,
   handlers: {
-    processOrder: ({ payload }) => {
+    processOrder: (_, { payload }) => {
       console.log(payload.orderId);
       return OkAsync(undefined);
     },
@@ -38,7 +38,7 @@ Handlers return `AsyncResult`, not `Promise`, so `async`/`await` is not availabl
 import { RetryableError } from "@amqp-contract/worker";
 import { fromPromise } from "unthrown";
 
-processOrder: ({ payload }) =>
+processOrder: (_, { payload }) =>
   fromPromise(
     saveOrder(payload),
     (cause) => new RetryableError("database unavailable", cause),
@@ -61,7 +61,7 @@ Choosing between the two is [the retry model](/explanation/the-retry-model); the
 ## Chain several async steps
 
 ```typescript
-processOrder: ({ payload }) =>
+processOrder: (_, { payload }) =>
   fromPromise(saveOrder(payload), qualifyRetryable("save failed"))
     .flatMap((order) => fromPromise(notify(order), qualifyRetryable("notify failed")))
     .map(() => undefined),
@@ -70,7 +70,7 @@ processOrder: ({ payload }) =>
 `flatMap` sequences dependent steps and short-circuits on the first failure. For independent steps, run them together:
 
 ```typescript
-processOrder: ({ payload }) =>
+processOrder: (_, { payload }) =>
   fromPromise(
     Promise.all([saveOrder(payload), sendConfirmation(payload.customerId)]),
     qualifyRetryable("order processing failed"),
@@ -85,7 +85,7 @@ Return `ErrAsync` directly when you can decide up front:
 import { NonRetryableError } from "@amqp-contract/worker";
 import { ErrAsync } from "unthrown";
 
-processOrder: ({ payload }) => {
+processOrder: (_, { payload }) => {
   if (payload.amount <= 0) {
     return ErrAsync(new NonRetryableError("non-positive amount"));
   }
@@ -98,7 +98,7 @@ processOrder: ({ payload }) => {
 Headers declared in the message's headers schema arrive validated and typed alongside the payload:
 
 ```typescript
-processOrder: ({ payload, headers }) => {
+processOrder: (_, { payload, headers }) => {
   console.log(headers.eventSource, headers.eventVersion);
   return OkAsync(undefined);
 },
@@ -106,12 +106,12 @@ processOrder: ({ payload, headers }) => {
 
 ## Reach the raw AMQP message
 
-The second argument is the underlying message — delivery tag, raw headers, redelivery flag:
+`raw`, in the helpers record, is the underlying delivery — delivery tag, raw headers, redelivery flag:
 
 ```typescript
-processOrder: ({ payload }, rawMessage) => {
-  console.log(rawMessage.fields.deliveryTag, rawMessage.fields.redelivered);
-  console.log(rawMessage.properties.correlationId);
+processOrder: ({ raw }, { payload }) => {
+  console.log(raw.fields.deliveryTag, raw.fields.redelivered);
+  console.log(raw.properties.correlationId);
   return OkAsync(undefined);
 },
 ```
@@ -128,7 +128,7 @@ import { declareHandler, qualifyRetryable } from "@amqp-contract/worker";
 import { fromPromise } from "unthrown";
 import { contract } from "../contract.js";
 
-export const processOrder = declareHandler(contract, "processOrder", ({ payload }) =>
+export const processOrder = declareHandler(contract, "processOrder", (_, { payload }) =>
   fromPromise(saveOrder(payload), qualifyRetryable("database unavailable")).map(() => undefined),
 );
 ```
@@ -165,7 +165,7 @@ Prefetch caps how many unacknowledged messages a consumer holds. Use the tuple f
 ```typescript
 handlers: {
   processOrder: [
-    ({ payload }) => fromPromise(save(payload), qualifyRetryable("save failed")).map(() => undefined),
+    (_, { payload }) => fromPromise(save(payload), qualifyRetryable("save failed")).map(() => undefined),
     { prefetch: 10 },
   ],
 },

--- a/docs/how-to/consume-messages.md
+++ b/docs/how-to/consume-messages.md
@@ -17,7 +17,7 @@ import { contract } from "./contract.js";
 const worker = await TypedAmqpWorker.create({
   contract,
   handlers: {
-    processOrder: (_, { payload }) => {
+    processOrder: ({ input: { payload } }) => {
       console.log(payload.orderId);
       return OkAsync(undefined);
     },
@@ -28,7 +28,7 @@ const worker = await TypedAmqpWorker.create({
 
 Creating the worker declares the contract's topology against the broker and starts consuming every queue in it. There is no separate `start()`.
 
-The message is on the helpers record as well as in the second parameter, so `({ message }) => …` and `(_, { payload }) => …` are the same call — oRPC's own shape, where `ProcedureHandlerOptions` carries `input` and the handler still takes it positionally. Take it whichever way reads better.
+The message is on the record as `input` as well as in the second parameter, so `({ input }) => …` and `({ errors }, message) => …` are the same call — oRPC's own shape, and its own word for it, where `ProcedureHandlerOptions` carries `input` and the handler still takes it positionally. Reach for the record: it is the one that needs no placeholder when a handler wants only its message.
 
 Every consumer in the contract must have a handler. Omit one and the object does not typecheck — and worker creation fails before any connection is acquired, so a missing handler surfaces immediately rather than as a silently unconsumed queue.
 
@@ -39,7 +39,7 @@ Handlers return `AsyncResult`, not `Promise`, so `async`/`await` is not availabl
 ```typescript
 import { fromPromise } from "unthrown";
 
-processOrder: ({ retryable }, { payload }) =>
+processOrder: ({ retryable, input: { payload } }) =>
   fromPromise(
     saveOrder(payload),
     (cause) => retryable("database unavailable", cause),
@@ -64,7 +64,7 @@ Choosing between the two is [the retry model](/explanation/the-retry-model); the
 ## Chain several async steps
 
 ```typescript
-processOrder: (_, { payload }) =>
+processOrder: ({ input: { payload } }) =>
   fromPromise(saveOrder(payload), qualifyRetryable("save failed"))
     .flatMap((order) => fromPromise(notify(order), qualifyRetryable("notify failed")))
     .map(() => undefined),
@@ -73,7 +73,7 @@ processOrder: (_, { payload }) =>
 `flatMap` sequences dependent steps and short-circuits on the first failure. For independent steps, run them together:
 
 ```typescript
-processOrder: (_, { payload }) =>
+processOrder: ({ input: { payload } }) =>
   fromPromise(
     Promise.all([saveOrder(payload), sendConfirmation(payload.customerId)]),
     qualifyRetryable("order processing failed"),
@@ -87,7 +87,7 @@ Return `ErrAsync` directly when you can decide up front:
 ```typescript
 import { ErrAsync } from "unthrown";
 
-processOrder: ({ nonRetryable }, { payload }) => {
+processOrder: ({ nonRetryable, input: { payload } }) => {
   if (payload.amount <= 0) {
     return ErrAsync(nonRetryable("non-positive amount"));
   }
@@ -100,7 +100,7 @@ processOrder: ({ nonRetryable }, { payload }) => {
 Headers declared in the message's headers schema arrive validated and typed alongside the payload:
 
 ```typescript
-processOrder: (_, { payload, headers }) => {
+processOrder: ({ input: { payload, headers } }) => {
   console.log(headers.eventSource, headers.eventVersion);
   return OkAsync(undefined);
 },
@@ -111,7 +111,7 @@ processOrder: (_, { payload, headers }) => {
 `raw`, in the helpers record, is the underlying delivery — delivery tag, raw headers, redelivery flag:
 
 ```typescript
-processOrder: ({ raw }, { payload }) => {
+processOrder: ({ raw, input: { payload } }) => {
   console.log(raw.fields.deliveryTag, raw.fields.redelivered);
   console.log(raw.properties.correlationId);
   return OkAsync(undefined);
@@ -130,7 +130,7 @@ import { declareHandler, qualifyRetryable } from "@amqp-contract/worker";
 import { fromPromise } from "unthrown";
 import { contract } from "../contract.js";
 
-export const processOrder = declareHandler(contract, "processOrder", (_, { payload }) =>
+export const processOrder = declareHandler(contract, "processOrder", ({ input: { payload } }) =>
   fromPromise(saveOrder(payload), qualifyRetryable("database unavailable")).map(() => undefined),
 );
 ```
@@ -167,7 +167,7 @@ Prefetch caps how many unacknowledged messages a consumer holds. Use the tuple f
 ```typescript
 handlers: {
   processOrder: [
-    (_, { payload }) => fromPromise(save(payload), qualifyRetryable("save failed")).map(() => undefined),
+    ({ input: { payload } }) => fromPromise(save(payload), qualifyRetryable("save failed")).map(() => undefined),
     { prefetch: 10 },
   ],
 },

--- a/docs/how-to/consume-messages.md
+++ b/docs/how-to/consume-messages.md
@@ -28,6 +28,8 @@ const worker = await TypedAmqpWorker.create({
 
 Creating the worker declares the contract's topology against the broker and starts consuming every queue in it. There is no separate `start()`.
 
+The message is on the helpers record as well as in the second parameter, so `({ message }) => …` and `(_, { payload }) => …` are the same call — oRPC's own shape, where `ProcedureHandlerOptions` carries `input` and the handler still takes it positionally. Take it whichever way reads better.
+
 Every consumer in the contract must have a handler. Omit one and the object does not typecheck — and worker creation fails before any connection is acquired, so a missing handler surfaces immediately rather than as a silently unconsumed queue.
 
 ## Do async work in a handler

--- a/docs/how-to/consume-messages.md
+++ b/docs/how-to/consume-messages.md
@@ -35,17 +35,18 @@ Every consumer in the contract must have a handler. Omit one and the object does
 Handlers return `AsyncResult`, not `Promise`, so `async`/`await` is not available. Lift the promise with `fromPromise` and say what a rejection means:
 
 ```typescript
-import { RetryableError } from "@amqp-contract/worker";
 import { fromPromise } from "unthrown";
 
-processOrder: (_, { payload }) =>
+processOrder: ({ retryable }, { payload }) =>
   fromPromise(
     saveOrder(payload),
-    (cause) => new RetryableError("database unavailable", cause),
+    (cause) => retryable("database unavailable", cause),
   ).map(() => undefined),
 ```
 
 The `.map(() => undefined)` discards the promise's value: a consumer handler must resolve to `void`.
+
+`retryable` and `nonRetryable` come off the helpers record, so the routing decision needs no import. The `RetryableError` / `NonRetryableError` classes are still exported for a handler that would rather construct them itself.
 
 The mapper is required. For the two common shapes there are prebuilt mappers:
 
@@ -82,12 +83,11 @@ processOrder: (_, { payload }) =>
 Return `ErrAsync` directly when you can decide up front:
 
 ```typescript
-import { NonRetryableError } from "@amqp-contract/worker";
 import { ErrAsync } from "unthrown";
 
-processOrder: (_, { payload }) => {
+processOrder: ({ nonRetryable }, { payload }) => {
   if (payload.amount <= 0) {
-    return ErrAsync(new NonRetryableError("non-positive amount"));
+    return ErrAsync(nonRetryable("non-positive amount"));
   }
   return fromPromise(saveOrder(payload), qualifyRetryable("save failed")).map(() => undefined);
 },
@@ -150,10 +150,10 @@ Note that `declareHandler`'s return type is a handler _entry_ — either the fun
 ```typescript
 import type { WorkerInferConsumerHandler } from "@amqp-contract/worker";
 
-export const processOrder: WorkerInferConsumerHandler<typeof contract, "processOrder"> = ({
-  payload,
-}) =>
-  fromPromise(saveOrder(payload), qualifyRetryable("database unavailable")).map(() => undefined);
+export const processOrder: WorkerInferConsumerHandler<typeof contract, "processOrder"> = (
+  _,
+  { payload },
+) => fromPromise(saveOrder(payload), qualifyRetryable("database unavailable")).map(() => undefined);
 ```
 
 This is still fully inferred from the contract, and it can be passed to `handlers` unchanged. Most handler testing is better done against a real broker — see [test with RabbitMQ](/how-to/test-with-rabbitmq).

--- a/docs/how-to/instrument-with-opentelemetry.md
+++ b/docs/how-to/instrument-with-opentelemetry.md
@@ -92,7 +92,7 @@ import { trace } from "@opentelemetry/api";
 
 const tracer = trace.getTracer("orders");
 
-processOrder: (_, { payload }) =>
+processOrder: ({ input: { payload } }) =>
   fromPromise(
     tracer.startActiveSpan("process-order", async (span) => {
       span.setAttribute("order.id", payload.orderId);

--- a/docs/how-to/instrument-with-opentelemetry.md
+++ b/docs/how-to/instrument-with-opentelemetry.md
@@ -92,7 +92,7 @@ import { trace } from "@opentelemetry/api";
 
 const tracer = trace.getTracer("orders");
 
-processOrder: ({ payload }) =>
+processOrder: (_, { payload }) =>
   fromPromise(
     tracer.startActiveSpan("process-order", async (span) => {
       span.setAttribute("order.id", payload.orderId);

--- a/docs/how-to/retry-failed-messages.md
+++ b/docs/how-to/retry-failed-messages.md
@@ -15,7 +15,7 @@ In the handler, map the underlying cause to one of two errors:
 import { NonRetryableError, RetryableError } from "@amqp-contract/worker";
 import { fromPromise } from "unthrown";
 
-processOrder: ({ payload }) =>
+processOrder: (_, { payload }) =>
   fromPromise(chargeCard(payload), (cause) => {
     // A declined card will be declined again. Don't spend retries on it.
     if (cause instanceof CardDeclined) {

--- a/docs/how-to/retry-failed-messages.md
+++ b/docs/how-to/retry-failed-messages.md
@@ -99,7 +99,8 @@ The supporting topology is derived for you at channel-setup time — one wait qu
 
 Per-delay wait queues are what make the schedule hold: RabbitMQ only expires messages at the head of a queue, so a single shared wait queue would let a parked 16s retry block a later 1s retry. With one queue per delay, a message's wait is bounded by its own tier — within a tier the skew is at most the jitter spread (jitter draws the actual delay from `[0.5x, 1.5x]` of the base, and the tier's queue-level TTL backstop is the jitter ceiling), and with `jitter: false` it is zero.
 
-One consequence of the retry hop: retried deliveries re-enter the main queue via the default exchange, so `rawMessage.fields.routingKey` is the queue name from the second attempt on. The routing key of the first delivery is preserved in the `x-original-routing-key` header.
+One consequence of the retry hop: retried deliveries re-enter the main queue via the default exchange, so `raw.fields.routingKey` — `raw` being the delivery on the handler's helpers
+record — is the queue name from the second attempt on. The routing key of the first delivery is preserved in the `x-original-routing-key` header.
 
 ## Turn retries off
 

--- a/docs/how-to/retry-failed-messages.md
+++ b/docs/how-to/retry-failed-messages.md
@@ -15,7 +15,7 @@ In the handler, map the underlying cause to one of two errors:
 import { NonRetryableError, RetryableError } from "@amqp-contract/worker";
 import { fromPromise } from "unthrown";
 
-processOrder: (_, { payload }) =>
+processOrder: ({ input: { payload } }) =>
   fromPromise(chargeCard(payload), (cause) => {
     // A declined card will be declined again. Don't spend retries on it.
     if (cause instanceof CardDeclined) {

--- a/docs/how-to/route-dead-letters.md
+++ b/docs/how-to/route-dead-letters.md
@@ -70,7 +70,7 @@ export const contract = defineContract({
 `failedOrder` exists to give the dead-letter consumer a payload type and a binding. Nothing publishes through it directly — the broker does the routing.
 
 ```typescript
-handleFailedOrders: ({ raw }, { payload }) => {
+handleFailedOrders: ({ raw, input: { payload } }) => {
   logger.error(
     { orderId: payload.orderId, death: raw.properties.headers?.["x-death"] },
     "order dead-lettered",
@@ -178,7 +178,7 @@ There is no built-in replay. Consume from the dead-letter queue and publish back
 import { NonRetryableError } from "@amqp-contract/worker";
 import { Err, OkAsync, P } from "unthrown";
 
-handleFailedOrders: (_, { payload }) =>
+handleFailedOrders: ({ input: { payload } }) =>
   shouldReplay(payload)
     ? client
         .publish("orderCreated", payload)

--- a/docs/how-to/route-dead-letters.md
+++ b/docs/how-to/route-dead-letters.md
@@ -70,9 +70,9 @@ export const contract = defineContract({
 `failedOrder` exists to give the dead-letter consumer a payload type and a binding. Nothing publishes through it directly — the broker does the routing.
 
 ```typescript
-handleFailedOrders: ({ payload }, rawMessage) => {
+handleFailedOrders: ({ raw }, { payload }) => {
   logger.error(
-    { orderId: payload.orderId, death: rawMessage.properties.headers?.["x-death"] },
+    { orderId: payload.orderId, death: raw.properties.headers?.["x-death"] },
     "order dead-lettered",
   );
   return OkAsync(undefined);
@@ -178,7 +178,7 @@ There is no built-in replay. Consume from the dead-letter queue and publish back
 import { NonRetryableError } from "@amqp-contract/worker";
 import { Err, OkAsync, P } from "unthrown";
 
-handleFailedOrders: ({ payload }) =>
+handleFailedOrders: (_, { payload }) =>
   shouldReplay(payload)
     ? client
         .publish("orderCreated", payload)

--- a/docs/how-to/share-connections.md
+++ b/docs/how-to/share-connections.md
@@ -36,7 +36,7 @@ The usual reason to want sharing. The subtlety is not the connection; it is that
 import { RetryableError } from "@amqp-contract/worker";
 import { Err, P } from "unthrown";
 
-processOrder: (_, { payload }) =>
+processOrder: ({ input: { payload } }) =>
   client
     .publish("orderProcessed", { orderId: payload.orderId, status: "completed" })
     .map(() => undefined)

--- a/docs/how-to/share-connections.md
+++ b/docs/how-to/share-connections.md
@@ -36,7 +36,7 @@ The usual reason to want sharing. The subtlety is not the connection; it is that
 import { RetryableError } from "@amqp-contract/worker";
 import { Err, P } from "unthrown";
 
-processOrder: ({ payload }) =>
+processOrder: (_, { payload }) =>
   client
     .publish("orderProcessed", { orderId: payload.orderId, status: "completed" })
     .map(() => undefined)

--- a/docs/how-to/test-with-rabbitmq.md
+++ b/docs/how-to/test-with-rabbitmq.md
@@ -57,7 +57,7 @@ describe("order worker", () => {
     const worker = await TypedAmqpWorker.create({
       contract,
       handlers: declareHandlers(contract, {
-        processOrder: (_, { payload }) => {
+        processOrder: ({ input: { payload } }) => {
           processed.push(payload);
           return OkAsync();
         },

--- a/docs/how-to/test-with-rabbitmq.md
+++ b/docs/how-to/test-with-rabbitmq.md
@@ -57,7 +57,7 @@ describe("order worker", () => {
     const worker = await TypedAmqpWorker.create({
       contract,
       handlers: declareHandlers(contract, {
-        processOrder: ({ payload }) => {
+        processOrder: (_, { payload }) => {
           processed.push(payload);
           return OkAsync();
         },

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -82,7 +82,7 @@ The payload type comes from the contract, so this means the contract disagrees w
 For a wildcard consumer receiving several message types, the payload is a union — narrow it before accessing anything type-specific:
 
 ```typescript
-notifyOrder: (_, { payload }) => {
+notifyOrder: ({ input: { payload } }) => {
   if ("items" in payload) {
     console.log(payload.items); // the full order
   } else {

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -82,7 +82,7 @@ The payload type comes from the contract, so this means the contract disagrees w
 For a wildcard consumer receiving several message types, the payload is a union — narrow it before accessing anything type-specific:
 
 ```typescript
-notifyOrder: ({ payload }) => {
+notifyOrder: (_, { payload }) => {
   if ("items" in payload) {
     console.log(payload.items); // the full order
   } else {

--- a/docs/how-to/upgrade.md
+++ b/docs/how-to/upgrade.md
@@ -376,17 +376,17 @@ a developer types by hand did not, and it is the one they relearn per transport.
     contract,
     handlers: {
 -     processOrder: ({ payload }) => save(payload),
-+     processOrder: (_, { payload }) => save(payload),
++     processOrder: ({ input: { payload } }) => save(payload),
 -     handleFailed: ({ payload }, rawMessage) => log(rawMessage.properties.headers),
-+     handleFailed: ({ raw }, { payload }) => log(raw.properties.headers),
++     handleFailed: ({ raw, input: { payload } }) => log(raw.properties.headers),
 -     getOrder: ({ payload }, _raw, { errors }) => lookup(payload, errors),
-+     getOrder: ({ errors }, { payload }) => lookup(payload, errors),
++     getOrder: ({ errors, input: { payload } }) => lookup(payload, errors),
     },
   }).get();
 ```
 
 A handler that needs none of the helpers still names the position:
-`(_, { payload }) => ...`. One that reads neither is just `() => ...`.
+`({ input: { payload } }) => ...`. One that reads neither is just `() => ...`.
 
 The message is on the helpers record too, so a handler can be written from one
 destructuring instead — `({ errors, message }) => ...`. That is oRPC's own
@@ -402,7 +402,7 @@ an import:
 -
 - processOrder: ({ payload }) =>
 -   fromPromise(save(payload), (cause) => new RetryableError("database unavailable", cause)),
-+ processOrder: ({ retryable }, { payload }) =>
++ processOrder: ({ retryable, input: { payload } }) =>
 +   fromPromise(save(payload), (cause) => retryable("database unavailable", cause)),
 ```
 

--- a/docs/how-to/upgrade.md
+++ b/docs/how-to/upgrade.md
@@ -388,6 +388,11 @@ a developer types by hand did not, and it is the one they relearn per transport.
 A handler that needs none of the helpers still names the position:
 `(_, { payload }) => ...`. One that reads neither is just `() => ...`.
 
+The message is on the helpers record too, so a handler can be written from one
+destructuring instead — `({ errors, message }) => ...`. That is oRPC's own
+shape: `ProcedureHandlerOptions` carries `input` and the handler still takes it
+positionally, and both spellings are the same call.
+
 **Two additions worth adopting while you are here.** The helpers record also
 carries `retryable` and `nonRetryable`, so the routing decision no longer needs
 an import:

--- a/docs/how-to/upgrade.md
+++ b/docs/how-to/upgrade.md
@@ -9,7 +9,7 @@ All six `@amqp-contract/*` packages version together, so upgrade them in lockste
 
 ## 2.4.x → 3.0
 
-Two independent breaking changes land together — `unthrown` v5 and the defect-channel move — plus three **safe defaults** that change runtime behaviour. Expect to touch every site that inspects a result.
+Two independent breaking changes land together — `unthrown` v5 and the defect-channel move — plus a handler-signature swap and three **safe defaults** that change runtime behaviour. Expect to touch every site that inspects a result, and every handler leaf.
 
 ::: danger Read this first: prefetch changed and nothing will tell you
 Of everything on this page, [consumers prefetch 10 by default](#consumers-prefetch-10-by-default) is the only change with **no compile error and no startup failure**. Your build stays green, your tests stay green, and your throughput profile changes. If you read one section, read that one.
@@ -355,6 +355,45 @@ Exported functions across the btravstack family now take at most two positional 
 
 `AmqpClient.publish` / `sendToQueue` also now return `AsyncResult<void, never>` instead of `AsyncResult<boolean, never>`: a full channel write buffer is triaged once, inside core, as a defect — downstream code no longer checks a boolean.
 
+### Handlers take helpers first, message second
+
+**What breaks:** every handler that reads its payload. The leaf's parameters
+swapped — the `{ context, errors, raw }` helpers record is the **first**
+argument now, the validated `{ payload, headers }` message the second, and the
+raw amqplib delivery moved from a third parameter into `raw` on the helpers.
+
+**Why:** oRPC is the reference shape for this family, being the most widely used
+of the three transports a `@btravstack/*` application composes — a developer
+arriving here has more likely seen `({ errors, context }, input)` than either of
+the others. The mint and compose calls already agreed across the three; the leaf
+a developer types by hand did not, and it is the one they relearn per transport.
+`@temporal-contract`'s activity leaf moved with it.
+
+**The exact edit:**
+
+```diff
+  const worker = await TypedAmqpWorker.create({
+    contract,
+    handlers: {
+-     processOrder: ({ payload }) => save(payload),
++     processOrder: (_, { payload }) => save(payload),
+-     handleFailed: ({ payload }, rawMessage) => log(rawMessage.properties.headers),
++     handleFailed: ({ raw }, { payload }) => log(raw.properties.headers),
+-     getOrder: ({ payload }, _raw, { errors }) => lookup(payload, errors),
++     getOrder: ({ errors }, { payload }) => lookup(payload, errors),
+    },
+  }).get();
+```
+
+A handler that needs none of the helpers still names the position:
+`(_, { payload }) => ...`. One that reads neither is just `() => ...`.
+
+**What the compiler does and does not catch:** a handler that reads its payload
+fails to compile, because the first parameter is the helpers record now. One
+that ignores its message keeps compiling with a parameter whose name lies —
+grep the handlers object for a leaf whose first parameter is not `_` or a
+helpers destructuring.
+
 ### Suggested order
 
 1. Bump `unthrown` and the six packages together.
@@ -362,8 +401,10 @@ Exported functions across the btravstack family now take at most two positional 
 3. Fix `create()` / `close()` extraction first; it is mechanical.
 4. Then convert each `match` / `*Err` site, moving `TechnicalError` handling into `defect` as you go.
 5. Resolve the `defineContract` dead-letter throws — both of them: the missing `deadLetter` pointer, and the exchange it names having nothing bound. Decide the broker route (new queue, policy, or accepted loss) _before_ editing the contract, since a live queue cannot take a `deadLetter`. Check each DLX's type on the broker before binding: `#` routes everything on a topic exchange and nothing on a direct one.
-6. Decide prefetch deliberately for every worker. It is the one change the compiler will not raise, so make it a review item rather than a discovery in production.
-7. Deploy workers before deleting the old `{queue}-wait` queue and `wait-exchange`/`retry-exchange` from the broker.
+6. Swap every handler leaf to `(helpers, message)` — the compiler names the
+   ones that read their payload; grep for the rest.
+7. Decide prefetch deliberately for every worker. It is the one change the compiler will not raise, so make it a review item rather than a discovery in production.
+8. Deploy workers before deleting the old `{queue}-wait` queue and `wait-exchange`/`retry-exchange` from the broker.
 
 ## 2.3.x → 2.4.x
 

--- a/docs/how-to/upgrade.md
+++ b/docs/how-to/upgrade.md
@@ -388,6 +388,22 @@ a developer types by hand did not, and it is the one they relearn per transport.
 A handler that needs none of the helpers still names the position:
 `(_, { payload }) => ...`. One that reads neither is just `() => ...`.
 
+**Two additions worth adopting while you are here.** The helpers record also
+carries `retryable` and `nonRetryable`, so the routing decision no longer needs
+an import:
+
+```diff
+- import { RetryableError } from "@amqp-contract/worker";
+-
+- processOrder: ({ payload }) =>
+-   fromPromise(save(payload), (cause) => new RetryableError("database unavailable", cause)),
++ processOrder: ({ retryable }, { payload }) =>
++   fromPromise(save(payload), (cause) => retryable("database unavailable", cause)),
+```
+
+The classes stay exported and `new RetryableError(...)` keeps working — this is
+the same value by a shorter route.
+
 **What the compiler does and does not catch:** a handler that reads its payload
 fails to compile, because the first parameter is the helpers record now. One
 that ignores its message keeps compiling with a parameter whose name lies —

--- a/docs/how-to/upgrade.md
+++ b/docs/how-to/upgrade.md
@@ -389,7 +389,7 @@ A handler that needs none of the helpers still names the position:
 `({ input: { payload } }) => ...`. One that reads neither is just `() => ...`.
 
 The message is on the helpers record too, so a handler can be written from one
-destructuring instead — `({ errors, message }) => ...`. That is oRPC's own
+destructuring instead — `({ errors, input }) => ...`. That is oRPC's own
 shape: `ProcedureHandlerOptions` carries `input` and the handler still takes it
 positionally, and both spellings are the same call.
 

--- a/docs/how-to/use-request-reply.md
+++ b/docs/how-to/use-request-reply.md
@@ -44,14 +44,14 @@ An RPC owns its queue and goes in `rpcs`, not in `publishers` or `consumers` —
 
 ```typescript
 handlers: {
-  calculate: (_, { payload }) => OkAsync({ sum: payload.a + payload.b }),
+  calculate: ({ input: { payload } }) => OkAsync({ sum: payload.a + payload.b }),
 },
 ```
 
 The returned value is the reply, typed by the response schema. Async work looks the same as in a consumer:
 
 ```typescript
-calculate: (_, { payload }) =>
+calculate: ({ input: { payload } }) =>
   fromPromise(lookupRate(payload), qualifyRetryable("rate service down")).map((rate) => ({
     sum: payload.a * rate,
   })),
@@ -100,7 +100,7 @@ Return one from the handler:
 ```typescript
 import { rpcError } from "@amqp-contract/worker";
 
-getOrder: (_, { payload }) => {
+getOrder: ({ input: { payload } }) => {
   const order = orders.get(payload.orderId);
   return order
     ? OkAsync({ orderId: order.id, status: order.status })
@@ -111,7 +111,7 @@ getOrder: (_, { payload }) => {
 Or, with autocomplete over the declared codes, via `helpers.errors`:
 
 ```typescript
-getOrder: ({ errors }, { payload }) =>
+getOrder: ({ errors, input: { payload } }) =>
   ErrAsync(errors.ORDER_NOT_FOUND({ orderId: payload.orderId })),
 ```
 

--- a/docs/how-to/use-request-reply.md
+++ b/docs/how-to/use-request-reply.md
@@ -44,14 +44,14 @@ An RPC owns its queue and goes in `rpcs`, not in `publishers` or `consumers` —
 
 ```typescript
 handlers: {
-  calculate: ({ payload }) => OkAsync({ sum: payload.a + payload.b }),
+  calculate: (_, { payload }) => OkAsync({ sum: payload.a + payload.b }),
 },
 ```
 
 The returned value is the reply, typed by the response schema. Async work looks the same as in a consumer:
 
 ```typescript
-calculate: ({ payload }) =>
+calculate: (_, { payload }) =>
   fromPromise(lookupRate(payload), qualifyRetryable("rate service down")).map((rate) => ({
     sum: payload.a * rate,
   })),
@@ -100,7 +100,7 @@ Return one from the handler:
 ```typescript
 import { rpcError } from "@amqp-contract/worker";
 
-getOrder: ({ payload }) => {
+getOrder: (_, { payload }) => {
   const order = orders.get(payload.orderId);
   return order
     ? OkAsync({ orderId: order.id, status: order.status })
@@ -111,7 +111,7 @@ getOrder: ({ payload }) => {
 Or, with autocomplete over the declared codes, via `helpers.errors`:
 
 ```typescript
-getOrder: ({ payload }, _raw, { errors }) =>
+getOrder: ({ errors }, { payload }) =>
   ErrAsync(errors.ORDER_NOT_FOUND({ orderId: payload.orderId })),
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,7 +117,7 @@ import { contract } from "./contract.js";
 const worker = await TypedAmqpWorker.create({
   contract,
   handlers: {
-    processOrder: (_, { payload }) => {
+    processOrder: ({ input: { payload } }) => {
       console.log(payload.orderId); // ✅ Fully typed!
       return OkAsync();
     },

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,7 +117,7 @@ import { contract } from "./contract.js";
 const worker = await TypedAmqpWorker.create({
   contract,
   handlers: {
-    processOrder: ({ payload }) => {
+    processOrder: (_, { payload }) => {
       console.log(payload.orderId); // ✅ Fully typed!
       return OkAsync();
     },

--- a/docs/tutorial/adding-request-reply.md
+++ b/docs/tutorial/adding-request-reply.md
@@ -131,7 +131,7 @@ export const contract = defineContract({
 The worker gains one handler. Add it to the `handlers` object in `consumer.ts`:
 
 ```typescript
-    checkAddress: ({ payload }) => {
+    checkAddress: (_, { payload }) => {
       const deliverable = payload.address.endsWith("@example.com");
       return OkAsync({
         deliverable,
@@ -257,7 +257,7 @@ import { ErrAsync, OkAsync } from "unthrown";
 ```
 
 ```typescript
-    checkAddress: ({ payload }) => {
+    checkAddress: (_, { payload }) => {
       if (!payload.address.includes("@")) {
         return ErrAsync(
           rpcError("MALFORMED_ADDRESS", { address: payload.address }, "missing @"),

--- a/docs/tutorial/adding-request-reply.md
+++ b/docs/tutorial/adding-request-reply.md
@@ -131,7 +131,7 @@ export const contract = defineContract({
 The worker gains one handler. Add it to the `handlers` object in `consumer.ts`:
 
 ```typescript
-    checkAddress: (_, { payload }) => {
+    checkAddress: ({ input: { payload } }) => {
       const deliverable = payload.address.endsWith("@example.com");
       return OkAsync({
         deliverable,
@@ -257,7 +257,7 @@ import { ErrAsync, OkAsync } from "unthrown";
 ```
 
 ```typescript
-    checkAddress: (_, { payload }) => {
+    checkAddress: ({ input: { payload } }) => {
       if (!payload.address.includes("@")) {
         return ErrAsync(
           rpcError("MALFORMED_ADDRESS", { address: payload.address }, "missing @"),

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -185,7 +185,7 @@ import { contract } from "./contract.js";
 const worker = await TypedAmqpWorker.create({
   contract,
   handlers: {
-    processEmail: ({ payload }) => {
+    processEmail: (_, { payload }) => {
       console.log("Received an email to send:");
       console.log(`  To:      ${payload.to}`);
       console.log(`  Subject: ${payload.subject}`);

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -185,7 +185,7 @@ import { contract } from "./contract.js";
 const worker = await TypedAmqpWorker.create({
   contract,
   handlers: {
-    processEmail: (_, { payload }) => {
+    processEmail: ({ input: { payload } }) => {
       console.log("Received an email to send:");
       console.log(`  To:      ${payload.to}`);
       console.log(`  Subject: ${payload.subject}`);

--- a/examples/basic-order-processing-worker/README.md
+++ b/examples/basic-order-processing-worker/README.md
@@ -30,11 +30,11 @@ Handlers are defined directly in the worker creation. This approach is suitable 
 const worker = await TypedAmqpWorker.create({
   contract: orderContract,
   handlers: {
-    processOrder: ({ payload }) => {
+    processOrder: (_, { payload }) => {
       // Handler logic here
       return OkAsync(undefined);
     },
-    notifyOrder: ({ payload }) => {
+    notifyOrder: (_, { payload }) => {
       // Handler logic here
       return OkAsync(undefined);
     },
@@ -54,10 +54,14 @@ Handlers can be organized in separate files using `declareHandler` or `declareHa
 
 ```typescript
 // handlers.ts
-export const processOrderHandler = declareHandler(orderContract, "processOrder", ({ payload }) => {
-  // Handler logic here
-  return OkAsync(undefined);
-});
+export const processOrderHandler = declareHandler(
+  orderContract,
+  "processOrder",
+  (_, { payload }) => {
+    // Handler logic here
+    return OkAsync(undefined);
+  },
+);
 
 // index.ts - to use external handlers, import them:
 import { processOrderHandler /* other handlers */ } from "./handlers.js";

--- a/examples/basic-order-processing-worker/README.md
+++ b/examples/basic-order-processing-worker/README.md
@@ -30,11 +30,11 @@ Handlers are defined directly in the worker creation. This approach is suitable 
 const worker = await TypedAmqpWorker.create({
   contract: orderContract,
   handlers: {
-    processOrder: (_, { payload }) => {
+    processOrder: ({ input: { payload } }) => {
       // Handler logic here
       return OkAsync(undefined);
     },
-    notifyOrder: (_, { payload }) => {
+    notifyOrder: ({ input: { payload } }) => {
       // Handler logic here
       return OkAsync(undefined);
     },
@@ -57,7 +57,7 @@ Handlers can be organized in separate files using `declareHandler` or `declareHa
 export const processOrderHandler = declareHandler(
   orderContract,
   "processOrder",
-  (_, { payload }) => {
+  ({ input: { payload } }) => {
     // Handler logic here
     return OkAsync(undefined);
   },

--- a/examples/basic-order-processing-worker/src/index.spec.ts
+++ b/examples/basic-order-processing-worker/src/index.spec.ts
@@ -14,7 +14,7 @@ describe("Basic Order Processing Worker Integration", () => {
     const worker = await TypedAmqpWorker.create({
       contract: orderContract,
       handlers: declareHandlers(orderContract, {
-        processOrder: (_, { payload }) => {
+        processOrder: ({ input: { payload } }) => {
           processedOrders.push(payload);
           return OkAsync(undefined);
         },
@@ -68,7 +68,7 @@ describe("Basic Order Processing Worker Integration", () => {
       contract: orderContract,
       handlers: declareHandlers(orderContract, {
         processOrder: () => OkAsync(undefined),
-        notifyOrder: (_, { payload }) => {
+        notifyOrder: ({ input: { payload } }) => {
           notifications.push(payload);
           return OkAsync(undefined);
         },
@@ -135,11 +135,11 @@ describe("Basic Order Processing Worker Integration", () => {
     const workerResult = await TypedAmqpWorker.create({
       contract: orderContract,
       handlers: declareHandlers(orderContract, {
-        processOrder: (_, { payload }) => {
+        processOrder: ({ input: { payload } }) => {
           processedOrders.push(payload);
           return OkAsync(undefined);
         },
-        notifyOrder: (_, { payload }) => {
+        notifyOrder: ({ input: { payload } }) => {
           notifications.push(payload);
           return OkAsync(undefined);
         },
@@ -198,7 +198,7 @@ describe("Basic Order Processing Worker Integration", () => {
         shipOrder: () => OkAsync(undefined),
         handleUrgentOrder: () => OkAsync(undefined),
         handleFailedOrders: () => OkAsync(undefined),
-        fulfillOrder: (_, { payload }) => {
+        fulfillOrder: ({ input: { payload } }) => {
           fulfilled.push(payload);
           return OkAsync(undefined);
         },

--- a/examples/basic-order-processing-worker/src/index.spec.ts
+++ b/examples/basic-order-processing-worker/src/index.spec.ts
@@ -14,7 +14,7 @@ describe("Basic Order Processing Worker Integration", () => {
     const worker = await TypedAmqpWorker.create({
       contract: orderContract,
       handlers: declareHandlers(orderContract, {
-        processOrder: ({ payload }) => {
+        processOrder: (_, { payload }) => {
           processedOrders.push(payload);
           return OkAsync(undefined);
         },
@@ -68,7 +68,7 @@ describe("Basic Order Processing Worker Integration", () => {
       contract: orderContract,
       handlers: declareHandlers(orderContract, {
         processOrder: () => OkAsync(undefined),
-        notifyOrder: ({ payload }) => {
+        notifyOrder: (_, { payload }) => {
           notifications.push(payload);
           return OkAsync(undefined);
         },
@@ -135,11 +135,11 @@ describe("Basic Order Processing Worker Integration", () => {
     const workerResult = await TypedAmqpWorker.create({
       contract: orderContract,
       handlers: declareHandlers(orderContract, {
-        processOrder: ({ payload }) => {
+        processOrder: (_, { payload }) => {
           processedOrders.push(payload);
           return OkAsync(undefined);
         },
-        notifyOrder: ({ payload }) => {
+        notifyOrder: (_, { payload }) => {
           notifications.push(payload);
           return OkAsync(undefined);
         },
@@ -198,7 +198,7 @@ describe("Basic Order Processing Worker Integration", () => {
         shipOrder: () => OkAsync(undefined),
         handleUrgentOrder: () => OkAsync(undefined),
         handleFailedOrders: () => OkAsync(undefined),
-        fulfillOrder: ({ payload }) => {
+        fulfillOrder: (_, { payload }) => {
           fulfilled.push(payload);
           return OkAsync(undefined);
         },

--- a/examples/basic-order-processing-worker/src/index.ts
+++ b/examples/basic-order-processing-worker/src/index.ts
@@ -27,7 +27,7 @@ async function main() {
     contract: orderContract,
     handlers: declareHandlers(orderContract, {
       // Handler for processing NEW orders (order.created)
-      processOrder: ({ payload, headers }) => {
+      processOrder: (_, { payload, headers }) => {
         logger.info(
           {
             orderId: payload.orderId,
@@ -52,7 +52,7 @@ async function main() {
       },
 
       // Handler for ALL order notifications (order.#)
-      notifyOrder: ({ payload }) => {
+      notifyOrder: (_, { payload }) => {
         // Check if it's a new order or a status update
         if ("items" in payload) {
           // It's a full order
@@ -87,7 +87,7 @@ async function main() {
       },
 
       // Handler for SHIPPED orders (order.shipped)
-      shipOrder: ({ payload }) => {
+      shipOrder: (_, { payload }) => {
         logger.info(
           {
             orderId: payload.orderId,
@@ -106,7 +106,7 @@ async function main() {
       },
 
       // Handler for URGENT orders (order.*.urgent)
-      handleUrgentOrder: ({ payload }) => {
+      handleUrgentOrder: (_, { payload }) => {
         logger.warn(
           {
             orderId: payload.orderId,
@@ -126,7 +126,7 @@ async function main() {
 
       // Command handler (task queue): the fulfillment worker owns this queue.
       // Unlike the event handlers above, this command reaches exactly one worker.
-      fulfillOrder: ({ payload }) => {
+      fulfillOrder: (_, { payload }) => {
         logger.info(
           {
             orderId: payload.orderId,
@@ -145,7 +145,7 @@ async function main() {
       },
 
       // Handler for FAILED orders (from dead letter exchange)
-      handleFailedOrders: ({ payload }) => {
+      handleFailedOrders: (_, { payload }) => {
         logger.error(
           {
             orderId: payload.orderId,

--- a/examples/basic-order-processing-worker/src/index.ts
+++ b/examples/basic-order-processing-worker/src/index.ts
@@ -27,7 +27,7 @@ async function main() {
     contract: orderContract,
     handlers: declareHandlers(orderContract, {
       // Handler for processing NEW orders (order.created)
-      processOrder: (_, { payload, headers }) => {
+      processOrder: ({ input: { payload, headers } }) => {
         logger.info(
           {
             orderId: payload.orderId,
@@ -52,7 +52,7 @@ async function main() {
       },
 
       // Handler for ALL order notifications (order.#)
-      notifyOrder: (_, { payload }) => {
+      notifyOrder: ({ input: { payload } }) => {
         // Check if it's a new order or a status update
         if ("items" in payload) {
           // It's a full order
@@ -87,7 +87,7 @@ async function main() {
       },
 
       // Handler for SHIPPED orders (order.shipped)
-      shipOrder: (_, { payload }) => {
+      shipOrder: ({ input: { payload } }) => {
         logger.info(
           {
             orderId: payload.orderId,
@@ -106,7 +106,7 @@ async function main() {
       },
 
       // Handler for URGENT orders (order.*.urgent)
-      handleUrgentOrder: (_, { payload }) => {
+      handleUrgentOrder: ({ input: { payload } }) => {
         logger.warn(
           {
             orderId: payload.orderId,
@@ -126,7 +126,7 @@ async function main() {
 
       // Command handler (task queue): the fulfillment worker owns this queue.
       // Unlike the event handlers above, this command reaches exactly one worker.
-      fulfillOrder: (_, { payload }) => {
+      fulfillOrder: ({ input: { payload } }) => {
         logger.info(
           {
             orderId: payload.orderId,
@@ -145,7 +145,7 @@ async function main() {
       },
 
       // Handler for FAILED orders (from dead letter exchange)
-      handleFailedOrders: (_, { payload }) => {
+      handleFailedOrders: ({ input: { payload } }) => {
         logger.error(
           {
             orderId: payload.orderId,

--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -124,7 +124,7 @@ const contract = defineContract({
 });
 
 // Server handler returns the response value, not void:
-//   handlers: { calculate: ({ payload }) => OkAsync({ sum: payload.a + payload.b }) }
+//   handlers: { calculate: (_, { payload }) => OkAsync({ sum: payload.a + payload.b }) }
 //
 // Client invokes with a required timeout:
 //   const result = await client.call("calculate", { a: 1, b: 2 }, { timeoutMs: 5_000 });

--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -124,7 +124,7 @@ const contract = defineContract({
 });
 
 // Server handler returns the response value, not void:
-//   handlers: { calculate: (_, { payload }) => OkAsync({ sum: payload.a + payload.b }) }
+//   handlers: { calculate: ({ input: { payload } }) => OkAsync({ sum: payload.a + payload.b }) }
 //
 // Client invokes with a required timeout:
 //   const result = await client.call("calculate", { a: 1, b: 2 }, { timeoutMs: 5_000 });

--- a/packages/contract/src/builder/consumer.ts
+++ b/packages/contract/src/builder/consumer.ts
@@ -107,7 +107,7 @@ export function extractConsumer(entry: ConsumerEntry): ConsumerDefinition {
  * // const worker = await TypedAmqpWorker.create({
  * //   contract,
  * //   handlers: {
- * //     processOrder: (_, { payload }) => {
+ * //     processOrder: ({ input: { payload } }) => {
  * //       // payload is automatically typed based on the schema
  * //       console.log(payload.orderId); // string
  * //       return OkAsync();

--- a/packages/contract/src/builder/consumer.ts
+++ b/packages/contract/src/builder/consumer.ts
@@ -107,7 +107,7 @@ export function extractConsumer(entry: ConsumerEntry): ConsumerDefinition {
  * // const worker = await TypedAmqpWorker.create({
  * //   contract,
  * //   handlers: {
- * //     processOrder: ({ payload }) => {
+ * //     processOrder: (_, { payload }) => {
  * //       // payload is automatically typed based on the schema
  * //       console.log(payload.orderId); // string
  * //       return OkAsync();

--- a/packages/contract/src/builder/contract.ts
+++ b/packages/contract/src/builder/contract.ts
@@ -132,7 +132,7 @@ function addResource<T>(
  * // - contract.queues['order-processing']
  * // - contract.bindings.processOrderBinding
  * // - client.publish('orderCreated', { orderId: string, amount: number })
- * // - handler: ({ payload }: { payload: { orderId: string, amount: number } }) => AsyncResult<void, HandlerError>
+ * // - handler: (_, { payload }: { payload: { orderId: string, amount: number } }) => AsyncResult<void, HandlerError>
  * ```
  */
 export function defineContract<TContract extends ContractDefinitionInput>(

--- a/packages/contract/src/builder/contract.ts
+++ b/packages/contract/src/builder/contract.ts
@@ -132,7 +132,7 @@ function addResource<T>(
  * // - contract.queues['order-processing']
  * // - contract.bindings.processOrderBinding
  * // - client.publish('orderCreated', { orderId: string, amount: number })
- * // - handler: (_, { payload }: { payload: { orderId: string, amount: number } }) => AsyncResult<void, HandlerError>
+ * // - handler: ({ input: { payload }: { payload: { orderId: string, amount: number } } }) => AsyncResult<void, HandlerError>
  * ```
  */
 export function defineContract<TContract extends ContractDefinitionInput>(

--- a/packages/contract/src/builder/rpc.ts
+++ b/packages/contract/src/builder/rpc.ts
@@ -44,7 +44,7 @@ import { _internal_assertKnownKeys, _internal_assertStandardSchema } from "./val
  *
  * // Server (worker): return the response, or a declared typed error
  * //   handlers: {
- * //     getOrder: (_, { payload }) =>
+ * //     getOrder: ({ input: { payload } }) =>
  * //       orders.has(payload.orderId)
  * //         ? OkAsync(orders.get(payload.orderId))
  * //         : ErrAsync(rpcError('ORDER_NOT_FOUND', { orderId: payload.orderId })),

--- a/packages/contract/src/builder/rpc.ts
+++ b/packages/contract/src/builder/rpc.ts
@@ -44,7 +44,7 @@ import { _internal_assertKnownKeys, _internal_assertStandardSchema } from "./val
  *
  * // Server (worker): return the response, or a declared typed error
  * //   handlers: {
- * //     getOrder: ({ payload }) =>
+ * //     getOrder: (_, { payload }) =>
  * //       orders.has(payload.orderId)
  * //         ? OkAsync(orders.get(payload.orderId))
  * //         : ErrAsync(rpcError('ORDER_NOT_FOUND', { orderId: payload.orderId })),

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -157,7 +157,7 @@ export function isRpcError(error: unknown): error is RpcError {
  * import { rpcError } from '@amqp-contract/worker';
  * import { ErrAsync } from 'unthrown';
  *
- * const handler = ({ payload }) => {
+ * const handler = (_, { payload }) => {
  *   if (!orders.has(payload.orderId)) {
  *     return ErrAsync(rpcError('ORDER_NOT_FOUND', { orderId: payload.orderId }));
  *   }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -157,7 +157,7 @@ export function isRpcError(error: unknown): error is RpcError {
  * import { rpcError } from '@amqp-contract/worker';
  * import { ErrAsync } from 'unthrown';
  *
- * const handler = (_, { payload }) => {
+ * const handler = ({ input: { payload } }) => {
  *   if (!orders.has(payload.orderId)) {
  *     return ErrAsync(rpcError('ORDER_NOT_FOUND', { orderId: payload.orderId }));
  *   }

--- a/packages/worker/README.md
+++ b/packages/worker/README.md
@@ -45,7 +45,7 @@ const logger: Logger = {
 const worker = await TypedAmqpWorker.create({
   contract,
   handlers: {
-    processOrder: ({ payload }) => {
+    processOrder: (_, { payload }) => {
       console.log("Processing order:", payload.orderId);
 
       // Your business logic here
@@ -111,7 +111,7 @@ import { fromPromise } from "unthrown";
 const worker = await TypedAmqpWorker.create({
   contract,
   handlers: {
-    processOrder: ({ payload }) =>
+    processOrder: (_, { payload }) =>
       // If this fails with RetryableError, message is automatically retried
       fromPromise(
         processPayment(payload),
@@ -137,7 +137,7 @@ import { RetryableError, NonRetryableError } from "@amqp-contract/worker";
 import { ErrAsync, fromPromise } from "unthrown";
 
 handlers: {
-  processOrder: ({ payload }) => {
+  processOrder: (_, { payload }) => {
     // Validation errors - non-retryable
     if (payload.amount <= 0) {
       return ErrAsync(new NonRetryableError("Invalid amount"));

--- a/packages/worker/README.md
+++ b/packages/worker/README.md
@@ -45,7 +45,7 @@ const logger: Logger = {
 const worker = await TypedAmqpWorker.create({
   contract,
   handlers: {
-    processOrder: (_, { payload }) => {
+    processOrder: ({ input: { payload } }) => {
       console.log("Processing order:", payload.orderId);
 
       // Your business logic here
@@ -111,7 +111,7 @@ import { fromPromise } from "unthrown";
 const worker = await TypedAmqpWorker.create({
   contract,
   handlers: {
-    processOrder: (_, { payload }) =>
+    processOrder: ({ input: { payload } }) =>
       // If this fails with RetryableError, message is automatically retried
       fromPromise(
         processPayment(payload),
@@ -137,7 +137,7 @@ import { RetryableError, NonRetryableError } from "@amqp-contract/worker";
 import { ErrAsync, fromPromise } from "unthrown";
 
 handlers: {
-  processOrder: (_, { payload }) => {
+  processOrder: ({ input: { payload } }) => {
     // Validation errors - non-retryable
     if (payload.amount <= 0) {
       return ErrAsync(new NonRetryableError("Invalid amount"));

--- a/packages/worker/src/__tests__/worker-double-ack.spec.ts
+++ b/packages/worker/src/__tests__/worker-double-ack.spec.ts
@@ -89,7 +89,7 @@ describe("Worker defensive nack guard", () => {
     const worker = await TypedAmqpWorker.create({
       contract,
       handlers: {
-        testConsumer: ({ payload }) => {
+        testConsumer: (_, { payload }) => {
           processed.push(payload.id);
           return OkAsync(undefined);
         },

--- a/packages/worker/src/__tests__/worker-double-ack.spec.ts
+++ b/packages/worker/src/__tests__/worker-double-ack.spec.ts
@@ -89,7 +89,7 @@ describe("Worker defensive nack guard", () => {
     const worker = await TypedAmqpWorker.create({
       contract,
       handlers: {
-        testConsumer: (_, { payload }) => {
+        testConsumer: ({ input: { payload } }) => {
           processed.push(payload.id);
           return OkAsync(undefined);
         },

--- a/packages/worker/src/__tests__/worker-middleware-context.spec.ts
+++ b/packages/worker/src/__tests__/worker-middleware-context.spec.ts
@@ -73,7 +73,7 @@ describe("Worker middleware context merge", () => {
       createContext: () => ({ fromSeed: "seed" }),
       middleware: injectingMiddleware,
       handlers: {
-        testConsumer: (_message, _raw, { context }) => {
+        testConsumer: ({ context }) => {
           seen.push(context);
           return OkAsync();
         },
@@ -111,7 +111,7 @@ describe("Worker middleware context merge", () => {
       // so a typed middleware needs the AnyWorkerMiddleware cast here.
       middleware: [injectingMiddleware as AnyWorkerMiddleware],
       handlers: {
-        testConsumer: (_message, _raw, { context }) => {
+        testConsumer: ({ context }) => {
           seen.push(context);
           return OkAsync();
         },

--- a/packages/worker/src/__tests__/worker-retry-head-of-line.spec.ts
+++ b/packages/worker/src/__tests__/worker-retry-head-of-line.spec.ts
@@ -66,7 +66,7 @@ describe("TTL-backoff head-of-line blocking", () => {
     let bAttempts = 0;
 
     await workerFactory(contract, {
-      testConsumer: (_, { payload }) => {
+      testConsumer: ({ input: { payload } }) => {
         deliveries.push({ id: payload.id, at: Date.now() });
         if (payload.id === "A") {
           aAttempts++;

--- a/packages/worker/src/__tests__/worker-retry-head-of-line.spec.ts
+++ b/packages/worker/src/__tests__/worker-retry-head-of-line.spec.ts
@@ -66,7 +66,7 @@ describe("TTL-backoff head-of-line blocking", () => {
     let bAttempts = 0;
 
     await workerFactory(contract, {
-      testConsumer: ({ payload }) => {
+      testConsumer: (_, { payload }) => {
         deliveries.push({ id: payload.id, at: Date.now() });
         if (payload.id === "A") {
           aAttempts++;

--- a/packages/worker/src/__tests__/worker-retry.spec.ts
+++ b/packages/worker/src/__tests__/worker-retry.spec.ts
@@ -946,7 +946,7 @@ describe("Worker Retry Mechanism", () => {
         const firstFailureTimestampHeaders: number[] = [];
 
         await workerFactory(contract, {
-          testConsumer: (_, msg) => {
+          testConsumer: ({ raw: msg }) => {
             attemptCount++;
             const retryCount = (msg.properties.headers?.["x-retry-count"] as number) ?? 0;
             const lastError = msg.properties.headers?.["x-last-error"] as string | undefined;
@@ -1157,7 +1157,7 @@ describe("Worker Retry Mechanism", () => {
       const capturedOriginalRoutingKeys: Array<unknown> = [];
 
       await workerFactory(contract, {
-        testConsumer: (_, msg) => {
+        testConsumer: ({ raw: msg }) => {
           attemptCount++;
           capturedRoutingKeys.push(msg.fields.routingKey);
           capturedOriginalRoutingKeys.push(msg.properties.headers?.["x-original-routing-key"]);

--- a/packages/worker/src/__tests__/worker-retry.spec.ts
+++ b/packages/worker/src/__tests__/worker-retry.spec.ts
@@ -64,10 +64,13 @@ describe("Worker Retry Mechanism", () => {
 
       let attemptCount = 0;
       await workerFactory(contract, {
-        testConsumer: () => {
+        // `retryable` off the helpers record rather than the imported class:
+        // the same routing has to follow from the constructor the handler was
+        // HANDED, or handing it over buys nothing.
+        testConsumer: ({ retryable }) => {
           attemptCount++;
           if (attemptCount === 1) {
-            return ErrAsync(new RetryableError("First attempt failed"));
+            return ErrAsync(retryable("First attempt failed"));
           }
           return OkAsync(undefined);
         },
@@ -1045,10 +1048,13 @@ describe("Worker Retry Mechanism", () => {
 
       let attemptCount = 0;
       await workerFactory(contract, {
-        testConsumer: () => {
+        // `retryable` off the helpers record rather than the imported class:
+        // the same routing has to follow from the constructor the handler was
+        // HANDED, or handing it over buys nothing.
+        testConsumer: ({ retryable }) => {
           attemptCount++;
           if (attemptCount === 1) {
-            return ErrAsync(new RetryableError("First attempt failed"));
+            return ErrAsync(retryable("First attempt failed"));
           }
           return OkAsync(undefined);
         },

--- a/packages/worker/src/__tests__/worker.spec.ts
+++ b/packages/worker/src/__tests__/worker.spec.ts
@@ -58,7 +58,7 @@ describe("AmqpWorker Integration", () => {
     await workerFactory(
       contract,
       declareHandlers(contract, {
-        testConsumer: ({ payload }) => {
+        testConsumer: (_, { payload }) => {
           messages.push(payload);
           return OkAsync(undefined);
         },
@@ -117,7 +117,7 @@ describe("AmqpWorker Integration", () => {
     await workerFactory(
       contract,
       declareHandlers(contract, {
-        testConsumer: ({ payload }) => {
+        testConsumer: (_, { payload }) => {
           messages.push(payload);
           return OkAsync(undefined);
         },
@@ -181,7 +181,7 @@ describe("AmqpWorker Integration", () => {
     await workerFactory(
       contract,
       declareHandlers(contract, {
-        testConsumer: ({ payload, headers }) => {
+        testConsumer: (_, { payload, headers }) => {
           messages.push(payload);
           messageHeaders.push(headers);
           return OkAsync(undefined);
@@ -253,7 +253,7 @@ describe("AmqpWorker Integration", () => {
     await workerFactory(
       contract,
       declareHandlers(contract, {
-        testConsumer: ({ payload }) => {
+        testConsumer: (_, { payload }) => {
           messages.push(payload);
           return OkAsync(undefined);
         },
@@ -313,11 +313,11 @@ describe("AmqpWorker Integration", () => {
     await workerFactory(
       contract,
       declareHandlers(contract, {
-        consumer1: ({ payload }) => {
+        consumer1: (_, { payload }) => {
           messages1.push(payload);
           return OkAsync(undefined);
         },
-        consumer2: ({ payload }) => {
+        consumer2: (_, { payload }) => {
           messages2.push(payload);
           return OkAsync(undefined);
         },
@@ -372,7 +372,7 @@ describe("AmqpWorker Integration", () => {
     await workerFactory(
       contract,
       declareHandlers(contract, {
-        testConsumer: ({ payload }) => {
+        testConsumer: (_, { payload }) => {
           messages.push(payload);
           return OkAsync(undefined);
         },
@@ -423,7 +423,7 @@ describe("AmqpWorker Integration", () => {
     await workerFactory(
       contract,
       declareHandlers(contract, {
-        testConsumer: ({ payload }) => {
+        testConsumer: (_, { payload }) => {
           attemptCount++;
           if (payload.shouldFail && attemptCount === 1) {
             return ErrAsync(new RetryableError("Handler error on first attempt"));
@@ -483,7 +483,7 @@ describe("AmqpWorker Integration", () => {
     await workerFactory(
       contract,
       declareHandlers(contract, {
-        destConsumer: ({ payload }) => {
+        destConsumer: (_, { payload }) => {
           messages.push(payload);
           return OkAsync(undefined);
         },
@@ -536,7 +536,7 @@ describe("AmqpWorker Integration", () => {
     const worker = await workerFactory(
       contract,
       declareHandlers(contract, {
-        testConsumer: ({ payload }) => {
+        testConsumer: (_, { payload }) => {
           messages.push(payload);
           return OkAsync(undefined);
         },
@@ -612,11 +612,11 @@ describe("AmqpWorker Integration", () => {
     await workerFactory(
       contract,
       declareHandlers(contract, {
-        orderConsumer: ({ payload }) => {
+        orderConsumer: (_, { payload }) => {
           orders.push(payload);
           return OkAsync(undefined);
         },
-        notificationConsumer: ({ payload }) => {
+        notificationConsumer: (_, { payload }) => {
           notifications.push(payload);
           return OkAsync(undefined);
         },

--- a/packages/worker/src/__tests__/worker.spec.ts
+++ b/packages/worker/src/__tests__/worker.spec.ts
@@ -58,7 +58,7 @@ describe("AmqpWorker Integration", () => {
     await workerFactory(
       contract,
       declareHandlers(contract, {
-        testConsumer: (_, { payload }) => {
+        testConsumer: ({ input: { payload } }) => {
           messages.push(payload);
           return OkAsync(undefined);
         },
@@ -117,7 +117,7 @@ describe("AmqpWorker Integration", () => {
     await workerFactory(
       contract,
       declareHandlers(contract, {
-        testConsumer: (_, { payload }) => {
+        testConsumer: ({ input: { payload } }) => {
           messages.push(payload);
           return OkAsync(undefined);
         },
@@ -181,7 +181,7 @@ describe("AmqpWorker Integration", () => {
     await workerFactory(
       contract,
       declareHandlers(contract, {
-        testConsumer: (_, { payload, headers }) => {
+        testConsumer: ({ input: { payload, headers } }) => {
           messages.push(payload);
           messageHeaders.push(headers);
           return OkAsync(undefined);
@@ -253,7 +253,7 @@ describe("AmqpWorker Integration", () => {
     await workerFactory(
       contract,
       declareHandlers(contract, {
-        testConsumer: (_, { payload }) => {
+        testConsumer: ({ input: { payload } }) => {
           messages.push(payload);
           return OkAsync(undefined);
         },
@@ -313,11 +313,11 @@ describe("AmqpWorker Integration", () => {
     await workerFactory(
       contract,
       declareHandlers(contract, {
-        consumer1: (_, { payload }) => {
+        consumer1: ({ input: { payload } }) => {
           messages1.push(payload);
           return OkAsync(undefined);
         },
-        consumer2: (_, { payload }) => {
+        consumer2: ({ input: { payload } }) => {
           messages2.push(payload);
           return OkAsync(undefined);
         },
@@ -372,7 +372,7 @@ describe("AmqpWorker Integration", () => {
     await workerFactory(
       contract,
       declareHandlers(contract, {
-        testConsumer: (_, { payload }) => {
+        testConsumer: ({ input: { payload } }) => {
           messages.push(payload);
           return OkAsync(undefined);
         },
@@ -423,7 +423,7 @@ describe("AmqpWorker Integration", () => {
     await workerFactory(
       contract,
       declareHandlers(contract, {
-        testConsumer: (_, { payload }) => {
+        testConsumer: ({ input: { payload } }) => {
           attemptCount++;
           if (payload.shouldFail && attemptCount === 1) {
             return ErrAsync(new RetryableError("Handler error on first attempt"));
@@ -483,7 +483,7 @@ describe("AmqpWorker Integration", () => {
     await workerFactory(
       contract,
       declareHandlers(contract, {
-        destConsumer: (_, { payload }) => {
+        destConsumer: ({ input: { payload } }) => {
           messages.push(payload);
           return OkAsync(undefined);
         },
@@ -536,7 +536,7 @@ describe("AmqpWorker Integration", () => {
     const worker = await workerFactory(
       contract,
       declareHandlers(contract, {
-        testConsumer: (_, { payload }) => {
+        testConsumer: ({ input: { payload } }) => {
           messages.push(payload);
           return OkAsync(undefined);
         },
@@ -612,11 +612,11 @@ describe("AmqpWorker Integration", () => {
     await workerFactory(
       contract,
       declareHandlers(contract, {
-        orderConsumer: (_, { payload }) => {
+        orderConsumer: ({ input: { payload } }) => {
           orders.push(payload);
           return OkAsync(undefined);
         },
-        notificationConsumer: (_, { payload }) => {
+        notificationConsumer: ({ input: { payload } }) => {
           notifications.push(payload);
           return OkAsync(undefined);
         },

--- a/packages/worker/src/errors.ts
+++ b/packages/worker/src/errors.ts
@@ -111,7 +111,7 @@ export function isHandlerError(error: unknown): error is HandlerError {
  * import { qualifyRetryable } from '@amqp-contract/worker';
  * import { fromPromise } from 'unthrown';
  *
- * const handler = (_, { payload }) =>
+ * const handler = ({ input: { payload } }) =>
  *   fromPromise(processPayment(payload), qualifyRetryable('Payment service unavailable'))
  *     .map(() => undefined);
  *
@@ -133,7 +133,7 @@ export function qualifyRetryable(message: string): (cause: unknown) => Retryable
  * import { qualifyNonRetryable } from '@amqp-contract/worker';
  * import { fromPromise } from 'unthrown';
  *
- * const handler = (_, { payload }) =>
+ * const handler = ({ input: { payload } }) =>
  *   fromPromise(chargeCard(payload), qualifyNonRetryable('Card permanently declined'))
  *     .map(() => undefined);
  * ```

--- a/packages/worker/src/errors.ts
+++ b/packages/worker/src/errors.ts
@@ -111,7 +111,7 @@ export function isHandlerError(error: unknown): error is HandlerError {
  * import { qualifyRetryable } from '@amqp-contract/worker';
  * import { fromPromise } from 'unthrown';
  *
- * const handler = ({ payload }) =>
+ * const handler = (_, { payload }) =>
  *   fromPromise(processPayment(payload), qualifyRetryable('Payment service unavailable'))
  *     .map(() => undefined);
  *
@@ -133,7 +133,7 @@ export function qualifyRetryable(message: string): (cause: unknown) => Retryable
  * import { qualifyNonRetryable } from '@amqp-contract/worker';
  * import { fromPromise } from 'unthrown';
  *
- * const handler = ({ payload }) =>
+ * const handler = (_, { payload }) =>
  *   fromPromise(chargeCard(payload), qualifyNonRetryable('Card permanently declined'))
  *     .map(() => undefined);
  * ```

--- a/packages/worker/src/handlers.spec.ts
+++ b/packages/worker/src/handlers.spec.ts
@@ -7,45 +7,12 @@ import {
   defineQueueBinding,
   defineRpc,
 } from "@amqp-contract/contract";
-import type { ConsumeMessage } from "amqplib";
 import { ErrAsync, OkAsync } from "unthrown";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { NonRetryableError, RetryableError } from "./errors.js";
 import { declareHandler, declareHandlers } from "./handlers.js";
-
-/**
- * Creates a mock ConsumeMessage for testing purposes.
- */
-function createMockConsumeMessage(): ConsumeMessage {
-  return {
-    content: Buffer.from("{}"),
-    fields: {
-      consumerTag: "test-consumer-tag",
-      deliveryTag: 1,
-      redelivered: false,
-      exchange: "test-exchange",
-      routingKey: "test.key",
-    },
-    properties: {
-      contentType: undefined,
-      contentEncoding: undefined,
-      headers: {},
-      deliveryMode: undefined,
-      priority: undefined,
-      correlationId: undefined,
-      replyTo: undefined,
-      expiration: undefined,
-      messageId: undefined,
-      timestamp: undefined,
-      type: undefined,
-      userId: undefined,
-      appId: undefined,
-      clusterId: undefined,
-    },
-  };
-}
 
 describe("handlers", () => {
   // Setup test contract
@@ -81,7 +48,7 @@ describe("handlers", () => {
   describe("declareHandler (safe handlers)", () => {
     it("should create a simple safe handler without options", () => {
       // GIVEN
-      const handler = ({ payload }: { payload: { id: string; data: string } }) => {
+      const handler = (_: unknown, { payload }: { payload: { id: string; data: string } }) => {
         console.log(payload.id);
         return OkAsync(undefined);
       };
@@ -95,7 +62,7 @@ describe("handlers", () => {
 
     it("should create a safe handler with prefetch option", () => {
       // GIVEN
-      const handler = ({ payload }: { payload: { id: string; data: string } }) => {
+      const handler = (_: unknown, { payload }: { payload: { id: string; data: string } }) => {
         console.log(payload.id);
         return OkAsync(undefined);
       };
@@ -109,7 +76,7 @@ describe("handlers", () => {
 
     it("should create an RPC handler returning a typed response", () => {
       // GIVEN
-      const handler = ({ payload }: { payload: { a: number; b: number } }) =>
+      const handler = (_: unknown, { payload }: { payload: { a: number; b: number } }) =>
         OkAsync({ sum: payload.a + payload.b });
 
       // WHEN
@@ -121,7 +88,7 @@ describe("handlers", () => {
 
     it("should create an RPC handler with options", () => {
       // GIVEN
-      const handler = ({ payload }: { payload: { a: number; b: number } }) =>
+      const handler = (_: unknown, { payload }: { payload: { a: number; b: number } }) =>
         OkAsync({ sum: payload.a + payload.b });
 
       // WHEN
@@ -133,7 +100,7 @@ describe("handlers", () => {
 
     it("should throw error if name is not in contract (mentioning both consumers and RPCs)", () => {
       // GIVEN
-      const handler = ({ payload }: { payload: { id: string; data: string } }) => {
+      const handler = (_: unknown, { payload }: { payload: { id: string; data: string } }) => {
         console.log(payload.id);
         return OkAsync(undefined);
       };
@@ -152,15 +119,15 @@ describe("handlers", () => {
     it("should create multiple safe handlers spanning consumers and RPCs", () => {
       // GIVEN
       const handlers = {
-        testConsumer: ({ payload }: { payload: { id: string; data: string } }) => {
+        testConsumer: (_: unknown, { payload }: { payload: { id: string; data: string } }) => {
           console.log(payload.id);
           return OkAsync(undefined);
         },
-        anotherConsumer: ({ payload }: { payload: { id: string; data: string } }) => {
+        anotherConsumer: (_: unknown, { payload }: { payload: { id: string; data: string } }) => {
           console.log(payload.data);
           return OkAsync(undefined);
         },
-        calculate: ({ payload }: { payload: { a: number; b: number } }) =>
+        calculate: (_: unknown, { payload }: { payload: { a: number; b: number } }) =>
           OkAsync({ sum: payload.a + payload.b }),
       };
 
@@ -174,15 +141,15 @@ describe("handlers", () => {
     it("should throw error if a handler key is not in contract (consumers ∪ rpcs)", () => {
       // GIVEN
       const handlers = {
-        testConsumer: ({ payload }: { payload: { id: string; data: string } }) => {
+        testConsumer: (_: unknown, { payload }: { payload: { id: string; data: string } }) => {
           console.log(payload.id);
           return OkAsync(undefined);
         },
-        anotherConsumer: ({ payload }: { payload: { id: string; data: string } }) => {
+        anotherConsumer: (_: unknown, { payload }: { payload: { id: string; data: string } }) => {
           console.log(payload.data);
           return OkAsync(undefined);
         },
-        calculate: ({ payload }: { payload: { a: number; b: number } }) =>
+        calculate: (_: unknown, { payload }: { payload: { a: number; b: number } }) =>
           OkAsync({ sum: payload.a + payload.b }),
         nonExistent: ({ payload }: { payload: { id: string; data: string } }) => {
           console.log(payload.data);
@@ -201,7 +168,7 @@ describe("handlers", () => {
     it("should throw error if a contract entry has no handler (reverse completeness)", () => {
       // GIVEN — only one of the three contract entries has a handler
       const handlers = {
-        testConsumer: ({ payload }: { payload: { id: string; data: string } }) => {
+        testConsumer: (_: unknown, { payload }: { payload: { id: string; data: string } }) => {
           console.log(payload.id);
           return OkAsync(undefined);
         },
@@ -254,10 +221,7 @@ describe("handlers", () => {
   describe("safe handlers error handling", () => {
     it("should allow returning RetryableError from safe handler", () => {
       // GIVEN
-      const handler = (
-        _message: { payload: { id: string; data: string } },
-        _rawMessage: ConsumeMessage,
-      ) => {
+      const handler = () => {
         return ErrAsync(new RetryableError("Transient failure"));
       };
 
@@ -268,19 +232,13 @@ describe("handlers", () => {
       expect(result).toBe(handler);
 
       // Verify the handler returns the expected error
-      const handlerResult = (result as typeof handler)(
-        { payload: { id: "1", data: "test" } },
-        createMockConsumeMessage(),
-      );
+      const handlerResult = (result as typeof handler)();
       expect(handlerResult).toBeDefined();
     });
 
     it("should allow returning NonRetryableError from safe handler", () => {
       // GIVEN
-      const handler = (
-        _message: { payload: { id: string; data: string } },
-        _rawMessage: ConsumeMessage,
-      ) => {
+      const handler = () => {
         return ErrAsync(new NonRetryableError("Invalid message"));
       };
 
@@ -291,10 +249,7 @@ describe("handlers", () => {
       expect(result).toBe(handler);
 
       // Verify the handler returns the expected error
-      const handlerResult = (result as typeof handler)(
-        { payload: { id: "1", data: "test" } },
-        createMockConsumeMessage(),
-      );
+      const handlerResult = (result as typeof handler)();
       expect(handlerResult).toBeDefined();
     });
   });

--- a/packages/worker/src/handlers.test-d.ts
+++ b/packages/worker/src/handlers.test-d.ts
@@ -14,6 +14,7 @@ import {
   defineRpc,
 } from "@amqp-contract/contract";
 import type { RpcError } from "@amqp-contract/core";
+import type { ConsumeMessage } from "amqplib";
 import { ErrAsync, OkAsync, type AsyncResult } from "unthrown";
 import { describe, expectTypeOf, test } from "vitest";
 import { z } from "zod";
@@ -91,7 +92,7 @@ describe("handler payload inference", () => {
 
   test("should infer the payload inside a handler", () => {
     declareHandlers(contract, {
-      processOrder: ({ payload }) => {
+      processOrder: (_, { payload }) => {
         expectTypeOf(payload).toEqualTypeOf<{ orderId: string; amount: number }>();
         return OkAsync(undefined);
       },
@@ -100,7 +101,7 @@ describe("handler payload inference", () => {
 
   test("should reject access to properties not in the schema", () => {
     declareHandlers(contract, {
-      processOrder: ({ payload }) => {
+      processOrder: (_, { payload }) => {
         expectTypeOf(payload).not.toHaveProperty("nonExistent");
         return OkAsync(undefined);
       },
@@ -119,7 +120,7 @@ describe("handler payload inference", () => {
 
   test("infers typed headers (validated OUTPUT: defaults applied)", () => {
     declareHandlers(headersContract, {
-      withHeaders: ({ headers }) => {
+      withHeaders: (_, { headers }) => {
         expectTypeOf(headers).toEqualTypeOf<{ "x-tenant-id": string; "x-priority": string }>();
         return OkAsync(undefined);
       },
@@ -129,7 +130,7 @@ describe("handler payload inference", () => {
   test("accepts [handler, options] tuple entries but rejects invalid options", () => {
     declareHandlers(contract, {
       processOrder: [
-        ({ payload }) => {
+        (_, { payload }) => {
           expectTypeOf(payload).toEqualTypeOf<{ orderId: string; amount: number }>();
           return OkAsync(undefined);
         },
@@ -168,7 +169,7 @@ describe("RPC handler inference", () => {
   test("RPC handlers get typed payload, helpers.errors, and a checked return type", () => {
     declareHandlers(rpcContract, {
       processOrder: () => OkAsync(undefined),
-      getOrder: ({ payload }, _raw, { errors }) => {
+      getOrder: ({ errors }, { payload }) => {
         expectTypeOf(payload).toEqualTypeOf<{ orderId: string }>();
         if (payload.orderId === "missing") {
           return ErrAsync(errors.ORDER_NOT_FOUND({ orderId: payload.orderId }));
@@ -191,7 +192,7 @@ describe("RPC handler inference", () => {
   });
 
   test("declareHandler overloads cover consumer and RPC names, with and without options", () => {
-    const consumerHandler = declareHandler(contract, "processOrder", ({ payload }) => {
+    const consumerHandler = declareHandler(contract, "processOrder", (_, { payload }) => {
       expectTypeOf(payload).toEqualTypeOf<{ orderId: string; amount: number }>();
       return OkAsync(undefined);
     });
@@ -209,10 +210,27 @@ describe("RPC handler inference", () => {
   test("middleware context threads into the handler's helpers", () => {
     type Ctx = { tenantId: string };
     declareHandlers<typeof contract, Ctx>(contract, {
-      processOrder: (_message, _raw, helpers) => {
+      processOrder: (helpers) => {
         expectTypeOf(helpers.context).toEqualTypeOf<Ctx>();
         return OkAsync(undefined);
       },
+    });
+  });
+
+  test("the raw delivery rides the helpers record, not a third parameter", () => {
+    declareHandlers(contract, {
+      processOrder: ({ raw }, { payload }) => {
+        expectTypeOf(raw).toEqualTypeOf<ConsumeMessage>();
+        expectTypeOf(payload).toEqualTypeOf<{ orderId: string; amount: number }>();
+        return OkAsync(undefined);
+      },
+    });
+  });
+
+  test("a handler takes no third parameter", () => {
+    declareHandlers(contract, {
+      // @ts-expect-error — helpers and message are the only two parameters
+      processOrder: (_helpers, _message, _raw: ConsumeMessage) => OkAsync(undefined),
     });
   });
 

--- a/packages/worker/src/handlers.test-d.ts
+++ b/packages/worker/src/handlers.test-d.ts
@@ -92,7 +92,7 @@ describe("handler payload inference", () => {
 
   test("should infer the payload inside a handler", () => {
     declareHandlers(contract, {
-      processOrder: (_, { payload }) => {
+      processOrder: ({ input: { payload } }) => {
         expectTypeOf(payload).toEqualTypeOf<{ orderId: string; amount: number }>();
         return OkAsync(undefined);
       },
@@ -101,7 +101,7 @@ describe("handler payload inference", () => {
 
   test("should reject access to properties not in the schema", () => {
     declareHandlers(contract, {
-      processOrder: (_, { payload }) => {
+      processOrder: ({ input: { payload } }) => {
         expectTypeOf(payload).not.toHaveProperty("nonExistent");
         return OkAsync(undefined);
       },
@@ -120,7 +120,7 @@ describe("handler payload inference", () => {
 
   test("infers typed headers (validated OUTPUT: defaults applied)", () => {
     declareHandlers(headersContract, {
-      withHeaders: (_, { headers }) => {
+      withHeaders: ({ input: { headers } }) => {
         expectTypeOf(headers).toEqualTypeOf<{ "x-tenant-id": string; "x-priority": string }>();
         return OkAsync(undefined);
       },
@@ -130,7 +130,7 @@ describe("handler payload inference", () => {
   test("accepts [handler, options] tuple entries but rejects invalid options", () => {
     declareHandlers(contract, {
       processOrder: [
-        (_, { payload }) => {
+        ({ input: { payload } }) => {
           expectTypeOf(payload).toEqualTypeOf<{ orderId: string; amount: number }>();
           return OkAsync(undefined);
         },
@@ -169,7 +169,7 @@ describe("RPC handler inference", () => {
   test("RPC handlers get typed payload, helpers.errors, and a checked return type", () => {
     declareHandlers(rpcContract, {
       processOrder: () => OkAsync(undefined),
-      getOrder: ({ errors }, { payload }) => {
+      getOrder: ({ errors, input: { payload } }) => {
         expectTypeOf(payload).toEqualTypeOf<{ orderId: string }>();
         if (payload.orderId === "missing") {
           return ErrAsync(errors.ORDER_NOT_FOUND({ orderId: payload.orderId }));
@@ -192,7 +192,7 @@ describe("RPC handler inference", () => {
   });
 
   test("declareHandler overloads cover consumer and RPC names, with and without options", () => {
-    const consumerHandler = declareHandler(contract, "processOrder", (_, { payload }) => {
+    const consumerHandler = declareHandler(contract, "processOrder", ({ input: { payload } }) => {
       expectTypeOf(payload).toEqualTypeOf<{ orderId: string; amount: number }>();
       return OkAsync(undefined);
     });
@@ -219,7 +219,7 @@ describe("RPC handler inference", () => {
 
   test("the raw delivery rides the helpers record, not a third parameter", () => {
     declareHandlers(contract, {
-      processOrder: ({ raw }, { payload }) => {
+      processOrder: ({ raw, input: { payload } }) => {
         expectTypeOf(raw).toEqualTypeOf<ConsumeMessage>();
         expectTypeOf(payload).toEqualTypeOf<{ orderId: string; amount: number }>();
         return OkAsync(undefined);
@@ -227,10 +227,10 @@ describe("RPC handler inference", () => {
     });
   });
 
-  test("the message is on the helpers record too, so one destructuring is a whole handler", () => {
+  test("the message is on the record as `input`, so one destructuring is a whole handler", () => {
     declareHandlers(contract, {
-      processOrder: ({ message }) => {
-        expectTypeOf(message.payload).toEqualTypeOf<{ orderId: string; amount: number }>();
+      processOrder: ({ input }) => {
+        expectTypeOf(input.payload).toEqualTypeOf<{ orderId: string; amount: number }>();
         return OkAsync(undefined);
       },
     });

--- a/packages/worker/src/handlers.test-d.ts
+++ b/packages/worker/src/handlers.test-d.ts
@@ -227,6 +227,15 @@ describe("RPC handler inference", () => {
     });
   });
 
+  test("the message is on the helpers record too, so one destructuring is a whole handler", () => {
+    declareHandlers(contract, {
+      processOrder: ({ message }) => {
+        expectTypeOf(message.payload).toEqualTypeOf<{ orderId: string; amount: number }>();
+        return OkAsync(undefined);
+      },
+    });
+  });
+
   test("the retry constructors ride the helpers record", () => {
     declareHandlers(contract, {
       processOrder: ({ retryable, nonRetryable }, { payload }) => {

--- a/packages/worker/src/handlers.test-d.ts
+++ b/packages/worker/src/handlers.test-d.ts
@@ -19,7 +19,7 @@ import { ErrAsync, OkAsync, type AsyncResult } from "unthrown";
 import { describe, expectTypeOf, test } from "vitest";
 import { z } from "zod";
 
-import type { HandlerError } from "./errors.js";
+import type { HandlerError, NonRetryableError, RetryableError } from "./errors.js";
 import { declareHandler, declareHandlers } from "./handlers.js";
 import type {
   WorkerInferConsumedMessage,
@@ -223,6 +223,18 @@ describe("RPC handler inference", () => {
         expectTypeOf(raw).toEqualTypeOf<ConsumeMessage>();
         expectTypeOf(payload).toEqualTypeOf<{ orderId: string; amount: number }>();
         return OkAsync(undefined);
+      },
+    });
+  });
+
+  test("the retry constructors ride the helpers record", () => {
+    declareHandlers(contract, {
+      processOrder: ({ retryable, nonRetryable }, { payload }) => {
+        expectTypeOf(retryable).toEqualTypeOf<
+          (message: string, cause?: unknown) => RetryableError
+        >();
+        expectTypeOf(nonRetryable("no", payload)).toEqualTypeOf<NonRetryableError>();
+        return ErrAsync(retryable("infrastructure comes back"));
       },
     });
   });

--- a/packages/worker/src/handlers.ts
+++ b/packages/worker/src/handlers.ts
@@ -168,6 +168,11 @@ function validateHandlers<TContract extends ContractDefinition>(
  * 1. Simple handler: just the function
  * 2. Handler with options: `[handler, { prefetch: 10 }]`
  *
+ * The leaf takes the helpers record first and the validated message second,
+ * with that message on the record as well — oRPC's shape — so
+ * `({ errors, message }) => ...` and `({ errors }, message) => ...` are the
+ * same call, and a handler needing neither is `(_, { payload }) => ...`.
+ *
  * @template TContract - The contract definition type
  * @template TName - The consumer or RPC name from the contract
  * @param contract - The contract definition containing the consumer or RPC

--- a/packages/worker/src/handlers.ts
+++ b/packages/worker/src/handlers.ts
@@ -170,8 +170,9 @@ function validateHandlers<TContract extends ContractDefinition>(
  *
  * The leaf takes the helpers record first and the validated message second,
  * with that message on the record as well — oRPC's shape — so
- * `({ errors, message }) => ...` and `({ errors }, message) => ...` are the
- * same call, and a handler needing neither is `(_, { payload }) => ...`.
+ * `({ errors, input }) => ...` and `({ errors }, message) => ...` are the same
+ * call — oRPC offers both — and a handler that wants only its message is
+ * `({ input: { payload } }) => ...`, with no placeholder to spell.
  *
  * @template TContract - The contract definition type
  * @template TName - The consumer or RPC name from the contract
@@ -191,7 +192,7 @@ function validateHandlers<TContract extends ContractDefinition>(
  * const processOrderHandler = declareHandler(
  *   orderContract,
  *   'processOrder',
- *   (_, { payload }) =>
+ *   ({ input: { payload } }) =>
  *     fromPromise(
  *       processPayment(payload),
  *       (error) => new RetryableError('Payment failed', error),
@@ -204,7 +205,7 @@ function validateHandlers<TContract extends ContractDefinition>(
  * const calculateHandler = declareHandler(
  *   rpcContract,
  *   'calculate',
- *   (_, { payload }) => OkAsync({ sum: payload.a + payload.b }),
+ *   ({ input: { payload } }) => OkAsync({ sum: payload.a + payload.b }),
  * );
  * ```
  */
@@ -280,12 +281,12 @@ export function declareHandler<
  * import { fromPromise, OkAsync } from 'unthrown';
  *
  * const handlers = declareHandlers(orderContract, {
- *   processOrder: (_, { payload }) =>
+ *   processOrder: ({ input: { payload } }) =>
  *     fromPromise(
  *       processPayment(payload),
  *       (error) => new RetryableError('Payment failed', error),
  *     ).map(() => undefined),
- *   calculate: (_, { payload }) => OkAsync({ sum: payload.a + payload.b }),
+ *   calculate: ({ input: { payload } }) => OkAsync({ sum: payload.a + payload.b }),
  * });
  * ```
  */

--- a/packages/worker/src/handlers.ts
+++ b/packages/worker/src/handlers.ts
@@ -186,7 +186,7 @@ function validateHandlers<TContract extends ContractDefinition>(
  * const processOrderHandler = declareHandler(
  *   orderContract,
  *   'processOrder',
- *   ({ payload }) =>
+ *   (_, { payload }) =>
  *     fromPromise(
  *       processPayment(payload),
  *       (error) => new RetryableError('Payment failed', error),
@@ -199,7 +199,7 @@ function validateHandlers<TContract extends ContractDefinition>(
  * const calculateHandler = declareHandler(
  *   rpcContract,
  *   'calculate',
- *   ({ payload }) => OkAsync({ sum: payload.a + payload.b }),
+ *   (_, { payload }) => OkAsync({ sum: payload.a + payload.b }),
  * );
  * ```
  */
@@ -275,12 +275,12 @@ export function declareHandler<
  * import { fromPromise, OkAsync } from 'unthrown';
  *
  * const handlers = declareHandlers(orderContract, {
- *   processOrder: ({ payload }) =>
+ *   processOrder: (_, { payload }) =>
  *     fromPromise(
  *       processPayment(payload),
  *       (error) => new RetryableError('Payment failed', error),
  *     ).map(() => undefined),
- *   calculate: ({ payload }) => OkAsync({ sum: payload.a + payload.b }),
+ *   calculate: (_, { payload }) => OkAsync({ sum: payload.a + payload.b }),
  * });
  * ```
  */

--- a/packages/worker/src/middleware.ts
+++ b/packages/worker/src/middleware.ts
@@ -59,7 +59,7 @@ export type WorkerMiddlewareNext<TContextOut extends Record<string, unknown> | E
  *
  * Middleware follow the guard-and-narrow pattern: check something, then call
  * `next({ context })` to run the rest of the chain with typed fields injected
- * into the handler's third argument — or short-circuit by returning without
+ * into the handler's helpers record — or short-circuit by returning without
  * calling `next`:
  *
  * - `Err(new RetryableError(...))` / `Err(new NonRetryableError(...))` routes through the normal

--- a/packages/worker/src/rpc-reply-failure.spec.ts
+++ b/packages/worker/src/rpc-reply-failure.spec.ts
@@ -124,7 +124,7 @@ describe("RPC reply publish failure routing", () => {
 
     const worker = await TypedAmqpWorker.create({
       contract,
-      handlers: { calculate: (_, { payload }) => OkAsync({ sum: payload.a + payload.b }) },
+      handlers: { calculate: ({ input: { payload } }) => OkAsync({ sum: payload.a + payload.b }) },
       urls: ["amqp://localhost"],
       logger,
     }).get();
@@ -162,7 +162,7 @@ describe("RPC reply publish failure routing", () => {
 
     const worker = await TypedAmqpWorker.create({
       contract,
-      handlers: { calculate: (_, { payload }) => OkAsync({ sum: payload.a + payload.b }) },
+      handlers: { calculate: ({ input: { payload } }) => OkAsync({ sum: payload.a + payload.b }) },
       urls: ["amqp://localhost"],
     }).get();
 

--- a/packages/worker/src/rpc-reply-failure.spec.ts
+++ b/packages/worker/src/rpc-reply-failure.spec.ts
@@ -124,7 +124,7 @@ describe("RPC reply publish failure routing", () => {
 
     const worker = await TypedAmqpWorker.create({
       contract,
-      handlers: { calculate: ({ payload }) => OkAsync({ sum: payload.a + payload.b }) },
+      handlers: { calculate: (_, { payload }) => OkAsync({ sum: payload.a + payload.b }) },
       urls: ["amqp://localhost"],
       logger,
     }).get();
@@ -162,7 +162,7 @@ describe("RPC reply publish failure routing", () => {
 
     const worker = await TypedAmqpWorker.create({
       contract,
-      handlers: { calculate: ({ payload }) => OkAsync({ sum: payload.a + payload.b }) },
+      handlers: { calculate: (_, { payload }) => OkAsync({ sum: payload.a + payload.b }) },
       urls: ["amqp://localhost"],
     }).get();
 

--- a/packages/worker/src/types.ts
+++ b/packages/worker/src/types.ts
@@ -151,10 +151,10 @@ export type WorkerInferRpcErrorConstructors<
  *
  * That is oRPC's shape, and the one this family converged on:
  * `ProcedureHandlerOptions` carries `input` and the handler still takes it
- * positionally, so `({ errors, message }) => ...` and
+ * positionally, so `({ errors, input }) => ...` and
  * `({ errors }, message) => ...` are the same call. `raw` rides here rather
  * than in a third parameter for the same reason — one record for everything
- * ambient, and the message where a reader wants it.
+ * the delivery carries.
  */
 export type WorkerHandlerHelpers<
   TContext extends Record<string, unknown> | EmptyContext = EmptyContext,
@@ -163,12 +163,13 @@ export type WorkerHandlerHelpers<
 > = {
   /**
    * The validated message — the SAME value the second parameter carries. It is
-   * on the record so a whole handler can be written from one destructuring,
-   * which is oRPC's own shape: `ProcedureHandlerOptions` carries `input` and
-   * the handler still takes it positionally. Take it whichever way reads better
-   * at the call.
+   * on the record so a whole handler is one destructuring, which is oRPC's own
+   * shape and its own word for it: `ProcedureHandlerOptions` carries `input`,
+   * and the handler still takes it positionally. One name across the three
+   * transports is the point — a developer moving between them destructures
+   * `input` in each.
    */
-  readonly message: TMessage;
+  readonly input: TMessage;
   /** Context produced by `createContext` and the middleware chain. */
   readonly context: TContext;
   /** Typed constructors for the contract-declared errors (empty for consumers). */
@@ -238,18 +239,18 @@ export type WorkerInferRpcResponse<
 /**
  * A consumed message containing parsed payload and headers.
  *
- * This type represents the second argument passed to consumer handlers — the
- * helpers record comes first. It contains the validated payload and (if
- * defined in the message schema) the validated headers.
+ * What a handler receives as `input` on its record, and again as the second
+ * positional argument. It contains the validated payload and (if defined in
+ * the message schema) the validated headers.
  *
  * @template TPayload - The inferred payload type from the message schema
  * @template THeaders - The inferred headers type from the message schema (undefined if not defined)
  *
  * @example
  * ```typescript
- * const handler = declareHandler(contract, 'processOrder', ({ raw }, message) => {
- *   console.log(message.payload.orderId);  // Typed payload
- *   console.log(message.headers?.priority); // Typed headers (if defined)
+ * const handler = declareHandler(contract, 'processOrder', ({ raw, input }) => {
+ *   console.log(input.payload.orderId);  // Typed payload
+ *   console.log(input.headers?.priority); // Typed headers (if defined)
  *   console.log(raw.fields.deliveryTag); // Raw AMQP delivery
  *   return OkAsync(undefined);
  * });
@@ -295,13 +296,14 @@ export type WorkerInferRpcConsumedMessage<
 // Every handler takes the `helpers` record FIRST and the validated message
 // second — oRPC's shape, which this family converged on, down to the message
 // being on the record as well as in the second parameter. `helpers` is
-// `{ message, context, errors, raw, retryable, nonRetryable }`: `context` is
+// `{ input, context, errors, raw, retryable, nonRetryable }`: `context` is
 // produced by `createContext` and the middleware chain (an empty object when
 // neither is configured), `errors` carries typed constructors for the RPC's
 // declared errors (empty for consumers), `raw` is the AMQP delivery, and the
-// two factories are the modeled failures. So `({ errors, message }) => ...`
-// and `({ errors }, message) => ...` are the same call, and a handler that
-// needs none of them is `(_, { payload }) => ...`.
+// two factories are the modeled failures. So `({ errors, input }) => ...` and
+// `({ errors }, message) => ...` are the same call — oRPC offers both — and a
+// handler that wants only its message is `({ input: { payload } }) => ...`,
+// with no placeholder to spell.
 
 /**
  * Handler signature for a regular consumer (event/command). Returns
@@ -379,12 +381,12 @@ export type WorkerInferRpcHandlerEntry<
  * @example
  * ```typescript
  * const handlers: WorkerInferHandlers<typeof contract> = {
- *   processOrder: (_, { payload }) =>
+ *   processOrder: ({ input: { payload } }) =>
  *     fromPromise(
  *       processPayment(payload),
  *       (error) => new RetryableError('Payment failed', error),
  *     ).map(() => undefined),
- *   calculate: (_, { payload }) => OkAsync({ sum: payload.a + payload.b }),
+ *   calculate: ({ input: { payload } }) => OkAsync({ sum: payload.a + payload.b }),
  * };
  * ```
  */

--- a/packages/worker/src/types.ts
+++ b/packages/worker/src/types.ts
@@ -146,18 +146,29 @@ export type WorkerInferRpcErrorConstructors<
 
 /**
  * The helpers record every handler receives as its FIRST argument —
- * everything ambient to the delivery, with the validated message second.
+ * everything the delivery carries, the validated message included, with that
+ * message repeated as the second parameter.
  *
- * That is oRPC's shape (`({ errors, context }, input)`) and the one this
- * family converged on, so a use case moving between transports finds its
- * triage site in the same position. `raw` rides here rather than in a third
- * parameter for the same reason: the leaf takes what the delivery carries,
- * then the message.
+ * That is oRPC's shape, and the one this family converged on:
+ * `ProcedureHandlerOptions` carries `input` and the handler still takes it
+ * positionally, so `({ errors, message }) => ...` and
+ * `({ errors }, message) => ...` are the same call. `raw` rides here rather
+ * than in a third parameter for the same reason — one record for everything
+ * ambient, and the message where a reader wants it.
  */
 export type WorkerHandlerHelpers<
   TContext extends Record<string, unknown> | EmptyContext = EmptyContext,
   TErrors = EmptyContext,
+  TMessage = unknown,
 > = {
+  /**
+   * The validated message — the SAME value the second parameter carries. It is
+   * on the record so a whole handler can be written from one destructuring,
+   * which is oRPC's own shape: `ProcedureHandlerOptions` carries `input` and
+   * the handler still takes it positionally. Take it whichever way reads better
+   * at the call.
+   */
+  readonly message: TMessage;
   /** Context produced by `createContext` and the middleware chain. */
   readonly context: TContext;
   /** Typed constructors for the contract-declared errors (empty for consumers). */
@@ -282,12 +293,15 @@ export type WorkerInferRpcConsumedMessage<
 // response payload. RetryableError → exponential backoff retry; NonRetryableError → DLQ.
 //
 // Every handler takes the `helpers` record FIRST and the validated message
-// second — oRPC's shape, which this family converged on. `helpers` is
-// `{ context, errors, raw }`: `context` is produced by `createContext` and the
-// middleware chain (an empty object when neither is configured), `errors`
-// carries typed constructors for the RPC's declared errors (empty for
-// consumers), and `raw` is the AMQP delivery. A handler that needs none of
-// them still names the position: `(_, { payload }) => ...`.
+// second — oRPC's shape, which this family converged on, down to the message
+// being on the record as well as in the second parameter. `helpers` is
+// `{ message, context, errors, raw, retryable, nonRetryable }`: `context` is
+// produced by `createContext` and the middleware chain (an empty object when
+// neither is configured), `errors` carries typed constructors for the RPC's
+// declared errors (empty for consumers), `raw` is the AMQP delivery, and the
+// two factories are the modeled failures. So `({ errors, message }) => ...`
+// and `({ errors }, message) => ...` are the same call, and a handler that
+// needs none of them is `(_, { payload }) => ...`.
 
 /**
  * Handler signature for a regular consumer (event/command). Returns
@@ -298,7 +312,11 @@ export type WorkerInferConsumerHandler<
   TName extends InferConsumerNames<TContract>,
   TContext extends Record<string, unknown> | EmptyContext = EmptyContext,
 > = (
-  helpers: WorkerHandlerHelpers<TContext>,
+  helpers: WorkerHandlerHelpers<
+    TContext,
+    EmptyContext,
+    WorkerInferConsumedMessage<TContract, TName>
+  >,
   message: WorkerInferConsumedMessage<TContract, TName>,
 ) => AsyncResult<void, HandlerError>;
 
@@ -317,7 +335,11 @@ export type WorkerInferRpcHandler<
   TName extends InferRpcNames<TContract>,
   TContext extends Record<string, unknown> | EmptyContext = EmptyContext,
 > = (
-  helpers: WorkerHandlerHelpers<TContext, WorkerInferRpcErrorConstructors<TContract, TName>>,
+  helpers: WorkerHandlerHelpers<
+    TContext,
+    WorkerInferRpcErrorConstructors<TContract, TName>,
+    WorkerInferRpcConsumedMessage<TContract, TName>
+  >,
   message: WorkerInferRpcConsumedMessage<TContract, TName>,
 ) => AsyncResult<
   WorkerInferRpcResponse<TContract, TName>,

--- a/packages/worker/src/types.ts
+++ b/packages/worker/src/types.ts
@@ -145,9 +145,14 @@ export type WorkerInferRpcErrorConstructors<
     : EmptyContext;
 
 /**
- * The helpers object every handler receives as its third argument: the
- * middleware-produced `context` and (for RPC handlers with a declared
- * `errors` map) the typed error `constructors`.
+ * The helpers record every handler receives as its FIRST argument —
+ * everything ambient to the delivery, with the validated message second.
+ *
+ * That is oRPC's shape (`({ errors, context }, input)`) and the one this
+ * family converged on, so a use case moving between transports finds its
+ * triage site in the same position. `raw` rides here rather than in a third
+ * parameter for the same reason: the leaf takes what the delivery carries,
+ * then the message.
  */
 export type WorkerHandlerHelpers<
   TContext extends Record<string, unknown> | EmptyContext = EmptyContext,
@@ -157,6 +162,8 @@ export type WorkerHandlerHelpers<
   readonly context: TContext;
   /** Typed constructors for the contract-declared errors (empty for consumers). */
   readonly errors: TErrors;
+  /** The raw AMQP delivery — `fields`, `properties`, and the untouched `content`. */
+  readonly raw: ConsumeMessage;
 };
 
 /**
@@ -209,18 +216,19 @@ export type WorkerInferRpcResponse<
 /**
  * A consumed message containing parsed payload and headers.
  *
- * This type represents the first argument passed to consumer handlers.
- * It contains the validated payload and (if defined in the message schema) the validated headers.
+ * This type represents the second argument passed to consumer handlers — the
+ * helpers record comes first. It contains the validated payload and (if
+ * defined in the message schema) the validated headers.
  *
  * @template TPayload - The inferred payload type from the message schema
  * @template THeaders - The inferred headers type from the message schema (undefined if not defined)
  *
  * @example
  * ```typescript
- * const handler = declareHandler(contract, 'processOrder', (message, rawMessage) => {
+ * const handler = declareHandler(contract, 'processOrder', ({ raw }, message) => {
  *   console.log(message.payload.orderId);  // Typed payload
  *   console.log(message.headers?.priority); // Typed headers (if defined)
- *   console.log(rawMessage.fields.deliveryTag); // Raw AMQP message
+ *   console.log(raw.fields.deliveryTag); // Raw AMQP delivery
  *   return OkAsync(undefined);
  * });
  * ```
@@ -262,12 +270,13 @@ export type WorkerInferRpcConsumedMessage<
 // error handling. Regular consumers return `void`; RPC handlers return the
 // response payload. RetryableError → exponential backoff retry; NonRetryableError → DLQ.
 //
-// Every handler additionally receives a third `helpers` argument —
-// `{ context, errors }`: `context` is produced by `createContext` and the
-// middleware chain (an empty object when neither is configured); `errors`
+// Every handler takes the `helpers` record FIRST and the validated message
+// second — oRPC's shape, which this family converged on. `helpers` is
+// `{ context, errors, raw }`: `context` is produced by `createContext` and the
+// middleware chain (an empty object when neither is configured), `errors`
 // carries typed constructors for the RPC's declared errors (empty for
-// consumers). `TContext` defaults to `EmptyContext` so handlers that ignore
-// the argument keep their existing two-parameter shape.
+// consumers), and `raw` is the AMQP delivery. A handler that needs none of
+// them still names the position: `(_, { payload }) => ...`.
 
 /**
  * Handler signature for a regular consumer (event/command). Returns
@@ -278,9 +287,8 @@ export type WorkerInferConsumerHandler<
   TName extends InferConsumerNames<TContract>,
   TContext extends Record<string, unknown> | EmptyContext = EmptyContext,
 > = (
-  message: WorkerInferConsumedMessage<TContract, TName>,
-  rawMessage: ConsumeMessage,
   helpers: WorkerHandlerHelpers<TContext>,
+  message: WorkerInferConsumedMessage<TContract, TName>,
 ) => AsyncResult<void, HandlerError>;
 
 /**
@@ -298,9 +306,8 @@ export type WorkerInferRpcHandler<
   TName extends InferRpcNames<TContract>,
   TContext extends Record<string, unknown> | EmptyContext = EmptyContext,
 > = (
-  message: WorkerInferRpcConsumedMessage<TContract, TName>,
-  rawMessage: ConsumeMessage,
   helpers: WorkerHandlerHelpers<TContext, WorkerInferRpcErrorConstructors<TContract, TName>>,
+  message: WorkerInferRpcConsumedMessage<TContract, TName>,
 ) => AsyncResult<
   WorkerInferRpcResponse<TContract, TName>,
   HandlerError | WorkerInferRpcErrors<TContract, TName>
@@ -339,12 +346,12 @@ export type WorkerInferRpcHandlerEntry<
  * @example
  * ```typescript
  * const handlers: WorkerInferHandlers<typeof contract> = {
- *   processOrder: ({ payload }) =>
+ *   processOrder: (_, { payload }) =>
  *     fromPromise(
  *       processPayment(payload),
  *       (error) => new RetryableError('Payment failed', error),
  *     ).map(() => undefined),
- *   calculate: ({ payload }) => OkAsync({ sum: payload.a + payload.b }),
+ *   calculate: (_, { payload }) => OkAsync({ sum: payload.a + payload.b }),
  * };
  * ```
  */

--- a/packages/worker/src/types.ts
+++ b/packages/worker/src/types.ts
@@ -16,7 +16,7 @@ import type { StandardSchemaV1 } from "@standard-schema/spec";
 import type { ConsumeMessage } from "amqplib";
 import type { AsyncResult } from "unthrown";
 
-import type { HandlerError } from "./errors.js";
+import type { HandlerError, NonRetryableError, RetryableError } from "./errors.js";
 import type { EmptyContext } from "./middleware.js";
 import { type ConsumerOptions } from "./worker.js";
 
@@ -164,6 +164,17 @@ export type WorkerHandlerHelpers<
   readonly errors: TErrors;
   /** The raw AMQP delivery — `fields`, `properties`, and the untouched `content`. */
   readonly raw: ConsumeMessage;
+  /**
+   * "Infrastructure comes back" — the failure the retry schedule is for,
+   * handed over rather than imported and constructed. `ErrAsync(retryable(...))`
+   * is `ErrAsync(new RetryableError(...))` without the import.
+   */
+  readonly retryable: (message: string, cause?: unknown) => RetryableError;
+  /**
+   * "This will never work" — straight to the dead-letter queue, no retry
+   * budget spent. The permanent twin of {@link WorkerHandlerHelpers.retryable}.
+   */
+  readonly nonRetryable: (message: string, cause?: unknown) => NonRetryableError;
 };
 
 /**

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -43,7 +43,7 @@ import {
 
 import { decompressBuffer } from "./decompression.js";
 import type { HandlerError } from "./errors.js";
-import { MessageValidationError, NonRetryableError } from "./errors.js";
+import { MessageValidationError, NonRetryableError, RetryableError } from "./errors.js";
 import {
   availableHandlerNames,
   invalidHandlerNames,
@@ -74,11 +74,22 @@ type HandlerName<TContract extends ContractDefinition> =
  * with a contract-declared `RpcError`, which the dispatch path publishes back
  * to the caller instead of routing to retry/DLQ.
  */
+/**
+ * The two modeled failures, as factories the handler is handed. Stateless, so
+ * they are built once for the module rather than per delivery.
+ */
+const retryableFactory = (message: string, cause?: unknown): RetryableError =>
+  new RetryableError(message, cause);
+const nonRetryableFactory = (message: string, cause?: unknown): NonRetryableError =>
+  new NonRetryableError(message, cause);
+
 type StoredHandler = (
   helpers: {
     context: Record<string, unknown>;
     errors: Record<string, (data: unknown, message?: string) => RpcError>;
     raw: ConsumeMessage;
+    retryable: (message: string, cause?: unknown) => RetryableError;
+    nonRetryable: (message: string, cause?: unknown) => NonRetryableError;
   },
   message: { payload: unknown; headers: unknown },
 ) => AsyncResult<unknown, HandlerError | RpcError>;
@@ -161,13 +172,13 @@ function isHandlerTuple(entry: unknown): entry is [unknown, ConsumerOptions] {
  *   contract: myContract,
  *   handlers: {
  *     // Simple handler
- *     processOrder: ({ payload }) => {
+ *     processOrder: (_, { payload }) => {
  *       console.log('Processing order:', payload.orderId);
  *       return OkAsync(undefined);
  *     },
  *     // Handler with prefetch configuration
  *     processPayment: [
- *       ({ payload }) => {
+ *       (_, { payload }) => {
  *         console.log('Processing payment:', payload.paymentId);
  *         return OkAsync(undefined);
  *       },
@@ -205,8 +216,9 @@ export type CreateWorkerOptions<
    *   accepts the declared `RpcError<code, data>` members (otherwise it
    *   stays plain `HandlerError`).
    *
-   * Handlers receive the middleware-produced context as a third argument
-   * (an empty object when no `middleware` is configured).
+   * Handlers receive the helpers record FIRST — `{ context, errors, raw }` —
+   * and the validated message second. `context` is an empty object when no
+   * `createContext` and no `middleware` are configured.
    *
    * Use `declareHandler` / `declareHandlers` to create handlers with full type
    * inference.
@@ -316,7 +328,7 @@ export type CreateWorkerOptions<
  * const worker = await TypedAmqpWorker.create({
  *   contract,
  *   handlers: {
- *     processOrder: ({ payload }) => {
+ *     processOrder: (_, { payload }) => {
  *       console.log('Processing order', payload.orderId);
  *       return OkAsync(undefined);
  *     },
@@ -444,7 +456,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
    * const result = await TypedAmqpWorker.create({
    *   contract: myContract,
    *   handlers: {
-   *     processOrder: ({ payload }) => OkAsync(undefined),
+   *     processOrder: (_, { payload }) => OkAsync(undefined),
    *   },
    *   urls: ['amqp://localhost'],
    * });
@@ -1036,7 +1048,13 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
         // already merges internally, so this keeps the bare `middleware: mw`
         // form and the array form observably identical (and is a no-op for
         // the composed chain, whose context already contains the seed).
-        const helpers = { context: { ...seedContext, ...opts?.context }, errors, raw: msg };
+        const helpers = {
+          context: { ...seedContext, ...opts?.context },
+          errors,
+          raw: msg,
+          retryable: retryableFactory,
+          nonRetryable: nonRetryableFactory,
+        };
         if (opts?.payload === undefined) {
           return handler(helpers, validatedMessage);
         }

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -85,6 +85,7 @@ const nonRetryableFactory = (message: string, cause?: unknown): NonRetryableErro
 
 type StoredHandler = (
   helpers: {
+    message: { payload: unknown; headers: unknown };
     context: Record<string, unknown>;
     errors: Record<string, (data: unknown, message?: string) => RpcError>;
     raw: ConsumeMessage;
@@ -1048,7 +1049,11 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
         // already merges internally, so this keeps the bare `middleware: mw`
         // form and the array form observably identical (and is a no-op for
         // the composed chain, whose context already contains the seed).
-        const helpers = {
+        // The message is on the record AND in the second parameter, oRPC's own
+        // shape — so it is built per invocation rather than once: a middleware
+        // that substituted the payload must not leave the record showing the
+        // value the handler did not receive.
+        const ambient = {
           context: { ...seedContext, ...opts?.context },
           errors,
           raw: msg,
@@ -1056,7 +1061,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
           nonRetryable: nonRetryableFactory,
         };
         if (opts?.payload === undefined) {
-          return handler(helpers, validatedMessage);
+          return handler({ ...ambient, message: validatedMessage }, validatedMessage);
         }
         // A middleware substituted the payload — re-validate against the
         // consumer's schema before the handler sees it, so middleware cannot
@@ -1068,9 +1073,10 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
           opts.payload,
           "Middleware-substituted payload",
           String(name),
-        ).flatMap((validatedPayload) =>
-          handler(helpers, { ...validatedMessage, payload: validatedPayload }),
-        );
+        ).flatMap((validatedPayload) => {
+          const substituted = { ...validatedMessage, payload: validatedPayload };
+          return handler({ ...ambient, message: substituted }, substituted);
+        });
       };
 
       if (!this.middleware) {

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -75,12 +75,12 @@ type HandlerName<TContract extends ContractDefinition> =
  * to the caller instead of routing to retry/DLQ.
  */
 type StoredHandler = (
-  message: { payload: unknown; headers: unknown },
-  rawMessage: ConsumeMessage,
   helpers: {
     context: Record<string, unknown>;
     errors: Record<string, (data: unknown, message?: string) => RpcError>;
+    raw: ConsumeMessage;
   },
+  message: { payload: unknown; headers: unknown },
 ) => AsyncResult<unknown, HandlerError | RpcError>;
 
 /**
@@ -1036,9 +1036,9 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
         // already merges internally, so this keeps the bare `middleware: mw`
         // form and the array form observably identical (and is a no-op for
         // the composed chain, whose context already contains the seed).
-        const helpers = { context: { ...seedContext, ...opts?.context }, errors };
+        const helpers = { context: { ...seedContext, ...opts?.context }, errors, raw: msg };
         if (opts?.payload === undefined) {
-          return handler(validatedMessage, msg, helpers);
+          return handler(helpers, validatedMessage);
         }
         // A middleware substituted the payload — re-validate against the
         // consumer's schema before the handler sees it, so middleware cannot
@@ -1051,7 +1051,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
           "Middleware-substituted payload",
           String(name),
         ).flatMap((validatedPayload) =>
-          handler({ ...validatedMessage, payload: validatedPayload }, msg, helpers),
+          handler(helpers, { ...validatedMessage, payload: validatedPayload }),
         );
       };
 

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -85,7 +85,7 @@ const nonRetryableFactory = (message: string, cause?: unknown): NonRetryableErro
 
 type StoredHandler = (
   helpers: {
-    message: { payload: unknown; headers: unknown };
+    input: { payload: unknown; headers: unknown };
     context: Record<string, unknown>;
     errors: Record<string, (data: unknown, message?: string) => RpcError>;
     raw: ConsumeMessage;
@@ -173,13 +173,13 @@ function isHandlerTuple(entry: unknown): entry is [unknown, ConsumerOptions] {
  *   contract: myContract,
  *   handlers: {
  *     // Simple handler
- *     processOrder: (_, { payload }) => {
+ *     processOrder: ({ input: { payload } }) => {
  *       console.log('Processing order:', payload.orderId);
  *       return OkAsync(undefined);
  *     },
  *     // Handler with prefetch configuration
  *     processPayment: [
- *       (_, { payload }) => {
+ *       ({ input: { payload } }) => {
  *         console.log('Processing payment:', payload.paymentId);
  *         return OkAsync(undefined);
  *       },
@@ -329,7 +329,7 @@ export type CreateWorkerOptions<
  * const worker = await TypedAmqpWorker.create({
  *   contract,
  *   handlers: {
- *     processOrder: (_, { payload }) => {
+ *     processOrder: ({ input: { payload } }) => {
  *       console.log('Processing order', payload.orderId);
  *       return OkAsync(undefined);
  *     },
@@ -457,7 +457,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
    * const result = await TypedAmqpWorker.create({
    *   contract: myContract,
    *   handlers: {
-   *     processOrder: (_, { payload }) => OkAsync(undefined),
+   *     processOrder: ({ input: { payload } }) => OkAsync(undefined),
    *   },
    *   urls: ['amqp://localhost'],
    * });
@@ -1049,10 +1049,10 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
         // already merges internally, so this keeps the bare `middleware: mw`
         // form and the array form observably identical (and is a no-op for
         // the composed chain, whose context already contains the seed).
-        // The message is on the record AND in the second parameter, oRPC's own
-        // shape — so it is built per invocation rather than once: a middleware
-        // that substituted the payload must not leave the record showing the
-        // value the handler did not receive.
+        // The message is on the record as `input` AND in the second parameter,
+        // oRPC's own shape — so the record is built per invocation rather than
+        // once: a middleware that substituted the payload must not leave it
+        // showing the value the handler did not receive.
         const ambient = {
           context: { ...seedContext, ...opts?.context },
           errors,
@@ -1061,7 +1061,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
           nonRetryable: nonRetryableFactory,
         };
         if (opts?.payload === undefined) {
-          return handler({ ...ambient, message: validatedMessage }, validatedMessage);
+          return handler({ ...ambient, input: validatedMessage }, validatedMessage);
         }
         // A middleware substituted the payload — re-validate against the
         // consumer's schema before the handler sees it, so middleware cannot
@@ -1075,7 +1075,7 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
           String(name),
         ).flatMap((validatedPayload) => {
           const substituted = { ...validatedMessage, payload: validatedPayload };
-          return handler({ ...ambient, message: substituted }, substituted);
+          return handler({ ...ambient, input: substituted }, substituted);
         });
       };
 

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -217,9 +217,11 @@ export type CreateWorkerOptions<
    *   accepts the declared `RpcError<code, data>` members (otherwise it
    *   stays plain `HandlerError`).
    *
-   * Handlers receive the helpers record FIRST — `{ context, errors, raw }` —
-   * and the validated message second. `context` is an empty object when no
-   * `createContext` and no `middleware` are configured.
+   * Handlers receive one record FIRST —
+   * `{ input, context, errors, raw, retryable, nonRetryable }`, where `input`
+   * is the validated message — and that message again as the second
+   * parameter. `context` is an empty object when no `createContext` and no
+   * `middleware` are configured.
    *
    * Use `declareHandler` / `declareHandlers` to create handlers with full type
    * inference.

--- a/tests/src/__tests__/client-worker.spec.ts
+++ b/tests/src/__tests__/client-worker.spec.ts
@@ -179,6 +179,7 @@ describe("Client and Worker Integration", () => {
           expect(mockHandler).toHaveBeenCalledTimes(1);
           expect(mockHandler).toHaveBeenNthCalledWith(
             1,
+            expect.anything(), // helpers: { context, errors, raw }
             {
               payload: {
                 orderId: "ORD-123",
@@ -191,8 +192,6 @@ describe("Client and Worker Integration", () => {
                 "x-default-header": "default-header-value", // Default value applied
               },
             },
-            expect.anything(), // rawMessage
-            expect.anything(), // middleware context
           );
         },
         { timeout: 5000 },
@@ -237,7 +236,7 @@ describe("Client and Worker Integration", () => {
 
       // GIVEN
       const receivedMessages: unknown[] = [];
-      const mockHandler = vi.fn().mockImplementation((message: unknown) => {
+      const mockHandler = vi.fn().mockImplementation((_helpers: unknown, message: unknown) => {
         receivedMessages.push(message);
         return OkAsync(undefined);
       });
@@ -435,26 +434,24 @@ describe("Client and Worker Integration", () => {
           expect(emailHandler).toHaveBeenCalledTimes(1);
           expect(emailHandler).toHaveBeenNthCalledWith(
             1,
+            expect.anything(), // helpers: { context, errors, raw }
             {
               payload: {
                 recipient: "user@example.com",
                 message: "Test email",
               },
             },
-            expect.anything(), // rawMessage
-            expect.anything(), // middleware context
           );
           expect(smsHandler).toHaveBeenCalledTimes(1);
           expect(smsHandler).toHaveBeenNthCalledWith(
             1,
+            expect.anything(), // helpers: { context, errors, raw }
             {
               payload: {
                 recipient: "+1234567890",
                 message: "Test SMS",
               },
             },
-            expect.anything(), // rawMessage
-            expect.anything(), // middleware context
           );
         },
         { timeout: 5000 },

--- a/tests/src/__tests__/compression.spec.ts
+++ b/tests/src/__tests__/compression.spec.ts
@@ -149,9 +149,8 @@ describe("Compression end-to-end", () => {
         { timeout: 5_000 },
       );
       expect(received).toHaveBeenCalledWith(
+        expect.anything(),
         expect.objectContaining({ payload }),
-        expect.anything(),
-        expect.anything(),
       );
     },
   );
@@ -181,10 +180,6 @@ describe("Compression end-to-end", () => {
       },
       { timeout: 5_000 },
     );
-    expect(received).toHaveBeenCalledWith(
-      expect.objectContaining({ payload }),
-      expect.anything(),
-      expect.anything(),
-    );
+    expect(received).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ payload }));
   });
 });

--- a/tests/src/__tests__/decompression-cap.spec.ts
+++ b/tests/src/__tests__/decompression-cap.spec.ts
@@ -58,7 +58,7 @@ describe("worker decompression cap and poison-message drop logging", () => {
         maxDecompressedBytes: 64,
         logger,
         handlers: {
-          consumeThing: (_, { payload }) => {
+          consumeThing: ({ input: { payload } }) => {
             handlerCalls.push(payload);
             return OkAsync();
           },

--- a/tests/src/__tests__/decompression-cap.spec.ts
+++ b/tests/src/__tests__/decompression-cap.spec.ts
@@ -58,7 +58,7 @@ describe("worker decompression cap and poison-message drop logging", () => {
         maxDecompressedBytes: 64,
         logger,
         handlers: {
-          consumeThing: ({ payload }) => {
+          consumeThing: (_, { payload }) => {
             handlerCalls.push(payload);
             return OkAsync();
           },

--- a/tests/src/__tests__/middleware.spec.ts
+++ b/tests/src/__tests__/middleware.spec.ts
@@ -133,7 +133,7 @@ const buildRpcContract = (suffix: string) => {
 };
 
 describe("worker middleware", () => {
-  it("injects typed context that handlers receive as third argument", async ({
+  it("injects typed context that handlers receive in their helpers record", async ({
     workerFactory,
     clientFactory,
   }) => {

--- a/tests/src/__tests__/middleware.spec.ts
+++ b/tests/src/__tests__/middleware.spec.ts
@@ -159,7 +159,7 @@ describe("worker middleware", () => {
       contract,
       middleware,
       handlers: {
-        processOrder: (_message, _raw, { context }) => {
+        processOrder: ({ context }) => {
           resolveSeen(context);
           return OkAsync(undefined);
         },
@@ -199,7 +199,7 @@ describe("worker middleware", () => {
       contract,
       middleware: [outer, inner],
       handlers: {
-        processOrder: (_message, _raw, { context }) => {
+        processOrder: ({ context }) => {
           resolveSeen(context as Record<string, unknown>);
           return OkAsync(undefined);
         },
@@ -263,7 +263,7 @@ describe("worker middleware", () => {
         return next();
       }),
       handlers: {
-        calculate: ({ payload }) => OkAsync({ sum: payload.a + payload.b }),
+        calculate: (_, { payload }) => OkAsync({ sum: payload.a + payload.b }),
       },
     });
     const client = await clientFactory({ contract });
@@ -302,7 +302,7 @@ describe("client interceptors", () => {
     await workerFactory({
       contract,
       handlers: {
-        processOrder: (_message, raw) => {
+        processOrder: ({ raw }) => {
           resolveHeaders(raw.properties.headers);
           return OkAsync(undefined);
         },
@@ -333,7 +333,7 @@ describe("client interceptors", () => {
     await workerFactory({
       contract,
       handlers: {
-        calculate: ({ payload }) => OkAsync({ sum: payload.a + payload.b }),
+        calculate: (_, { payload }) => OkAsync({ sum: payload.a + payload.b }),
       },
     });
 
@@ -383,7 +383,7 @@ describe("createContext and handler helpers", () => {
         (args, next) => next({ context: { ...args.context, stamped: true } }),
       ),
       handlers: {
-        processOrder: (_message, _raw, { context }) => {
+        processOrder: ({ context }) => {
           resolveSeen(context);
           return OkAsync(undefined);
         },
@@ -432,7 +432,7 @@ describe("createContext and handler helpers", () => {
     await workerFactory({
       contract,
       handlers: {
-        calculate: ({ payload }, _raw, { errors }) =>
+        calculate: ({ errors }, { payload }) =>
           payload.a < 0
             ? ErrAsync(errors.BLOCKED({ reason: "negative" }))
             : OkAsync({ sum: payload.a + payload.b }),
@@ -469,7 +469,7 @@ describe("middleware payload substitution", () => {
         return next({ payload: { orderId: `${payload.orderId}-rewritten` } });
       }),
       handlers: {
-        processOrder: ({ payload }) => {
+        processOrder: (_, { payload }) => {
           resolveSeen(payload);
           return OkAsync(undefined);
         },

--- a/tests/src/__tests__/middleware.spec.ts
+++ b/tests/src/__tests__/middleware.spec.ts
@@ -263,7 +263,7 @@ describe("worker middleware", () => {
         return next();
       }),
       handlers: {
-        calculate: (_, { payload }) => OkAsync({ sum: payload.a + payload.b }),
+        calculate: ({ input: { payload } }) => OkAsync({ sum: payload.a + payload.b }),
       },
     });
     const client = await clientFactory({ contract });
@@ -333,7 +333,7 @@ describe("client interceptors", () => {
     await workerFactory({
       contract,
       handlers: {
-        calculate: (_, { payload }) => OkAsync({ sum: payload.a + payload.b }),
+        calculate: ({ input: { payload } }) => OkAsync({ sum: payload.a + payload.b }),
       },
     });
 
@@ -432,7 +432,7 @@ describe("createContext and handler helpers", () => {
     await workerFactory({
       contract,
       handlers: {
-        calculate: ({ errors }, { payload }) =>
+        calculate: ({ errors, input: { payload } }) =>
           payload.a < 0
             ? ErrAsync(errors.BLOCKED({ reason: "negative" }))
             : OkAsync({ sum: payload.a + payload.b }),
@@ -469,7 +469,7 @@ describe("middleware payload substitution", () => {
         return next({ payload: { orderId: `${payload.orderId}-rewritten` } });
       }),
       handlers: {
-        processOrder: (_, { payload }) => {
+        processOrder: ({ input: { payload } }) => {
           resolveSeen(payload);
           return OkAsync(undefined);
         },

--- a/tests/src/__tests__/rpc.spec.ts
+++ b/tests/src/__tests__/rpc.spec.ts
@@ -108,7 +108,10 @@ describe("TypedAmqpClient RPC", () => {
     const contract = buildContract("rpc.calculate.success");
 
     await workerFactory(contract, {
-      calculate: (_, { payload }) => OkAsync({ sum: payload.a + payload.b }),
+      // The single-record spelling, once, in a test that already proves the
+      // round trip: `message` on the helpers is the same value the second
+      // parameter carries, or one of the two is lying.
+      calculate: ({ message }) => OkAsync({ sum: message.payload.a + message.payload.b }),
     });
     const client = await clientFactory(contract);
 

--- a/tests/src/__tests__/rpc.spec.ts
+++ b/tests/src/__tests__/rpc.spec.ts
@@ -109,9 +109,9 @@ describe("TypedAmqpClient RPC", () => {
 
     await workerFactory(contract, {
       // The single-record spelling, once, in a test that already proves the
-      // round trip: `message` on the helpers is the same value the second
+      // round trip: `input` on the record is the same value the second
       // parameter carries, or one of the two is lying.
-      calculate: ({ message }) => OkAsync({ sum: message.payload.a + message.payload.b }),
+      calculate: ({ input }) => OkAsync({ sum: input.payload.a + input.payload.b }),
     });
     const client = await clientFactory(contract);
 
@@ -266,7 +266,7 @@ describe("TypedAmqpClient RPC typed errors", () => {
     const contract = buildErrorContract("rpc.calculate.typed-error");
 
     await workerFactory(contract, {
-      calculate: (_, { payload }) =>
+      calculate: ({ input: { payload } }) =>
         payload.a < 0 || payload.b < 0
           ? ErrAsync(
               rpcError("NEGATIVE_NUMBERS", { a: payload.a, b: payload.b }, "negatives rejected"),
@@ -295,7 +295,7 @@ describe("TypedAmqpClient RPC typed errors", () => {
     const contract = buildErrorContract("rpc.calculate.typed-error-ok");
 
     await workerFactory(contract, {
-      calculate: (_, { payload }) =>
+      calculate: ({ input: { payload } }) =>
         payload.a < 0 || payload.b < 0
           ? ErrAsync(rpcError("NEGATIVE_NUMBERS", { a: payload.a, b: payload.b }))
           : OkAsync({ sum: payload.a + payload.b }),
@@ -317,7 +317,7 @@ describe("TypedAmqpClient RPC typed errors", () => {
     const contract = buildErrorContract("rpc.calculate.typed-error-codes");
 
     await workerFactory(contract, {
-      calculate: (_, { payload }) =>
+      calculate: ({ input: { payload } }) =>
         payload.a + payload.b > 100
           ? ErrAsync(rpcError("LIMIT_EXCEEDED", { limit: 100 }))
           : OkAsync({ sum: payload.a + payload.b }),
@@ -458,7 +458,7 @@ describe("TypedAmqpClient RPC DLQ routing", () => {
 
     let handlerCalls = 0;
     await workerFactory(contract, {
-      calculate: (_, { payload }) => {
+      calculate: ({ input: { payload } }) => {
         handlerCalls++;
         return OkAsync({ sum: payload.a + payload.b });
       },

--- a/tests/src/__tests__/rpc.spec.ts
+++ b/tests/src/__tests__/rpc.spec.ts
@@ -18,7 +18,7 @@ import {
 } from "@amqp-contract/contract";
 import { TechnicalError } from "@amqp-contract/core";
 import { it as baseIt } from "@amqp-contract/testing/extension";
-import { rpcError, TypedAmqpWorker } from "@amqp-contract/worker";
+import { NonRetryableError, rpcError, TypedAmqpWorker } from "@amqp-contract/worker";
 import { ErrAsync, fromSafePromise, OkAsync } from "unthrown";
 import { describe, expect, vi } from "vitest";
 import { z } from "zod";
@@ -108,10 +108,13 @@ describe("TypedAmqpClient RPC", () => {
     const contract = buildContract("rpc.calculate.success");
 
     await workerFactory(contract, {
-      // The single-record spelling, once, in a test that already proves the
-      // round trip: `input` on the record is the same value the second
-      // parameter carries, or one of the two is lying.
-      calculate: ({ input }) => OkAsync({ sum: input.payload.a + input.payload.b }),
+      // Both spellings, once, in a test that already proves the round trip:
+      // the record's `input` must BE the positional message — not an equal
+      // copy — or one of the two is lying about what the handler received.
+      calculate: ({ input }, message) =>
+        input === message
+          ? OkAsync({ sum: input.payload.a + input.payload.b })
+          : ErrAsync(new NonRetryableError("helpers.input is not the positional message")),
     });
     const client = await clientFactory(contract);
 

--- a/tests/src/__tests__/rpc.spec.ts
+++ b/tests/src/__tests__/rpc.spec.ts
@@ -108,7 +108,7 @@ describe("TypedAmqpClient RPC", () => {
     const contract = buildContract("rpc.calculate.success");
 
     await workerFactory(contract, {
-      calculate: ({ payload }) => OkAsync({ sum: payload.a + payload.b }),
+      calculate: (_, { payload }) => OkAsync({ sum: payload.a + payload.b }),
     });
     const client = await clientFactory(contract);
 
@@ -263,7 +263,7 @@ describe("TypedAmqpClient RPC typed errors", () => {
     const contract = buildErrorContract("rpc.calculate.typed-error");
 
     await workerFactory(contract, {
-      calculate: ({ payload }) =>
+      calculate: (_, { payload }) =>
         payload.a < 0 || payload.b < 0
           ? ErrAsync(
               rpcError("NEGATIVE_NUMBERS", { a: payload.a, b: payload.b }, "negatives rejected"),
@@ -292,7 +292,7 @@ describe("TypedAmqpClient RPC typed errors", () => {
     const contract = buildErrorContract("rpc.calculate.typed-error-ok");
 
     await workerFactory(contract, {
-      calculate: ({ payload }) =>
+      calculate: (_, { payload }) =>
         payload.a < 0 || payload.b < 0
           ? ErrAsync(rpcError("NEGATIVE_NUMBERS", { a: payload.a, b: payload.b }))
           : OkAsync({ sum: payload.a + payload.b }),
@@ -314,7 +314,7 @@ describe("TypedAmqpClient RPC typed errors", () => {
     const contract = buildErrorContract("rpc.calculate.typed-error-codes");
 
     await workerFactory(contract, {
-      calculate: ({ payload }) =>
+      calculate: (_, { payload }) =>
         payload.a + payload.b > 100
           ? ErrAsync(rpcError("LIMIT_EXCEEDED", { limit: 100 }))
           : OkAsync({ sum: payload.a + payload.b }),
@@ -455,7 +455,7 @@ describe("TypedAmqpClient RPC DLQ routing", () => {
 
     let handlerCalls = 0;
     await workerFactory(contract, {
-      calculate: ({ payload }) => {
+      calculate: (_, { payload }) => {
         handlerCalls++;
         return OkAsync({ sum: payload.a + payload.b });
       },


### PR DESCRIPTION
Closes #670.

```diff
- processOrder: ({ payload }) => save(payload),
+ processOrder: (_, { payload }) => save(payload),
- handleFailed: ({ payload }, rawMessage) => log(rawMessage.properties.headers),
+ handleFailed: ({ raw }, { payload }) => log(raw.properties.headers),
- getOrder: ({ payload }, _raw, { errors }) => lookup(payload, errors),
+ getOrder: ({ errors }, { payload }) => lookup(payload, errors),
```

The issue was filed when this leaf had **no helpers record at all**; it has one
now, as a third parameter. What was left is the order — and the raw amqplib
delivery, which moved from that third parameter into `raw` on the helpers, so
the leaf has the same **arity and shape** as the other two rather than an extra
parameter neither of them has:

| Transport | Leaf |
| --- | --- |
| HTTP (oRPC) | `place: ({ errors, context }, input) => …` |
| Temporal | `place: ({ errors, context }, args) => …` (btravstack/temporal-contract#415) |
| AMQP (this) | `process: ({ errors, context, raw }, message) => …` |

oRPC is the reference because it is the most widely used of the three, so it is
the shape that costs the least to match. And per the issue, the AMQP row was the
one that was not merely ordered differently: a handler reaching for `errors` it
was handed is what makes its triage site the same shape as the other two, rather
than importing `RetryableError` and constructing it by hand.

### What changed

Three lines at the dispatch seam (`runHandler`), the `StoredHandler` shape, and
the two leaf types — plus `raw` on `WorkerHandlerHelpers`. Everything else is
the sweep: 63 samples across the docs site, the READMEs, the agent rules and the
example worker, the unit and integration specs, and a new §"Handlers take
helpers first, message second" in the upgrade guide.

Two new type gates: `raw` is on the helpers record and typed `ConsumeMessage`,
and a third parameter is a compile error.

### What the compiler does and does not catch

**Reads its payload → fails to compile.** **Ignores its message → keeps
compiling**, with a parameter whose name lies. That asymmetry is in the upgrade
guide with the grep for it, and it is why the sweep was done by reading every
handlers object rather than by chasing the error list.

### Gate

`format --check`, `lint` (0 warnings), `typecheck` 17/17, `knip`, `build`, unit
13/13, and the integration tier against a real RabbitMQ — worker 33, tests 47,
core 33, client 14, both examples — all green.

https://claude.ai/code/session_01GGixjxi5AQ2cNK62bBymfF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Worker and RPC handlers now receive a helpers record first and the validated message second.
  * Access payloads and headers through `helpers.input`; raw delivery details are available through `helpers.raw`.
  * Separate raw-message and helpers parameters are no longer supported.

* **New Features**
  * Helpers now provide retryable and non-retryable error factories.

* **Documentation**
  * Updated guides, examples, READMEs, and upgrade instructions for the revised handler API.

* **Tests**
  * Updated fixtures and assertions for the new handler signature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->