### PR TITLE
fix(core): a refused topology fails create(), and fails it fast

### DIFF
--- a/.changeset/setup-failure-fails-create.md
+++ b/.changeset/setup-failure-fails-create.md
@@ -1,0 +1,30 @@
+---
+"@amqp-contract/core": patch
+---
+
+`create()` fails when the broker refuses the contract's topology, instead of
+handing back a ready-looking client whose exchanges and queues do not exist.
+
+`amqp-connection-manager` catches a `setup` rejection, emits it as an `error`
+event, and announces the connection anyway (`ChannelWrapper._onConnect`), so
+`waitForConnect()` answered `Ok` for a client that had just been told
+`406 PRECONDITION_FAILED` — a mismatched queue declaration, a missing exchange,
+a permission the credentials lack. The only trace was a log line.
+
+`AmqpClient` now records the first `error` that arrives **before** the wrapper
+ever announces a connection — the window in which `setup` is the only thing
+that has run — and fails that first `waitForConnect()` with a `Defect` carrying
+a `TechnicalError`. A defect rather than a modeled error, unlike the
+`ConnectionError` beside it: a topology the broker refuses is a broken
+contract, which is a bug rather than an operator's business.
+
+**Only the first connect.** On a reconnect the caller is long gone and the
+manager keeps retrying, so the existing log-and-continue is untouched.
+
+It also fails **fast**: the failure is raced against the connect, rather than
+noticed after it. A refused topology closes the channel, so waiting for
+`connect` meant sitting out the whole 30s connect timeout and then reporting an
+unreachable broker — the wrong failure, half a minute late. Measured on the new
+integration test: 132 ms.
+
+Closes #675.

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -31,7 +31,7 @@ docker exec rabbitmq rabbitmqctl set_permissions -p / app ".*" ".*" ".*"
 
 A vhost in the URL must exist and be URL-encoded: `amqp://user:pass@host:5672/my-vhost`, and `/` as a vhost is `%2F`.
 
-### `create()` throws with a `ConnectionError`
+### `create()` answers `Err(ConnectionError)`
 
 Expected from `.getOrThrow()` — an unreachable broker is a modeled `Err`, and
 `.getOrThrow()` throws it. To handle it rather than crash, triage the tag:
@@ -66,14 +66,14 @@ const client = await TypedAmqpClient.create({ contract, urls })
 
 To wait indefinitely instead of timing out after 30s, pass `connectTimeoutMs: null`. That is the only way to disable it — an invalid value (`NaN`, zero, negative, `Infinity`) is itself a defect from `create()` rather than silently turning the timeout off.
 
-### `create()` throws with "AMQP topology setup failed"
+### `create()` answers a defect: "AMQP topology setup failed"
 
 The connection is fine; the broker refused the contract's own declarations. The
 usual cause is a queue that already exists with different arguments — declaring
 `durable: false` over a durable queue is `406 PRECONDITION_FAILED` — followed by
 a missing exchange and permissions the credentials lack.
 
-Read the defect's `cause`: it names the queue or exchange the setup failed on.
+`create()` returns an `AsyncResult`, so this arrives on the defect channel — `.getOrThrow()` is what turns it into a throw, and the message above is what you see when it does. Read the defect's `cause`: it names the queue or exchange the setup failed on.
 Then either fix the contract to match what is on the broker, or delete the
 existing object if it is yours to delete. This surfaces as a defect rather than
 a modeled error on purpose: a topology the broker rejects is a broken contract,

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -66,6 +66,19 @@ const client = await TypedAmqpClient.create({ contract, urls })
 
 To wait indefinitely instead of timing out after 30s, pass `connectTimeoutMs: null`. That is the only way to disable it — an invalid value (`NaN`, zero, negative, `Infinity`) is itself a defect from `create()` rather than silently turning the timeout off.
 
