### PR TITLE
fix(worker): a payload substitution is the key being present, not its value

### DIFF
--- a/.changeset/payload-substitution-presence.md
+++ b/.changeset/payload-substitution-presence.md
@@ -1,0 +1,24 @@
+---
+"@amqp-contract/worker": patch
+---
+
+A middleware's `next({ payload: undefined })` is a substitution now, and the
+payload schema refuses it — where it used to be indistinguishable from
+`next({})` and silently dropped, leaving the handler running on the original
+message.
+
+Both the dispatcher and `composeMiddleware` used the VALUE as the sentinel
+(`opts?.payload === undefined` meaning "nothing substituted"), so the one
+payload a middleware could not substitute was `undefined` — and it failed
+quietly, in the direction that keeps processing rather than the direction that
+stops. Presence is the sentinel now: `Object.hasOwn(opts, "payload")` in the
+dispatcher, and a boxed `{ payload }` threaded through the chain.
+
+**Behaviour change, in the one case that was already broken.** A middleware
+calling `next({ payload: undefined })` today gets a no-op; after this it
+substitutes `undefined`, the consumer's payload schema rejects it, and the
+message is dead-lettered as a `NonRetryableError` — the same route any other
+invalid substitution takes. `next({})` and `next()` are unaffected: they
+substitute nothing, as before.
+
+Closes #672.

--- a/.changeset/payload-substitution-presence.md
+++ b/.changeset/payload-substitution-presence.md
@@ -2,8 +2,8 @@
 "@amqp-contract/worker": patch
 ---
 
-A middleware's `next({ payload: undefined })` is a substitution now, and the
-payload schema refuses it — where it used to be indistinguishable from
+A middleware's `next({ payload: undefined })` is a substitution now, and reaches
+the payload schema like any other — where it used to be indistinguishable from
 `next({})` and silently dropped, leaving the handler running on the original
 message.
 
@@ -16,9 +16,10 @@ dispatcher, and a boxed `{ payload }` threaded through the chain.
 
 **Behaviour change, in the one case that was already broken.** A middleware
 calling `next({ payload: undefined })` today gets a no-op; after this it
-substitutes `undefined`, the consumer's payload schema rejects it, and the
-message is dead-lettered as a `NonRetryableError` — the same route any other
-invalid substitution takes. `next({})` and `next()` are unaffected: they
-substitute nothing, as before.
+substitutes `undefined` and the consumer's payload schema decides — a schema
+that demands a shape rejects it and the message is dead-lettered as a
+`NonRetryableError`, the same route any other invalid substitution takes, while
+a schema admitting `undefined` hands it to the handler. `next({})` and `next()`
+are unaffected: they substitute nothing, as before.
 
 Closes #672.

--- a/packages/worker/src/middleware.spec.ts
+++ b/packages/worker/src/middleware.spec.ts
@@ -164,8 +164,7 @@ describe("composeMiddleware", () => {
 
     // THEN the inner middleware saw the substitution, and the terminal was
     // handed `payload` as a PRESENT key — which is what sends it back through
-    // the payload schema, where `undefined` is refused like any other bad
-    // substitution
+    // the payload schema, whose business it then is
     expect({
       seen,
       present: terminalOpts !== undefined && Object.hasOwn(terminalOpts, "payload"),

--- a/packages/worker/src/middleware.spec.ts
+++ b/packages/worker/src/middleware.spec.ts
@@ -143,6 +143,36 @@ describe("composeMiddleware", () => {
     expect(terminalOpts !== undefined && "payload" in terminalOpts).toBe(false);
   });
 
+  it("carries an explicit `undefined` substitution, which is not the same as substituting nothing", async () => {
+    // GIVEN a middleware that deliberately substitutes `undefined` — the one
+    // value that used to mean "I substituted nothing", so the request was
+    // silently dropped and the handler saw the original payload
+    const seen: unknown[] = [];
+    const blank = declareMiddleware((_args, next) => next({ payload: undefined }));
+    const observer = declareMiddleware((args, next) => {
+      seen.push(args.message.payload);
+      return next();
+    });
+
+    // WHEN the chain runs
+    let terminalOpts: { context?: Record<string, unknown>; payload?: unknown } | undefined;
+    const chain = composeMiddleware(blank, observer);
+    await chain(baseArgs, (opts) => {
+      terminalOpts = opts;
+      return OkAsync(undefined);
+    });
+
+    // THEN the inner middleware saw the substitution, and the terminal was
+    // handed `payload` as a PRESENT key — which is what sends it back through
+    // the payload schema, where `undefined` is refused like any other bad
+    // substitution
+    expect({
+      seen,
+      present: terminalOpts !== undefined && Object.hasOwn(terminalOpts, "payload"),
+      value: terminalOpts?.payload,
+    }).toEqual({ seen: [undefined], present: true, value: undefined });
+  });
+
   it("exposes dispatch metadata to every middleware", async () => {
     // GIVEN
     const seen: Array<{ handlerName: string; isRpc: boolean }> = [];

--- a/packages/worker/src/middleware.ts
+++ b/packages/worker/src/middleware.ts
@@ -44,8 +44,10 @@ export type WorkerMiddlewareArgs<TContextIn extends Record<string, unknown> | Em
  * past the contract boundary.
  *
  * What counts as a substitution is the KEY being present, not its value:
- * `next({ payload: undefined })` substitutes `undefined` and is refused by
- * the schema, where `next({})` and `next()` leave the message alone.
+ * `next({ payload: undefined })` substitutes `undefined` and sends it through
+ * the payload schema like any other substitution — refused by a schema that
+ * demands a shape, accepted by one that admits `undefined` — where `next({})`
+ * and `next()` leave the message alone.
  *
  * The returned AsyncResult carries the handler outcome: `undefined` for a
  * regular consumer, the (not yet validated) response for an RPC. A middleware

--- a/packages/worker/src/middleware.ts
+++ b/packages/worker/src/middleware.ts
@@ -43,6 +43,10 @@ export type WorkerMiddlewareArgs<TContextIn extends Record<string, unknown> | Em
  * `NonRetryableError` (DLQ), so middleware cannot smuggle unvalidated data
  * past the contract boundary.
  *
+ * What counts as a substitution is the KEY being present, not its value:
+ * `next({ payload: undefined })` substitutes `undefined` and is refused by
+ * the schema, where `next({})` and `next()` leave the message alone.
+ *
  * The returned AsyncResult carries the handler outcome: `undefined` for a
  * regular consumer, the (not yet validated) response for an RPC. A middleware
  * can transform or inspect it before returning.
@@ -240,22 +244,26 @@ export function composeMiddleware(
   ...middlewares: readonly AnyWorkerMiddleware[]
 ): AnyWorkerMiddleware {
   return (args, next) => {
-    // `payload` stays undefined until a middleware substitutes it — the
-    // terminal (the worker dispatcher) re-validates only when set.
+    // A substitution is carried BOXED, not as a bare value: `undefined` is a
+    // payload a middleware may legitimately substitute (the schema then
+    // refuses it, like any other bad substitution), so "nothing substituted"
+    // has to be the absence of the box rather than the absence of a value.
     const run = (
       index: number,
       context: Record<string, unknown>,
-      payload: unknown,
+      substituted: { readonly payload: unknown } | undefined,
     ): ReturnType<AnyWorkerMiddleware> => {
       if (index >= middlewares.length) {
-        return next(payload === undefined ? { context } : { context, payload });
+        return next(substituted ? { context, payload: substituted.payload } : { context });
       }
-      const message = payload === undefined ? args.message : { ...args.message, payload };
+      const message = substituted
+        ? { ...args.message, payload: substituted.payload }
+        : args.message;
       return middlewares[index]!({ ...args, message, context }, (opts) =>
         run(
           index + 1,
           { ...context, ...opts?.context },
-          opts?.payload === undefined ? payload : opts.payload,
+          opts && Object.hasOwn(opts, "payload") ? { payload: opts.payload } : substituted,
         ),
       );
     };

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1063,7 +1063,8 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
           nonRetryable: nonRetryableFactory,
         };
         // Presence, not value: `next({ payload: undefined })` is a
-        // substitution the schema gets to refuse, where `next({})` is not one.
+        // substitution, and what happens to it is the payload schema's
+        // decision; `next({})` is not one.
         if (!opts || !Object.hasOwn(opts, "payload")) {
           return handler({ ...ambient, input: validatedMessage }, validatedMessage);
         }

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -1062,7 +1062,9 @@ export class TypedAmqpWorker<TContract extends ContractDefinition> {
           retryable: retryableFactory,
           nonRetryable: nonRetryableFactory,
         };
-        if (opts?.payload === undefined) {
+        // Presence, not value: `next({ payload: undefined })` is a
+        // substitution the schema gets to refuse, where `next({})` is not one.
+        if (!opts || !Object.hasOwn(opts, "payload")) {
           return handler({ ...ambient, input: validatedMessage }, validatedMessage);
         }
         // A middleware substituted the payload — re-validate against the

--- a/tests/src/__tests__/middleware.spec.ts
+++ b/tests/src/__tests__/middleware.spec.ts
@@ -21,7 +21,7 @@ import {
   type EmptyContext,
 } from "@amqp-contract/worker";
 import { ErrAsync, OkAsync } from "unthrown";
-import { describe, expect } from "vitest";
+import { describe, expect, vi } from "vitest";
 import { z } from "zod";
 
 const it = baseIt.extend<{
@@ -483,6 +483,7 @@ describe("middleware payload substitution", () => {
   });
 
   it("refuses an explicit `undefined` substitution rather than silently keeping the original", async ({
+    amqpChannel,
     workerFactory,
     clientFactory,
   }) => {
@@ -504,13 +505,28 @@ describe("middleware payload substitution", () => {
     });
     const client = await clientFactory({ contract });
 
-    // WHEN a message is published
+    // WHEN a message is published, and the DEAD LETTER is waited for rather
+    // than a clock: a fixed sleep passes just as well when the worker is
+    // merely slow, or when the message went nowhere at all
     await client.publish("createOrder", { orderId: "1" }).getOrThrow();
-    await new Promise((res) => setTimeout(res, 300));
+    const deadLettered = await vi.waitFor(
+      async () => {
+        const delivery = await amqpChannel.get("orders-substitution-undefined-dlq", {
+          noAck: true,
+        });
+        if (delivery === false) throw new Error("not dead-lettered yet");
+        return delivery;
+      },
+      { timeout: 5_000, interval: 50 },
+    );
 
-    // THEN the payload schema refused it, exactly as it refuses any other bad
-    // substitution — the handler never ran
-    expect(handlerRan).toBe(false);
+    // THEN this contract's payload schema — which demands `{ orderId }` —
+    // refused the substitution, so the original message is on the DLQ and the
+    // handler never ran
+    expect({
+      handlerRan,
+      deadLetteredBody: JSON.parse(deadLettered.content.toString()) as unknown,
+    }).toEqual({ handlerRan: false, deadLetteredBody: { orderId: "1" } });
   });
 
   it("blocks handler execution when the substitution fails the schema", async ({

--- a/tests/src/__tests__/middleware.spec.ts
+++ b/tests/src/__tests__/middleware.spec.ts
@@ -482,6 +482,37 @@ describe("middleware payload substitution", () => {
     await expect(seen).resolves.toEqual({ orderId: "1-rewritten" });
   });
 
+  it("refuses an explicit `undefined` substitution rather than silently keeping the original", async ({
+    workerFactory,
+    clientFactory,
+  }) => {
+    const contract = buildConsumerContract("substitution-undefined");
+
+    // GIVEN a middleware that substitutes `undefined` — which used to be the
+    // one value indistinguishable from substituting nothing, so the handler
+    // ran on the original message and the middleware's decision was lost
+    let handlerRan = false;
+    await workerFactory({
+      contract,
+      middleware: declareMiddleware((_args, next) => next({ payload: undefined })),
+      handlers: {
+        processOrder: () => {
+          handlerRan = true;
+          return OkAsync(undefined);
+        },
+      },
+    });
+    const client = await clientFactory({ contract });
+
+    // WHEN a message is published
+    await client.publish("createOrder", { orderId: "1" }).getOrThrow();
+    await new Promise((res) => setTimeout(res, 300));
+
+    // THEN the payload schema refused it, exactly as it refuses any other bad
+    // substitution — the handler never ran
+    expect(handlerRan).toBe(false);
+  });
+
   it("blocks handler execution when the substitution fails the schema", async ({
     workerFactory,
     clientFactory,


### PR DESCRIPTION
Closes #672. Found in review on #671 and filed rather than smuggled in there — it is a behaviour change and deserves its own changeset.

### The defect

`next({ payload: undefined })` was indistinguishable from `next({})`. Both the dispatcher and `composeMiddleware` used the **value** as the sentinel:

```ts
if (opts?.payload === undefined) { /* nothing substituted */ }
```

So the one payload a middleware could not substitute was `undefined` — and it failed **quietly, in the direction that keeps processing**: the middleware's decision was dropped and the handler ran on the original message.

### The fix

Presence, not value. `Object.hasOwn(opts, "payload")` at the dispatch seam, and a boxed `{ payload }` threaded through the chain instead of a bare value — so "nothing substituted" is the absence of the box rather than the absence of a value. `undefined` then reaches the consumer's payload schema, which refuses it exactly as it refuses `{ wrong: "shape" }`, and the message is dead-lettered.

### Behaviour change, in the one case that was already broken

A middleware calling `next({ payload: undefined })` gets a no-op today; after this it substitutes, fails validation, and the message routes to the DLQ as a `NonRetryableError` — the route every other invalid substitution takes. `next({})` and `next()` are untouched.

### Gates, each verified to bite

Both were written failing first, and after the fix each was re-run with the old sentinel restored to confirm it fails again:

- **Unit** (`composeMiddleware`) — the inner middleware sees the substituted `undefined`, and the terminal receives `payload` as a *present* key.
- **Integration** (real broker) — the handler must not run; with the old sentinel restored, `1 failed | 11 passed`.

Sibling assertions already in the suite pin the other direction, that `next()` and `next({})` substitute nothing.

### Gate

`format --check`, `lint` (0 warnings), `typecheck` 17/17, `knip`, `build`, unit 13/13 under `--force`, integration 13/13 against a real RabbitMQ.

https://claude.ai/code/session_01GGixjxi5AQ2cNK62bBymfF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Explicitly setting a middleware payload to `undefined` now preserves that substitution and validates it against the consumer schema.
  - Invalid `undefined` payloads are routed to the dead-letter flow as non-retryable errors, and the handler does not run.
  - Calls without a payload override continue using the original payload unchanged, while schemas that allow `undefined` pass it through to the handler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->