+### `create()` throws with "AMQP topology setup failed"
+
+The connection is fine; the broker refused the contract's own declarations. The
+usual cause is a queue that already exists with different arguments — declaring
+`durable: false` over a durable queue is `406 PRECONDITION_FAILED` — followed by
+a missing exchange and permissions the credentials lack.
+
+Read the defect's `cause`: it names the queue or exchange the setup failed on.
+Then either fix the contract to match what is on the broker, or delete the
+existing object if it is yours to delete. This surfaces as a defect rather than
+a modeled error on purpose: a topology the broker rejects is a broken contract,
+which is a bug rather than something a running service can route around.
+
 ### Connections drop repeatedly
 
 Usually missed heartbeats caused by a blocked event loop, not a network fault. See [tune performance](/how-to/tune-performance#heartbeats).

--- a/docs/reference/error-model.md
+++ b/docs/reference/error-model.md
@@ -153,6 +153,8 @@ const started = await TypedAmqpWorker.create({ contract, handlers, urls }).match
 
 `isConnectionError(error)` is the type guard, exported from `@amqp-contract/core` and re-exported by client and worker. A connection LOST later — mid-publish, mid-consume — is not this: that is a `TechnicalError` defect, since no caller asked for it and none can act on it.
 
+Neither is a **topology the broker refuses**. If the connection succeeds but the contract's exchanges, queues or bindings cannot be declared — `406 PRECONDITION_FAILED` on a mismatched queue, a missing exchange, a permission the credentials lack — `create()` answers a **defect** carrying a `TechnicalError`. The dial is an operator's business; a topology the broker rejects is a broken contract, which is a bug. It fails at once rather than at the connect timeout, and only on the first connect: a reconnect has no caller left to fail, so it is logged and retried as before.
+
 ## `TechnicalError`
 
 Any failure of the transport or framework: connection lost, channel closed, a rejected assert, a publish that never reached the broker, a compression or JSON-parse failure, or a schema validator that threw.

--- a/packages/core/src/amqp-client-error-events.spec.ts
+++ b/packages/core/src/amqp-client-error-events.spec.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AmqpClient } from "./amqp-client.js";
 import { ConnectionManagerSingleton } from "./connection-manager.js";
+import { TechnicalError } from "./errors.js";
 
 /**
  * Regression guard for the audit's crash finding: amqp-connection-manager's
@@ -77,6 +78,42 @@ describe("AmqpClient channel error events", () => {
     expect(() => wrapper().emit("error", new Error("boom"), { name: "c" })).not.toThrow();
 
     void client.close();
+  });
+
+  it("INVARIANT: a setup failure before the first connect fails waitForConnect, rather than reporting a ready client", async () => {
+    // GIVEN a client whose topology setup blew up — amqp-connection-manager
+    // catches the rejection, emits it as 'error', and announces the connection
+    // anyway, so the wrapper looks perfectly healthy afterwards
+    const client = new AmqpClient(contract, { urls: ["amqp://localhost"] });
+    const cause = new Error("406 PRECONDITION_FAILED - inequivalent arg 'durable'");
+    wrapper().emit("error", cause, { name: "test-channel" });
+
+    // WHEN the caller waits for the connection
+    const connected = await client.waitForConnect();
+
+    // THEN it is a defect carrying the setup failure: a topology the broker
+    // refuses is a broken contract, and a client that cannot declare its own
+    // exchanges and queues is not ready whatever the socket says
+    expect(connected).toBeDefectWith(
+      expect.objectContaining({ constructor: TechnicalError, cause }),
+    );
+
+    await client.close();
+  });
+
+  it("keeps reporting ready when the error arrives AFTER the first connect — a reconnect has no caller left to fail", async () => {
+    // GIVEN a client that connected cleanly
+    const client = new AmqpClient(contract, { urls: ["amqp://localhost"] });
+    wrapper().emit("connect");
+
+    // WHEN a later setup failure arrives, as it does on every reconnect
+    wrapper().emit("error", new Error("later reconnect setup failure"), { name: "c" });
+
+    // THEN `waitForConnect` still answers Ok — the caller has its client, and
+    // the manager keeps retrying behind it
+    await expect(client.waitForConnect()).toBeOk();
+
+    await client.close();
   });
 
   it("still delivers the event to user listeners attached via client.on('error')", () => {

--- a/packages/core/src/amqp-client.ts
+++ b/packages/core/src/amqp-client.ts
@@ -274,7 +274,7 @@ export class AmqpClient {
    * every later one is a reconnect, where the caller is long gone and
    * log-and-retry is the only thing left to do.
    */
-  private initialSetupError: unknown;
+  private initialSetupError: unknown = undefined;
 
   /**
    * Settles with that same error, so `waitForConnect` can lose the race to it

--- a/packages/core/src/amqp-client.ts
+++ b/packages/core/src/amqp-client.ts
@@ -12,11 +12,13 @@ import {
   fromSafePromise,
   fromSafeThrowable,
   Ok,
+  OkAsync,
   type AsyncResult,
   type Result,
 } from "unthrown";
 
 import { ConnectionManagerSingleton, type ConnectionLease } from "./connection-manager.js";
+import { technicalDefect } from "./defect.js";
 import { ConnectionError, TechnicalError } from "./errors.js";
 import type { Logger } from "./logger.js";
 import { setupAmqpTopology } from "./setup.js";
@@ -261,6 +263,33 @@ export class AmqpClient {
   private channelEpoch = 0;
 
   /**
+   * The first `error` the ChannelWrapper emitted before it ever announced a
+   * connection — in practice a setup failure, since `setup` is the only thing
+   * that runs before `'connect'`.
+   *
+   * amqp-connection-manager catches a setup rejection, emits it as `'error'`,
+   * and then emits `'connect'` anyway (`ChannelWrapper._onConnect`), so
+   * `waitForConnect()` would otherwise answer `Ok` for a client whose topology
+   * does not exist. Recorded here so the FIRST `waitForConnect()` can fail;
+   * every later one is a reconnect, where the caller is long gone and
+   * log-and-retry is the only thing left to do.
+   */
+  private initialSetupError: unknown;
+
+  /**
+   * Settles with that same error, so `waitForConnect` can lose the race to it
+   * instead of sitting out the connect timeout. A refused topology closes the
+   * channel, and the manager then retries forever behind it — without this,
+   * "the broker refused your queue declaration" reaches the caller thirty
+   * seconds later wearing a connect timeout's clothes.
+   */
+  private readonly initialSetupFailure: Promise<unknown>;
+  private announceInitialSetupFailure!: (error: unknown) => void;
+
+  /** Whether the wrapper has ever announced a connection. */
+  private hasConnected = false;
+
+  /**
    * Create a new AMQP client instance.
    *
    * The client will automatically:
@@ -334,6 +363,10 @@ export class AmqpClient {
       channelOpts.publishTimeout = DEFAULT_PUBLISH_TIMEOUT_MS;
     }
 
+    this.initialSetupFailure = new Promise<unknown>((resolve) => {
+      this.announceInitialSetupFailure = resolve;
+    });
+
     this.channelWrapper = this.connection.createChannel(channelOpts);
 
     // amqp-connection-manager's ChannelWrapper emits plain 'error' events for
@@ -346,11 +379,20 @@ export class AmqpClient {
     // still letting callers attach their own observers via `on('error', …)`.
     this.channelWrapper.on("connect", () => {
       this.channelEpoch += 1;
+      this.hasConnected = true;
     });
 
     const logger = options.logger;
     this.logger = logger;
     this.channelWrapper.on("error", (error: unknown, info?: { name?: string }) => {
+      // Before the first 'connect', the only thing that has run is `setup` —
+      // so this is the topology failing, and somebody is still waiting on
+      // `waitForConnect()`. Keep the first one; after that the caller has its
+      // client and a reconnect can only be logged.
+      if (!this.hasConnected && this.initialSetupError === undefined) {
+        this.initialSetupError = error;
+        this.announceInitialSetupFailure(error);
+      }
       logger?.error("AMQP channel error", {
         error: error instanceof Error ? error.message : String(error),
         cause: error,
@@ -389,17 +431,28 @@ export class AmqpClient {
    * automatically. The typed factories handle this cleanup for you.
    */
   waitForConnect(): AsyncResult<void, ConnectionError> {
-    const connectPromise = this.channelWrapper.waitForConnect();
     const timeoutMs = this.connectTimeoutMs;
+
+    // Three outcomes, and the setup failure has to be one of them rather than
+    // something noticed afterwards: a refused topology closes the channel, so
+    // waiting for `connect` would mean waiting out the whole connect timeout
+    // and reporting the wrong failure at the end of it.
+    const connected = this.channelWrapper
+      .waitForConnect()
+      .then(() => ({ kind: "connected" }) as const);
+    const setupFailed = this.initialSetupFailure.then(
+      (cause) => ({ kind: "setup-failed", cause }) as const,
+    );
 
     // `AbortSignal.timeout` rather than a hand-rolled `setTimeout` race: its
     // timer does not hold the event loop open, so a settled connect needs no
     // paired `clearTimeout` to avoid keeping the process alive.
     const racedPromise =
       timeoutMs === null
-        ? connectPromise
+        ? Promise.race([connected, setupFailed])
         : Promise.race([
-            connectPromise,
+            connected,
+            setupFailed,
             new Promise<never>((_resolve, reject) => {
               AbortSignal.timeout(timeoutMs).addEventListener("abort", () => {
                 reject(new Error(`Timed out waiting for AMQP connection after ${timeoutMs}ms`));
@@ -417,6 +470,21 @@ export class AmqpClient {
           "Failed to connect to AMQP broker — verify the broker is running and reachable at the configured `urls`",
           error,
         ),
+    ).flatMap((outcome) =>
+      // A DEFECT rather than a modeled error: a topology the broker refuses (a
+      // mismatched queue declaration, a missing exchange, a permission the
+      // credentials lack) is a broken contract, which is a bug rather than an
+      // operator's business — unlike the dial above. `initialSetupError` is
+      // checked on the connected arm too, since the manager announces the
+      // connection even when setup failed on the way.
+      outcome.kind === "connected" && this.initialSetupError === undefined
+        ? OkAsync()
+        : technicalDefect(
+            new TechnicalError(
+              "AMQP topology setup failed — the broker refused the contract's exchanges, queues or bindings",
+              this.initialSetupError,
+            ),
+          ).toAsync(),
     );
   }
 

--- a/tests/src/__tests__/topology-setup-failure.spec.ts
+++ b/tests/src/__tests__/topology-setup-failure.spec.ts
@@ -1,0 +1,72 @@
+import {
+  defineConsumer,
+  defineContract,
+  defineExchange,
+  defineMessage,
+  defineQueue,
+  defineQueueBinding,
+} from "@amqp-contract/contract";
+import { it } from "@amqp-contract/testing/extension";
+import { TypedAmqpWorker } from "@amqp-contract/worker";
+import { OkAsync } from "unthrown";
+import { describe, expect } from "vitest";
+import { z } from "zod";
+
+/**
+ * The dial succeeding while the topology does not exist (#675).
+ *
+ * amqp-connection-manager catches a `setup` rejection, emits it as an `error`
+ * event, and announces the connection anyway — so `waitForConnect()` used to
+ * answer `Ok` for a worker whose exchanges and queues had never been declared.
+ * A real broker is the only honest way to prove the fix: the refusal has to be
+ * RabbitMQ's own `406 PRECONDITION_FAILED`, not a simulated one.
+ */
+describe("initial topology setup failure", () => {
+  it("fails create() when the broker refuses the contract's own queue declaration", async ({
+    amqpChannel,
+    amqpConnectionUrl,
+  }) => {
+    // GIVEN a queue that already exists as DURABLE on the broker
+    await amqpChannel.assertQueue("setup-clash", { durable: true });
+
+    // ...and a contract declaring the same queue as transient — the classic
+    // operator mistake, which RabbitMQ answers with 406 PRECONDITION_FAILED
+    const exchange = defineExchange("setup-clash-x", { type: "topic", durable: false });
+    const dlx = defineExchange("setup-clash-dlx", { type: "topic", durable: false });
+    const dlq = defineQueue("setup-clash-dlq", { type: "classic", durable: false });
+    const queue = defineQueue("setup-clash", {
+      type: "classic",
+      durable: false,
+      deadLetter: { exchange: dlx },
+    });
+    const message = defineMessage(z.object({ id: z.string() }));
+    const contract = defineContract({
+      consumers: { onClash: defineConsumer(queue, message, { exchange, routingKey: "clash" }) },
+      queues: { dlq },
+      bindings: { dlqBinding: defineQueueBinding(dlq, dlx, { routingKey: "#" }) },
+    });
+
+    // WHEN a worker is created against it
+    const created = await TypedAmqpWorker.create({
+      contract,
+      handlers: { onClash: () => OkAsync(undefined) },
+      urls: [amqpConnectionUrl],
+      connectTimeoutMs: 5_000,
+    });
+
+    // THEN it is a defect, not a ready worker: a topology the broker refuses
+    // is a broken contract, which is a bug rather than an operator's business.
+    // The matchers are not registered in this workspace, so the channel is
+    // read directly — and the cause is asserted, so a defect for some other
+    // reason (an unreachable broker, say) cannot pass this test.
+    expect({
+      defect: created.isDefect(),
+      cause: created.isDefect() ? String((created.cause as Error).cause) : undefined,
+    }).toEqual({
+      defect: true,
+      // The cause names the queue the broker refused, so a defect raised for
+      // any other reason — an unreachable broker, a bad option — cannot pass
+      cause: expect.stringContaining("Failed to setup queues: setup-clash"),
+    });
+  });
+});


### PR DESCRIPTION
Closes #675.

### The hole

`amqp-connection-manager@5.0.0` catches a `setup` rejection, emits it as an `error` event, and announces the connection anyway:

```js
pb.call(setupFn, this, channel).catch((err) => { … this.emit('error', err) })   // swallowed
await this._settingUp;
this.emit('connect');                                                          // fires regardless
```

So `waitForConnect()` answered `Ok` for a client the broker had just refused with `406 PRECONDITION_FAILED`. The worker came up, its queues did not exist, and the only trace was a log line — `AmqpClient`'s own constructor comment admitted it was absorbing "topology setup failure on connect/reconnect".

### The fix

Keep the first `error` that arrives **before** the wrapper has ever announced a connection — the window in which `setup` is the only thing that has run — and fail that first `waitForConnect()` with a **Defect** carrying a `TechnicalError`.

A defect rather than a modeled error, unlike the `ConnectionError` beside it: a topology the broker refuses is a broken contract, which is a bug rather than an operator's business. That is the disagreement I flagged when filing, and it is what shipped.

**Only the first connect.** A reconnect has no caller left to fail, so log-and-retry there is untouched — pinned by its own test.

### It is raced, not checked afterwards — which the integration test is what taught me

The first draft checked `initialSetupError` after `await connect`. Against a real broker that is wrong: a refused topology **closes the channel**, so `connect` never comes, and the caller sat out the whole connect timeout only to be told the broker was unreachable — the wrong failure, half a minute late. The setup failure is now one arm of the race. Measured on the new test: **132 ms**.

### Gates, both verified to bite

- **Unit** (`amqp-client-error-events.spec.ts`) — an `error` before the first connect makes `waitForConnect()` a defect carrying the cause; an `error` after it still answers `Ok`, which is the reconnect case.
- **Integration** (`topology-setup-failure.spec.ts`) — declares `setup-clash` as **durable** on a real RabbitMQ, then hands the worker a contract calling the same queue transient, so the refusal is the broker's own. Asserts the defect's cause names the offending queue, so a defect for any other reason cannot pass.

Both were re-run with the fix reverted to confirm they fail.

### Docs

A paragraph in the error-model reference (dial vs topology, and why they land on different channels) and a troubleshooting entry for the message, since "AMQP topology setup failed" is a string an operator will search for.

### Gate

`format --check`, `lint` (0 warnings), `typecheck` 17/17, `knip`, `build`, unit 13/13 under `--force`, integration 13/13 against a real RabbitMQ.

https://claude.ai/code/session_01GGixjxi5AQ2cNK62bBymfF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Initial AMQP topology setup failures now surface immediately when creating a client or worker, including details about the underlying broker error.
  - Connection timeouts remain distinct from topology setup failures.
  - Topology failures during reconnects continue to be logged and retried without interrupting subsequent connection attempts.

- **Documentation**
  - Added troubleshooting guidance for queue, exchange, and permission configuration errors.
  - Clarified how topology setup failures are represented and handled during initial and subsequent connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->